### PR TITLE
Removing the App Engine new module framework support from Community

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineSupportProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineSupportProvider.java
@@ -57,6 +57,7 @@ import com.intellij.packaging.artifacts.ArtifactType;
 import com.intellij.packaging.elements.ArtifactRootElement;
 import com.intellij.packaging.elements.PackagingElementFactory;
 import com.intellij.packaging.impl.artifacts.ArtifactUtil;
+import com.intellij.util.PlatformUtils;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -95,7 +96,11 @@ public class AppEngineSupportProvider extends FrameworkSupportInModuleProvider {
 
   @Override
   public boolean isEnabledForModuleType(@NotNull ModuleType moduleType) {
-    return moduleType instanceof JavaModuleType;
+    if (PlatformUtils.isIdeaUltimate()) {
+      return moduleType instanceof JavaModuleType;
+    } else {
+      return false;
+    }
   }
 
   @Override


### PR DESCRIPTION
This framework support is broken currently since it requires  web
functionality that is not in CE during module generation.

Closes #1003, related to #986