### PR TITLE
Fix jenkins test issue

### DIFF
--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/DefaultAppEngineProjectServiceTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/DefaultAppEngineProjectServiceTest.java
@@ -35,6 +35,7 @@ import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.WriteExternalException;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.xml.XmlFile;
 import com.intellij.testFramework.PlatformTestCase;
@@ -55,7 +56,7 @@ public class DefaultAppEngineProjectServiceTest extends PlatformTestCase {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-
+    VfsRootAccess.allowRootAccess(getHomePath());
     appEngineProjectService = new DefaultAppEngineProjectService();
   }
 
@@ -75,11 +76,11 @@ public class DefaultAppEngineProjectServiceTest extends PlatformTestCase {
 
     // JAR Artifact Type
     assertEquals(AppEngineEnvironment.APP_ENGINE_FLEX,
-        appEngineProjectService.getModuleAppEngineEnvironment(null /**appengine-web.xml*/));
+        appEngineProjectService.getModuleAppEngineEnvironment(null /*appengine-web.xml*/));
 
     // WAR Artifact Type
     assertEquals(AppEngineEnvironment.APP_ENGINE_FLEX,
-        appEngineProjectService.getModuleAppEngineEnvironment(null /**appengine-web.xml*/));
+        appEngineProjectService.getModuleAppEngineEnvironment(null /*appengine-web.xml*/));
   }
 
   public void testGetAppEngineArtifactEnvironment_FlexibleCompat() {

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/DefaultAppEngineProjectServiceTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/DefaultAppEngineProjectServiceTest.java
@@ -56,6 +56,7 @@ public class DefaultAppEngineProjectServiceTest extends PlatformTestCase {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
+    // Fixes https://youtrack.jetbrains.com/issue/IDEA-129297. Only occurs in Jenkins.
     VfsRootAccess.allowRootAccess(System.getProperty("user.dir"));
     appEngineProjectService = new DefaultAppEngineProjectService();
   }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/DefaultAppEngineProjectServiceTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/DefaultAppEngineProjectServiceTest.java
@@ -56,7 +56,7 @@ public class DefaultAppEngineProjectServiceTest extends PlatformTestCase {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    VfsRootAccess.allowRootAccess(getHomePath());
+    VfsRootAccess.allowRootAccess(System.getProperty("user.dir"));
     appEngineProjectService = new DefaultAppEngineProjectService();
   }
 


### PR DESCRIPTION
Jenkins builds failed when I moved the workspaces to an SSD. 

Failure was here:
https://cloud-tools-for-java-testing.appspot.com/job/google-cloud-intellij%20CI%20Build%20(IDEA%2015)/75/testReport/junit/com.google.cloud.tools.intellij.appengine.cloud/DefaultAppEngineProjectServiceTest/testGetAppEngineArtifactEnvironment_Standard/

No idea what the reason it would start failing after switch to SSD. Maybe the fact I'm using symbolic links to the workspace is causing problems. Either that or```
 LocalFileSystem.getInstance().findFileByIoFile(
        new File(path));
``` returns a different appengine-web.xml that's not in the content root because.. who knows.