### PR TITLE
Use the common library for flexible environment staging

### DIFF
--- a/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/app.yaml
+++ b/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/app.yaml
@@ -1,4 +1,4 @@
-runtime: custom
+runtime: java
 vm: true
 env_variables:
   'DBG_ENABLE': 'true'

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
@@ -129,7 +129,7 @@ public class AppEngineDeploymentConfiguration extends
     this.version = version;
   }
 
-  public boolean isAuto() {
-    return getConfigType() == ConfigType.AUTO;
+  public boolean isCustom() {
+    return getConfigType() == ConfigType.CUSTOM;
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -278,10 +278,10 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
     } else {
       labelBuilder.append(".flex");
 
-      if (deploymentConfiguration.isAuto()) {
-        labelBuilder.append(".auto");
-      } else {
+      if (deploymentConfiguration.isCustom()) {
         labelBuilder.append(".custom");
+      } else {
+        labelBuilder.append(".auto");
       }
     }
 


### PR DESCRIPTION
fixes #717 

@patflynn @chanseokoh 

A couple things to note:
- I renamed and moved the jar/war versions of the Dockerfile templates so that we wouldn't have to do any programmatic renaming prior to sending them to the common lib
- I am still manually staging the artifact file. The reason is that this file could have any name based on the project configuration. Our Dockerfile templates currently hardcode a pointer to `target.jar` / `target.war`. The simplest path here was to just move the artifact to the staging directory and rename it. The other more complicated option (but minimizes manual staging on our part) is to make the Dockerfile a dynamic template (like freemarker or something) where we can pass in the name of the artifact rather then using `target` for everything. Thoughts on this?
