### PR TITLE
Fix deployment sources for flex compat projects; fix maven deploy targets for flex compat

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.intellij.appengine.project.AppEngineProjectService
 
 import com.intellij.openapi.module.ModulePointer;
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.xml.XmlFile;
 import com.intellij.remoteServer.configuration.deployment.DeploymentSourceType;
 import com.intellij.remoteServer.impl.configuration.deployment.ModuleDeploymentSourceImpl;
 
@@ -97,15 +98,17 @@ public class MavenBuildDeploymentSource extends ModuleDeploymentSourceImpl
         new File(mavenProject.getBuildDirectory()).getPath() + File.separator
             + mavenProject.getFinalName();
 
+    XmlFile appEngineWebXml = AppEngineAssetProvider.getInstance()
+        .loadAppEngineStandardWebXml(project, Collections.singletonList(getModule()));
+    AppEngineProjectService projectService = AppEngineProjectService.getInstance();
+
     // The environment will be null for newly deserialized deployment sources to ensure freshness.
     // In this case, we need to reload the environment.
     if (environment == null) {
-      environment = AppEngineProjectService.getInstance().getModuleAppEngineEnvironment(
-          AppEngineAssetProvider.getInstance().loadAppEngineStandardWebXml(project,
-              Collections.singletonList(getModule())));
+      environment = projectService.getModuleAppEngineEnvironment(appEngineWebXml);
     }
 
-    if (environment.isFlexible()) {
+    if (environment.isFlexible() && !projectService.isFlexCompat(appEngineWebXml)) {
       targetBuild += "." + mavenProject.getPackaging();
     }
 


### PR DESCRIPTION
fixes #993 

Flex compat projects should show the same sources as AE standard projects.

Also fixes error when deploying a maven deployment source for flex compat projects: since the cloud environment for these projects is flex, it incorrectly used the war target instead of the exploded directory.