### PR TITLE
Correctly setup run configuration when a new AppEngine project is created as Java EE project (#945)

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineWebIntegration.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineWebIntegration.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.intellij.appengine.facet;
 
+import com.intellij.execution.configurations.ModuleRunConfiguration;
 import com.intellij.framework.addSupport.FrameworkSupportInModuleProvider;
 import com.intellij.ide.util.frameworkSupport.FrameworkSupportModel;
 import com.intellij.openapi.components.ServiceManager;
@@ -64,7 +65,8 @@ public abstract class AppEngineWebIntegration {
 
   public abstract void setupJpaSupport(@NotNull Module module, @NotNull VirtualFile persistenceXml);
 
-  public abstract void setupRunConfiguration(@Nullable Artifact artifact, @NotNull Project project);
+  public abstract void setupRunConfiguration(@Nullable Artifact artifact, @NotNull Project project,
+      @Nullable ModuleRunConfiguration existingConfiguration);
 
   public abstract void setupDevServer();
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineCommunityWebIntegration.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineCommunityWebIntegration.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.intellij.appengine.facet.impl;
 
 import com.google.cloud.tools.intellij.appengine.facet.AppEngineWebIntegration;
 
+import com.intellij.execution.configurations.ModuleRunConfiguration;
 import com.intellij.framework.addSupport.FrameworkSupportInModuleProvider;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
@@ -81,7 +82,8 @@ public class AppEngineCommunityWebIntegration extends AppEngineWebIntegration {
   }
 
   @Override
-  public void setupRunConfiguration(@Nullable Artifact artifact, @NotNull Project project) {
+  public void setupRunConfiguration(@Nullable Artifact artifact, @NotNull Project project,
+      ModuleRunConfiguration existingConfiguration) {
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/maven/AppEngineFacetImporter.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/maven/AppEngineFacetImporter.java
@@ -85,7 +85,8 @@ public class AppEngineFacetImporter extends
       final String artifactName = module.getName() + ":war exploded";
       final Artifact webArtifact = modelsProvider.getModifiableArtifactModel()
           .findArtifact(artifactName);
-      AppEngineWebIntegration.getInstance().setupRunConfiguration(webArtifact, module.getProject());
+      AppEngineWebIntegration.getInstance().setupRunConfiguration(webArtifact, module.getProject(),
+          null);
     }
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/maven/AppEngineFacetImporter.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/maven/AppEngineFacetImporter.java
@@ -86,7 +86,7 @@ public class AppEngineFacetImporter extends
       final Artifact webArtifact = modelsProvider.getModifiableArtifactModel()
           .findArtifact(artifactName);
       AppEngineWebIntegration.getInstance().setupRunConfiguration(webArtifact, module.getProject(),
-          null);
+          null /* existingConfiguration */);
     }
   }
 }

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
@@ -41,7 +41,7 @@ public class AppEngineJavaeeSupportContributor extends JavaeeFrameworkSupportCon
     }
     if (artifactToDeploy != null) {
       AppEngineWebIntegration.getInstance()
-          .setupRunConfiguration(artifactToDeploy, model.getProject());
+          .setupRunConfiguration(artifactToDeploy, model.getProject(), model.getRunConfiguration());
     }
   }
 }

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineUltimateWebIntegration.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineUltimateWebIntegration.java
@@ -115,16 +115,15 @@ public class AppEngineUltimateWebIntegration extends AppEngineWebIntegration {
 
       CommonModel configuration;
       if (existingConfiguration instanceof CommonModel
-          && ((CommonModel) existingConfiguration).getServerModel() instanceof AppEngineServerModel) {
+          && ((CommonModel) existingConfiguration).getServerModel()
+          instanceof AppEngineServerModel) {
         configuration = (CommonModel) existingConfiguration;
-      }
-      else if (RunManager.getInstance(project)
+      } else if (RunManager.getInstance(project)
           .getConfigurationSettingsList(configurationType).isEmpty()) {
         final RunnerAndConfigurationSettings settings = J2EEConfigurationFactory.getInstance()
             .addAppServerConfiguration(project, configurationType.getLocalFactory(), appServer);
         configuration = (CommonModel) settings.getConfiguration();
-      }
-      else {
+      } else {
         configuration = null;
       }
 

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineUltimateWebIntegration.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineUltimateWebIntegration.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.intellij.appengine.server.run.AppEngineServerConfi
 
 import com.intellij.execution.RunManager;
 import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.execution.configurations.ModuleRunConfiguration;
 import com.intellij.facet.FacetManager;
 import com.intellij.framework.addSupport.FrameworkSupportInModuleProvider.FrameworkDependency;
 import com.intellij.ide.util.frameworkSupport.FrameworkSupportModel;
@@ -105,22 +106,32 @@ public class AppEngineUltimateWebIntegration extends AppEngineWebIntegration {
     }
   }
 
