### PR TITLE
Use project jdk for dev_appserver local run

### DIFF
--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -73,16 +73,16 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
   private ArtifactPointer artifactPointer;
   private CommonModel commonModel;
   private Sdk devAppServerJdk;
+  private ProjectSdksModel projectJdksModel;
 
   private AppEngineModelSettings settings = new AppEngineModelSettings();
 
   public AppEngineServerModel() {
-    initDefaultJdk();
+    projectJdksModel = new ProjectSdksModel();
   }
 
   @Nullable
   private Sdk getCurrentProjectJdk() {
-    ProjectSdksModel projectJdksModel = new ProjectSdksModel();
     projectJdksModel.reset(commonModel.getProject());
     return projectJdksModel.getProjectSdk();
   }

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -96,8 +96,8 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
 
   @Override
   public J2EEServerInstance createServerInstance() throws ExecutionException {
-    // FIXME: This keeps the dev_appserver's jdk in sync with the project jdk on behalf of the user.
-    // This behavior should be removed once
+    // TODO(alexsloan): This keeps the dev_appserver's jdk in sync with the project jdk on behalf of
+    // the user. This behavior should be removed once
     // https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/926 is completed.
     initDefaultJdk();
 

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -40,9 +40,9 @@ import com.intellij.javaee.run.execution.OutputProcessor;
 import com.intellij.javaee.serverInstances.J2EEServerInstance;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.roots.ui.configuration.projectRoot.ProjectSdksModel;
 import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.WriteExternalException;
@@ -83,8 +83,11 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
   }
 
   private void initDefaultJdk() {
-    Project currentProject = ProjectManager.getInstance().getDefaultProject();
-    Sdk projectJdk = ProjectRootManager.getInstance(currentProject).getProjectSdk();
+    Project currentProject = ProjectUtil.guessCurrentProject(null);
+    ProjectSdksModel sdkModel = new ProjectSdksModel();
+    sdkModel.reset(currentProject);
+    Sdk projectJdk = sdkModel.getProjectSdk();
+
     if (projectJdk != null) {
       setDevAppServerJdk(projectJdk);
     }

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -82,12 +82,16 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
     initDefaultJdk();
   }
 
