### PR TITLE
Fix gwt extension point wiring

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/inspections/AppEngineForbiddenCodeHandler.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/inspections/AppEngineForbiddenCodeHandler.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public abstract class AppEngineForbiddenCodeHandler {
   public static final ExtensionPointName<AppEngineForbiddenCodeHandler> EP_NAME
-      = ExtensionPointName.create("com.intellij.appengine.forbiddenCodeHandler");
+      = ExtensionPointName.create("com.google.gct.core.forbiddenCodeHandler");
 
   public abstract boolean isNativeMethodAllowed(@NotNull PsiMethod method);
 }

--- a/google-cloud-tools-plugin/ultimate/resources/META-INF/gwt-integration.xml
+++ b/google-cloud-tools-plugin/ultimate/resources/META-INF/gwt-integration.xml
@@ -17,6 +17,8 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
     <gwt.devModeServerProvider implementation="com.google.cloud.tools.intellij.appengine.gwt.AppEngineGwtServerProvider"/>
+  </extensions>
+  <extensions defaultExtensionNs="com.google.gct">
     <appengine.forbiddenCodeHandler implementation="com.google.cloud.tools.intellij.appengine.gwt.GwtNativeMethodsHandler"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
fixes #862 

The GWT forbidden native code inspection was broken.

The ForbiddenCodeHandler extension point is now defined within our plugin, not by the platform. Therefore the namespaces needed to be updated so that the extension point can be located.

To test out the working inspection:

1. In the new project wizard, under JavaEE select a GWT project. Provide all the SDKs, and click the checkbox to generate a project template.
2. Under module settings, add the Google App Engine Facet.
3. Add some forbidden native code as follows to the GWT client class:
```
public static native void alert(String msg) /*-{
  $wnd.alert(msg);
}-*/;
```
4. Observe that the inspection is now working:

![image](https://cloud.githubusercontent.com/assets/1735744/19197629/dd35d916-8c88-11e6-877e-4b6f69deb13b.png)

