### PR TITLE
Sync change-notes with CHANGELOG.md

### DIFF
--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -32,11 +32,7 @@ Code inspections for App Engine Java code.</description>
       <h3>Added</h3>
       <ul>
         <li>App Engine standard environment support (<a href="https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/767">#767</a>)</li>
-      </ul>
-      <h3>Changed</h3>
-      <ul>
         <li>Extra fields now available in the deployment config (<a href="https://github.com/GoogleCloudPlatform/google-cloud-intellij/pull/868">#868</a>)</li>
-        <li>Local run debug updated to use the newer tooling (<a href="https://github.com/GoogleCloudPlatform/google-cloud-intellij/pull/811">#811</a>)</li>
       </ul>
     </html>]]>
   </change-notes>


### PR DESCRIPTION
Follow-up to https://github.com/GoogleCloudPlatform/google-cloud-intellij/pull/890. Commit https://github.com/GoogleCloudPlatform/google-cloud-intellij/pull/890/commits/80e679b378fbbf71bdc0c237bfd54dc8e4a3b40b was incomplete - the `<change-notes>` section of plugin.xml was not updated in sync with updates to the `CHANGELOG.md`.