### PR TITLE
isModified() should not only return true if the user has enabled tracking

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTrackerPanel.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTrackerPanel.java
@@ -80,7 +80,7 @@ public class UsageTrackerPanel {
   }
 
   public boolean isModified() {
-    return usageTrackerManager.isTrackingEnabled()
+    return usageTrackerManager.isUsageTrackingAvailable()
         && usageTrackerManager.hasUserOptedIn() != enableUsageTrackerBox.isSelected();
   }
 


### PR DESCRIPTION
I'm a bit perplexed as to how this ever worked. I'm going to have to dig in the history to figure out what happened here as I'm confident this setting used to persist. 

Fixes #969 