-  private void initDefaultJdk() {
-    Project currentProject = ProjectUtil.guessCurrentProject(null);
-    ProjectSdksModel sdkModel = new ProjectSdksModel();
-    sdkModel.reset(currentProject);
-    Sdk projectJdk = sdkModel.getProjectSdk();
+  @Nullable
+  private Sdk getCurrentProjectJdk() {
+    Project project = ProjectUtil.guessCurrentProject(null);
+    ProjectSdksModel projectJdksModel = new ProjectSdksModel();
+    projectJdksModel.reset(project);
+    return projectJdksModel.getProjectSdk();
+  }
 
+  private void initDefaultJdk() {
+    Sdk projectJdk = getCurrentProjectJdk();
     if (projectJdk != null) {
       setDevAppServerJdk(projectJdk);
     }
@@ -95,6 +99,11 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
 
   @Override
   public J2EEServerInstance createServerInstance() throws ExecutionException {
+    // FIXME: This keeps the dev_appserver's jdk in sync with the project jdk on behalf of the user.
+    // This behavior should be removed once
+    // https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/926 is completed.
+    initDefaultJdk();
+
     return new AppEngineServerInstance(commonModel);
   }
 

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -39,6 +39,10 @@ import com.intellij.javaee.run.execution.DefaultOutputProcessor;
 import com.intellij.javaee.run.execution.OutputProcessor;
 import com.intellij.javaee.serverInstances.J2EEServerInstance;
 import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.WriteExternalException;
@@ -70,8 +74,21 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
 
   private ArtifactPointer artifactPointer;
   private CommonModel commonModel;
+  private Sdk devAppServerJdk;
 
   private AppEngineModelSettings settings = new AppEngineModelSettings();
+
+  public AppEngineServerModel() {
+    initDefaultJdk();
+  }
+
+  private void initDefaultJdk() {
+    Project currentProject = ProjectManager.getInstance().getDefaultProject();
+    Sdk projectJdk = ProjectRootManager.getInstance(currentProject).getProjectSdk();
+    if (projectJdk != null) {
+      setDevAppServerJdk(projectJdk);
+    }
+  }
 
   @Override
   public J2EEServerInstance createServerInstance() throws ExecutionException {
@@ -419,6 +436,20 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
     settings.setDefaultGcsBucketName(defaultGcsBucketName);
   }
 
+  @Override
+  public String getJavaHomeDir() {
+    return settings.getJavaHomeDir();
+  }
+
+  public Sdk getDevAppServerJdk() {
+    return devAppServerJdk;
+  }
+
+  public void setDevAppServerJdk(Sdk devAppServerJdk) {
+    this.devAppServerJdk = devAppServerJdk;
+    settings.setJavaHomeDir(devAppServerJdk.getHomePath());
+  }
+
   /**
    * This class is used to serialize run/debug config settings. It only supports basic types (e.g.,
    * int, String, etc.).
@@ -474,6 +505,8 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
     private boolean skipSdkUpdateCheck;
     @Tag("default_gcs_bucket_name")
     private String defaultGcsBucketName;
+    @Tag("java_home_directory")
+    private String javaHomeDir;
 
     public String getArtifact() {
       return artifact;
@@ -649,6 +682,14 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
 
     public void setDefaultGcsBucketName(String defaultGcsBucketName) {
       this.defaultGcsBucketName = defaultGcsBucketName;
+    }
+
+    public String getJavaHomeDir() {
+      return javaHomeDir;
+    }
+
+    public void setJavaHomeDir(String javaHomeDir) {
+      this.javaHomeDir = javaHomeDir;
     }
 
     @Override

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -84,9 +84,8 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
 
   @Nullable
   private Sdk getCurrentProjectJdk() {
-    Project project = ProjectUtil.guessCurrentProject(null);
     ProjectSdksModel projectJdksModel = new ProjectSdksModel();
-    projectJdksModel.reset(project);
+    projectJdksModel.reset(commonModel.getProject());
     return projectJdksModel.getProjectSdk();
   }
 

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -39,8 +39,6 @@ import com.intellij.javaee.run.execution.DefaultOutputProcessor;
 import com.intellij.javaee.run.execution.OutputProcessor;
 import com.intellij.javaee.serverInstances.J2EEServerInstance;
 import com.intellij.openapi.options.SettingsEditor;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ui.configuration.projectRoot.ProjectSdksModel;
 import com.intellij.openapi.util.InvalidDataException;

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ ideaVersion = 15.0.6
 javaVersion = 1.7
 ijPluginRepoChannel = alpha
 version = 1.0-BETA-0.3-SNAPSHOT
-toolsLibVersion = 0.1.11-SNAPSHOT
+toolsLibVersion = 0.1.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ ideaVersion = 15.0.6
 javaVersion = 1.7
 ijPluginRepoChannel = alpha
 version = 1.0-BETA-0.3-SNAPSHOT
-toolsLibVersion = 0.1.8
+toolsLibVersion = 0.1.11

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ ideaVersion = 15.0.6
 javaVersion = 1.7
 ijPluginRepoChannel = alpha
 version = 1.0-BETA-0.3-SNAPSHOT
-toolsLibVersion = 0.1.8
+toolsLibVersion = 0.1.11-SNAPSHOT


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/927

Sets the dev_appserver's configured jdk to use the current project jdk. The ability for the user to manually configure the jdk was purposely omitted. This enhancement will come in a future PR (see https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/926).

TODO before merging:
- [x] perform 0.1.11 release of appengine-plugins-core
- [x] merge https://github.com/GoogleCloudPlatform/google-cloud-intellij/pull/943 (updates to the latest appengine-plugins-core release)
