### PR TITLE
GAE framework support no longer adds local devserver library to dependencies list

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineSupportProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineSupportProvider.java
@@ -148,8 +148,6 @@ public class AppEngineSupportProvider extends FrameworkSupportInModuleProvider {
       }
     }
 
-    webIntegration.addDevServerToModuleDependencies(rootModel);
-
     addMavenLibraries(librariesToAdd, module, rootModel, webArtifact);
   }
 


### PR DESCRIPTION
Only application server does that now for Java EE projects.

Fixes #945