-  public void setupRunConfiguration(Artifact artifact, @NotNull Project project) {
+  public void setupRunConfiguration(Artifact artifact, @NotNull Project project,
+      ModuleRunConfiguration existingConfiguration) {
     final ApplicationServer appServer = getOrCreateAppServer();
     if (appServer != null) {
       AppEngineServerConfigurationType configurationType = AppEngineServerConfigurationType
           .getInstance();
-      List<RunnerAndConfigurationSettings> list = RunManager.getInstance(project)
-          .getConfigurationSettingsList(configurationType);
-      if (list.isEmpty()) {
+
+      CommonModel configuration;
+      if (existingConfiguration instanceof CommonModel
+          && ((CommonModel) existingConfiguration).getServerModel() instanceof AppEngineServerModel) {
+        configuration = (CommonModel) existingConfiguration;
+      }
+      else if (RunManager.getInstance(project)
+          .getConfigurationSettingsList(configurationType).isEmpty()) {
         final RunnerAndConfigurationSettings settings = J2EEConfigurationFactory.getInstance()
             .addAppServerConfiguration(project, configurationType.getLocalFactory(), appServer);
-        if (artifact != null) {
-          final CommonModel configuration = (CommonModel) settings.getConfiguration();
-          ((AppEngineServerModel) configuration.getServerModel()).setArtifact(artifact);
-          BuildArtifactsBeforeRunTaskProvider
-              .setBuildArtifactBeforeRun(project, configuration, artifact);
-        }
+        configuration = (CommonModel) settings.getConfiguration();
+      }
+      else {
+        configuration = null;
+      }
+
+      if (artifact != null && configuration != null) {
+        ((AppEngineServerModel) configuration.getServerModel()).setArtifact(artifact);
+        BuildArtifactsBeforeRunTaskProvider
+            .setBuildArtifactBeforeRun(project, configuration, artifact);
       }
     }
   }

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineRunConfigurationEditor.java
@@ -114,6 +114,11 @@ public class AppEngineRunConfigurationEditor extends SettingsEditor<CommonModel>
     final AppEngineServerModel serverModel = (AppEngineServerModel) commonModel.getServerModel();
     final Artifact artifact = serverModel.getArtifact();
     myArtifactComboBox.setSelectedItem(artifact);
+    if (artifact == null && myArtifactComboBox.getItemCount() == 1) {
+      myArtifactComboBox.setSelectedIndex(0);
+      BuildArtifactsBeforeRunTaskProvider.setBuildArtifactBeforeRun(
+          commonModel.getProject(), commonModel, (Artifact) myArtifactComboBox.getSelectedItem());
+    }
     port.setText(intToString(serverModel.getPort()));
     host.setText(serverModel.getHost());
     adminHost.setText(serverModel.getAdminHost());


### PR DESCRIPTION
When a new Java EE project is created it may create its own run configuration in AppServerSupportConfigurable, so we need to reuse it.