### PR TITLE
Disambiguate deployment sources

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -69,7 +69,6 @@ appengine.config.deployment.source.error=Select a valid deployment source.
 appengine.config.version.error=Enter a version ID.
 appengine.flex.deployment.cost.warning={0}There is no free quota for App Engine flexible environment deployments. Please visit {1}GCP Pricing{2} for pricing information.{3}
 appengine.flex.user.specified.deploymentsource.name=Filesystem JAR or WAR file
-appengine.flex.user.specified.deploymentsource.name.with.filename=Filesystem JAR or WAR file - {0}
 appengine.action.credential.not.found=We were unable to find a credential for your cloud project's user. Are you sure you are logged in?
 appengine.deployment.error.creating.staging.directory=There was an unexpected error creating the staging directory
 appengine.generate.config.button=Generate...

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
@@ -56,7 +56,7 @@ public class AppEngineArtifactDeploymentSource extends ArtifactDeploymentSourceI
   @NotNull
   @Override
   public String getPresentableName() {
-    return String.format("[%s] ", DateTime.now().toString("HH:mm:ss")) + name;
+    return String.format("[%s] ", DateTime.now().toString("yyyy-MM-dd HH:mm:ss")) + name;
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
@@ -30,12 +30,14 @@ public class AppEngineArtifactDeploymentSource extends ArtifactDeploymentSourceI
     implements AppEngineDeployable {
 
   private AppEngineEnvironment environment;
+  private String name;
 
   /**
    * Default constructor used instantiating plain Artifact Deployment sources.
    */
   public AppEngineArtifactDeploymentSource(@NotNull ArtifactPointer pointer) {
     super(pointer);
+    setName(getDefaultName());
   }
 
   /**
@@ -47,6 +49,23 @@ public class AppEngineArtifactDeploymentSource extends ArtifactDeploymentSourceI
       @NotNull ArtifactPointer pointer) {
     super(pointer);
     this.environment = environment;
+    setName(getDefaultName());
+  }
+
+  @NotNull
+  @Override
+  public String getPresentableName() {
+    return name;
+  }
+
+  @Override
+  public String getDefaultName() {
+    return getArtifactPointer().getArtifactName();
+  }
+
+  @Override
+  public void setName(String name) {
+    this.name = name;
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
@@ -21,6 +21,7 @@ import com.intellij.remoteServer.configuration.deployment.DeploymentSourceType;
 import com.intellij.remoteServer.impl.configuration.deployment.ArtifactDeploymentSourceImpl;
 
 import org.jetbrains.annotations.NotNull;
+import org.joda.time.DateTime;
 
 /**
  * An App Engine implementation of {@link ArtifactDeploymentSourceImpl} that provides its targeted
@@ -55,7 +56,7 @@ public class AppEngineArtifactDeploymentSource extends ArtifactDeploymentSourceI
   @NotNull
   @Override
   public String getPresentableName() {
-    return name;
+    return String.format("[%s] ", DateTime.now().toString("HH:mm:ss")) + name;
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
@@ -21,7 +21,7 @@ import com.intellij.remoteServer.configuration.deployment.DeploymentSourceType;
 import com.intellij.remoteServer.impl.configuration.deployment.ArtifactDeploymentSourceImpl;
 
 import org.jetbrains.annotations.NotNull;
-import org.joda.time.DateTime;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An App Engine implementation of {@link ArtifactDeploymentSourceImpl} that provides its targeted
@@ -31,47 +31,44 @@ public class AppEngineArtifactDeploymentSource extends ArtifactDeploymentSourceI
     implements AppEngineDeployable {
 
   private AppEngineEnvironment environment;
-  private String name;
 
-  /**
-   * Default constructor used instantiating plain Artifact Deployment sources.
-   */
-  public AppEngineArtifactDeploymentSource(@NotNull ArtifactPointer pointer) {
-    super(pointer);
-    setName(getDefaultName());
-  }
+  private String projectName;
+  private String version;
 
   /**
    * Initialize the artifact deployment source given a target App Engine environment, and an
    * artifact pointer.
    */
   public AppEngineArtifactDeploymentSource(
-      @NotNull AppEngineEnvironment environment,
+      @Nullable AppEngineEnvironment environment,
       @NotNull ArtifactPointer pointer) {
     super(pointer);
     this.environment = environment;
-    setName(getDefaultName());
-  }
-
-  @NotNull
-  @Override
-  public String getPresentableName() {
-    return String.format("[%s] ", DateTime.now().toString("yyyy-MM-dd HH:mm:ss")) + name;
-  }
-
-  @Override
-  public String getDefaultName() {
-    return getArtifactPointer().getArtifactName();
-  }
-
-  @Override
-  public void setName(String name) {
-    this.name = name;
   }
 
   @Override
   public AppEngineEnvironment getEnvironment() {
     return environment;
+  }
+
+  @Override
+  public String getProjectName() {
+    return projectName;
+  }
+
+  @Override
+  public void setProjectName(String projectName) {
+    this.projectName = projectName;
+  }
+
+  @Override
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public void setVersion(String version) {
+    this.version = version;
   }
 
   @NotNull

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSourceType.java
@@ -84,7 +84,7 @@ public class AppEngineArtifactDeploymentSourceType
   @Override
   public void save(@NotNull ArtifactDeploymentSource deploymentSource,
       @NotNull Element tag) {
-    tag.setAttribute(NAME_ATTRIBUTE, deploymentSource.getPresentableName());
+    tag.setAttribute(NAME_ATTRIBUTE, ((AppEngineDeployable) deploymentSource).getDefaultName());
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployable.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployable.java
@@ -29,18 +29,26 @@ public interface AppEngineDeployable extends DeploymentSource {
    */
   AppEngineEnvironment getEnvironment();
 
-  /**
-   * Sets the name of this deployable. Used for display in the Application Server deployment window
-   * and for disambiguation of multiple deployables. This field is mutable so that, at deploy time,
-   * we can append additional information to the name to ensure uniqueness (e.g. version).
-   */
-  void setName(String name);
 
   /**
-   * Returns the default name for this deployable. The default name represents the name of the
-   * deployment source prior to deploy time. For example, this would not include version information
-   * since it is not yet known.
+   * Returns the targeted cloud project name.
    */
-  String getDefaultName();
+  String getProjectName();
 
+  /**
+   * Sets the targeted cloud project. It is mutable because the cloud project is not known until
+   * deploy time where it is then set.
+   */
+  void setProjectName(String projectName);
+
+  /**
+   * Returns the targeted cloud project version.
+   */
+  String getVersion();
+
+  /**
+   * Sets the targeted cloud project version. It is mutable because the cloud project version is
+   * not known until deploy time where it is then set.
+   */
+  void setVersion(String version);
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployable.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployable.java
@@ -30,7 +30,7 @@ public interface AppEngineDeployable extends DeploymentSource {
   AppEngineEnvironment getEnvironment();
 
   /**
-   * Set the name of this deployable. Used for display in the Application Server deployment window
+   * Sets the name of this deployable. Used for display in the Application Server deployment window
    * and for disambiguation of multiple deployables. This field is mutable so that, at deploy time,
    * we can append additional information to the name to ensure uniqueness (e.g. version).
    */

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployable.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployable.java
@@ -29,4 +29,18 @@ public interface AppEngineDeployable extends DeploymentSource {
    */
   AppEngineEnvironment getEnvironment();
 
+  /**
+   * Set the name of this deployable. Used for display in the Application Server deployment window
+   * and for disambiguation of multiple deployables. This field is mutable so that, at deploy time,
+   * we can append additional information to the name to ensure uniqueness (e.g. version).
+   */
+  void setName(String name);
+
+  /**
+   * Returns the default name for this deployable. The default name represents the name of the
+   * deployment source prior to deploy time. For example, this would not include version information
+   * since it is not yet known.
+   */
+  String getDefaultName();
+
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -290,7 +290,7 @@ public class AppEngineDeploymentRunConfigurationEditor extends
     configuration.setPromote(promoteCheckbox.isSelected());
     configuration.setStopPreviousVersion(stopPreviousVersionCheckbox.isSelected());
 
-    setDeploymentSourceName();
+    setDeploymentProjectAndVersion();
     updateJarWarSelector();
   }
 
@@ -345,24 +345,14 @@ public class AppEngineDeploymentRunConfigurationEditor extends
   }
 
   /**
-   * The name of the currently selected deployment source is displayed in the Application Servers
-   * window. We want to disambiguate this name as much as possible so that unique deployments show
-   * up as individual line items in the deployment UI.
+   * Sets the project / version to allow the deployment line items to be decorated with additional
+   * identifying data. See {@link AppEngineRuntimeInstance#getDeploymentName}.
    */
-  private void setDeploymentSourceName() {
+  private void setDeploymentProjectAndVersion() {
     AppEngineDeployable deployable = (AppEngineDeployable) deploymentSource;
 
-    String projectVersionSuffix = ". Project: " + projectSelector.getText()
-        + ". Version: " + getDisplayableVersion();
-
-    if (isUserSpecifiedPathDeploymentSource()
-        && !StringUtil.isEmpty(userSpecifiedArtifactFileSelector.getText())) {
-      deployable.setName(deployable.getDefaultName() + " - "
-          + Paths.get(userSpecifiedArtifactFileSelector.getText()).getFileName()
-          + projectVersionSuffix);
-    } else {
-      deployable.setName(deployable.getDefaultName() + projectVersionSuffix);
-    }
+    deployable.setProjectName(projectSelector.getText());
+    deployable.setVersion(getDisplayableVersion());
   }
 
   private String getDisplayableVersion() {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -346,17 +346,27 @@ public class AppEngineDeploymentRunConfigurationEditor extends
 
   /**
    * The name of the currently selected deployment source is displayed in the Application Servers
-   * window. We want this name to also include the path to the manually chosen archive when one
-   * is selected.
+   * window. We want to disambiguate this name as much as possible so that unique deployments show
+   * up as individual line items in the deployment UI.
    */
   private void setDeploymentSourceName(String filePath) {
+    AppEngineDeployable deployable = (AppEngineDeployable) deploymentSource;
+
     if (isUserSpecifiedPathDeploymentSource()
         && !StringUtil.isEmpty(userSpecifiedArtifactFileSelector.getText())) {
-      ((UserSpecifiedPathDeploymentSource) deploymentSource).setName(
-          GctBundle.message(
-              "appengine.flex.user.specified.deploymentsource.name.with.filename",
-              new File(filePath).getName()));
+      deployable.setName(
+          deployable.getDefaultName() + " - " + new File(filePath).getName()
+              + ". Version: " + getDisplayableVersion());
+    } else {
+      deployable.setName(
+          deployable.getDefaultName() + ". Version: " + getDisplayableVersion());
     }
+  }
+
+  private String getDisplayableVersion() {
+    return versionOverrideCheckBox.isSelected()
+        ? versionIdField.getText() : "auto";
+
   }
 
   private void validateConfiguration() throws ConfigurationException {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -352,15 +352,15 @@ public class AppEngineDeploymentRunConfigurationEditor extends
   private void setDeploymentSourceName() {
     AppEngineDeployable deployable = (AppEngineDeployable) deploymentSource;
 
-    String projectVersion = ". Project: " + projectSelector.getText()
+    String projectVersionSuffix = ". Project: " + projectSelector.getText()
         + ". Version: " + getDisplayableVersion();
 
     if (isUserSpecifiedPathDeploymentSource()
         && !StringUtil.isEmpty(userSpecifiedArtifactFileSelector.getText())) {
       deployable.setName(deployable.getDefaultName() + " - "
-          + new File(userSpecifiedArtifactFileSelector.getText()).getName() + projectVersion);
+          + new File(userSpecifiedArtifactFileSelector.getText()).getName() + projectVersionSuffix);
     } else {
-      deployable.setName(deployable.getDefaultName() + projectVersion);
+      deployable.setName(deployable.getDefaultName() + projectVersionSuffix);
     }
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -290,7 +290,7 @@ public class AppEngineDeploymentRunConfigurationEditor extends
     configuration.setPromote(promoteCheckbox.isSelected());
     configuration.setStopPreviousVersion(stopPreviousVersionCheckbox.isSelected());
 
-    setDeploymentSourceName(configuration.getUserSpecifiedArtifactPath());
+    setDeploymentSourceName();
     updateJarWarSelector();
   }
 
@@ -349,20 +349,18 @@ public class AppEngineDeploymentRunConfigurationEditor extends
    * window. We want to disambiguate this name as much as possible so that unique deployments show
    * up as individual line items in the deployment UI.
    */
-  private void setDeploymentSourceName(String filePath) {
+  private void setDeploymentSourceName() {
     AppEngineDeployable deployable = (AppEngineDeployable) deploymentSource;
+
+    String projectVersion = ". Project: " + projectSelector.getText()
+        + ". Version: " + getDisplayableVersion();
 
     if (isUserSpecifiedPathDeploymentSource()
         && !StringUtil.isEmpty(userSpecifiedArtifactFileSelector.getText())) {
-      deployable.setName(
-          deployable.getDefaultName() + " - " + new File(filePath).getName()
-              + ". Project: " + projectSelector.getText()
-              + ". Version: " + getDisplayableVersion());
+      deployable.setName(deployable.getDefaultName() + " - "
+          + new File(userSpecifiedArtifactFileSelector.getText()).getName() + projectVersion);
     } else {
-      deployable.setName(
-          deployable.getDefaultName()
-              + ". Project: " + projectSelector.getText()
-              + ". Version: " + getDisplayableVersion());
+      deployable.setName(deployable.getDefaultName() + projectVersion);
     }
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -358,7 +358,8 @@ public class AppEngineDeploymentRunConfigurationEditor extends
     if (isUserSpecifiedPathDeploymentSource()
         && !StringUtil.isEmpty(userSpecifiedArtifactFileSelector.getText())) {
       deployable.setName(deployable.getDefaultName() + " - "
-          + new File(userSpecifiedArtifactFileSelector.getText()).getName() + projectVersionSuffix);
+          + Paths.get(userSpecifiedArtifactFileSelector.getText()).getFileName()
+          + projectVersionSuffix);
     } else {
       deployable.setName(deployable.getDefaultName() + projectVersionSuffix);
     }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -356,10 +356,13 @@ public class AppEngineDeploymentRunConfigurationEditor extends
         && !StringUtil.isEmpty(userSpecifiedArtifactFileSelector.getText())) {
       deployable.setName(
           deployable.getDefaultName() + " - " + new File(filePath).getName()
+              + ". Project: " + projectSelector.getText()
               + ". Version: " + getDisplayableVersion());
     } else {
       deployable.setName(
-          deployable.getDefaultName() + ". Version: " + getDisplayableVersion());
+          deployable.getDefaultName()
+              + ". Project: " + projectSelector.getText()
+              + ". Version: " + getDisplayableVersion());
     }
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
@@ -45,6 +45,7 @@ public class MavenBuildDeploymentSource extends ModuleDeploymentSourceImpl
 
   private final Project project;
   private AppEngineEnvironment environment;
+  private String name;
 
   /**
    * Default constructor used instantiating plain Maven Build Deployment sources.
@@ -52,6 +53,7 @@ public class MavenBuildDeploymentSource extends ModuleDeploymentSourceImpl
   public MavenBuildDeploymentSource(@NotNull ModulePointer pointer, @NotNull Project project) {
     super(pointer);
     this.project = project;
+    setName(getDefaultName());
   }
 
   public MavenBuildDeploymentSource(@NotNull ModulePointer pointer,
@@ -60,12 +62,23 @@ public class MavenBuildDeploymentSource extends ModuleDeploymentSourceImpl
     super(pointer);
     this.project = project;
     this.environment = environment;
+    setName(getDefaultName());
   }
 
   @NotNull
   @Override
   public String getPresentableName() {
-    return String.format("Maven build: %s", getModulePointer().getModuleName());
+    return name;
+  }
+
+  @Override
+  public String getDefaultName() {
+    return "Maven build: " + getModulePointer().getModuleName();
+  }
+
+  @Override
+  public void setName(String name) {
+    this.name = name;
   }
 
   @Nullable

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.project.MavenProject;
 import org.jetbrains.idea.maven.project.MavenProjectsManager;
-import org.joda.time.DateTime;
 
 import java.io.File;
 import java.util.Collections;
@@ -47,6 +46,8 @@ public class MavenBuildDeploymentSource extends ModuleDeploymentSourceImpl
   private final Project project;
   private AppEngineEnvironment environment;
   private String name;
+  private String projectName;
+  private String version;
 
   /**
    * Default constructor used instantiating plain Maven Build Deployment sources.
@@ -54,7 +55,7 @@ public class MavenBuildDeploymentSource extends ModuleDeploymentSourceImpl
   public MavenBuildDeploymentSource(@NotNull ModulePointer pointer, @NotNull Project project) {
     super(pointer);
     this.project = project;
-    setName(getDefaultName());
+    this.name = getDefaultName();
   }
 
   public MavenBuildDeploymentSource(@NotNull ModulePointer pointer,
@@ -63,23 +64,37 @@ public class MavenBuildDeploymentSource extends ModuleDeploymentSourceImpl
     super(pointer);
     this.project = project;
     this.environment = environment;
-    setName(getDefaultName());
+    this.name = getDefaultName();
   }
 
   @NotNull
   @Override
   public String getPresentableName() {
-    return String.format("[%s] ", DateTime.now().toString("yyyy-MM-dd HH:mm:ss")) + name;
+    return name;
   }
 
   @Override
-  public String getDefaultName() {
+  public String getProjectName() {
+    return projectName;
+  }
+
+  @Override
+  public void setProjectName(String projectName) {
+    this.projectName = projectName;
+  }
+
+  @Override
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  private String getDefaultName() {
     return "Maven build: " + getModulePointer().getModuleName();
-  }
-
-  @Override
-  public void setName(String name) {
-    this.name = name;
   }
 
   @Nullable

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.project.MavenProject;
 import org.jetbrains.idea.maven.project.MavenProjectsManager;
+import org.joda.time.DateTime;
 
 import java.io.File;
 import java.util.Collections;
@@ -68,7 +69,7 @@ public class MavenBuildDeploymentSource extends ModuleDeploymentSourceImpl
   @NotNull
   @Override
   public String getPresentableName() {
-    return name;
+    return String.format("[%s] ", DateTime.now().toString("HH:mm:ss")) + name;
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
@@ -25,8 +25,6 @@ import com.intellij.psi.xml.XmlFile;
 import com.intellij.remoteServer.configuration.deployment.DeploymentSourceType;
 import com.intellij.remoteServer.impl.configuration.deployment.ModuleDeploymentSourceImpl;
 
-import icons.MavenIcons;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.project.MavenProject;
@@ -37,6 +35,8 @@ import java.io.File;
 import java.util.Collections;
 
 import javax.swing.Icon;
+
+import icons.MavenIcons;
 
 /**
  * A deployment source backed by the Maven build system.
@@ -74,7 +74,7 @@ public class MavenBuildDeploymentSource extends ModuleDeploymentSourceImpl
 
   @Override
   public String getDefaultName() {
-    return getModulePointer().getModuleName();
+    return "Maven build: " + getModulePointer().getModuleName();
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
@@ -69,7 +69,7 @@ public class MavenBuildDeploymentSource extends ModuleDeploymentSourceImpl
   @NotNull
   @Override
   public String getPresentableName() {
-    return String.format("[%s] ", DateTime.now().toString("HH:mm:ss")) + name;
+    return String.format("[%s] ", DateTime.now().toString("yyyy-MM-dd HH:mm:ss")) + name;
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
@@ -25,6 +25,8 @@ import com.intellij.psi.xml.XmlFile;
 import com.intellij.remoteServer.configuration.deployment.DeploymentSourceType;
 import com.intellij.remoteServer.impl.configuration.deployment.ModuleDeploymentSourceImpl;
 
+import icons.MavenIcons;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.project.MavenProject;
@@ -35,8 +37,6 @@ import java.io.File;
 import java.util.Collections;
 
 import javax.swing.Icon;
-
-import icons.MavenIcons;
 
 /**
  * A deployment source backed by the Maven build system.

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSource.java
@@ -74,7 +74,7 @@ public class MavenBuildDeploymentSource extends ModuleDeploymentSourceImpl
 
   @Override
   public String getDefaultName() {
-    return "Maven build: " + getModulePointer().getModuleName();
+    return getModulePointer().getModuleName();
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSourceType.java
@@ -46,6 +46,8 @@ public class MavenBuildDeploymentSourceType extends BuildDeploymentSourceType {
   private static final String MAVEN_TASK_PACKAGE = "package";
   private static final String SOURCE_TYPE_ID = "maven-build-source";
   private static final String NAME_ATTRIBUTE = "name";
+  private static final String PROJECT_ATTRIBUTE = "project";
+  private static final String VERSION_ATTRIBUTE = "version";
 
   public MavenBuildDeploymentSourceType() {
     super(SOURCE_TYPE_ID);
@@ -82,13 +84,30 @@ public class MavenBuildDeploymentSourceType extends BuildDeploymentSourceType {
   public MavenBuildDeploymentSource load(@NotNull Element tag, @NotNull Project project) {
     final String moduleName = tag.getAttributeValue(NAME_ATTRIBUTE);
 
-    return new MavenBuildDeploymentSource(
+    MavenBuildDeploymentSource source = new MavenBuildDeploymentSource(
         ModulePointerManager.getInstance(project).create(moduleName), project);
+    source.setProjectName(tag.getAttributeValue(PROJECT_ATTRIBUTE));
+    source.setVersion(tag.getAttributeValue(VERSION_ATTRIBUTE));
+
+    return source;
   }
 
   @Override
-  public void save(@NotNull ModuleDeploymentSource source, @NotNull Element tag) {
-    tag.setAttribute(NAME_ATTRIBUTE, source.getModulePointer().getModuleName());
+  public void save(@NotNull ModuleDeploymentSource deploymentSource, @NotNull Element tag) {
+    tag.setAttribute(NAME_ATTRIBUTE, deploymentSource.getModulePointer().getModuleName());
+
+    if (deploymentSource instanceof AppEngineDeployable) {
+      AppEngineDeployable deployable = (AppEngineDeployable) deploymentSource;
+
+      if (deployable.getProjectName() != null) {
+        tag.setAttribute(PROJECT_ATTRIBUTE,
+            ((AppEngineDeployable) deploymentSource).getProjectName());
+      }
+
+      if (deployable.getVersion() != null) {
+        tag.setAttribute(VERSION_ATTRIBUTE, ((AppEngineDeployable) deploymentSource).getVersion());
+      }
+    }
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSourceType.java
@@ -88,7 +88,7 @@ public class MavenBuildDeploymentSourceType extends BuildDeploymentSourceType {
 
   @Override
   public void save(@NotNull ModuleDeploymentSource source, @NotNull Element tag) {
-    tag.setAttribute(NAME_ATTRIBUTE, source.getModulePointer().getModuleName());
+    tag.setAttribute(NAME_ATTRIBUTE, ((AppEngineDeployable) source).getDefaultName());
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/MavenBuildDeploymentSourceType.java
@@ -88,7 +88,7 @@ public class MavenBuildDeploymentSourceType extends BuildDeploymentSourceType {
 
   @Override
   public void save(@NotNull ModuleDeploymentSource source, @NotNull Element tag) {
-    tag.setAttribute(NAME_ATTRIBUTE, ((AppEngineDeployable) source).getDefaultName());
+    tag.setAttribute(NAME_ATTRIBUTE, source.getModulePointer().getModuleName());
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSource.java
@@ -25,7 +25,6 @@ import com.intellij.remoteServer.impl.configuration.deployment.ModuleDeploymentS
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.joda.time.DateTime;
 
 import java.io.File;
 
@@ -38,12 +37,13 @@ import javax.swing.Icon;
 public class UserSpecifiedPathDeploymentSource extends ModuleDeploymentSourceImpl
     implements AppEngineDeployable {
 
-  private String name;
+  public static final String moduleName = "userSpecifiedSource";
   private String userSpecifiedFilePath;
+  private String projectName;
+  private String version;
 
   public UserSpecifiedPathDeploymentSource(@NotNull ModulePointer pointer) {
     super(pointer);
-    setName(getDefaultName());
   }
 
   @Override
@@ -60,17 +60,27 @@ public class UserSpecifiedPathDeploymentSource extends ModuleDeploymentSourceImp
   @NotNull
   @Override
   public String getPresentableName() {
-    return String.format("[%s] ", DateTime.now().toString("yyyy-MM-dd HH:mm:ss")) + name;
-  }
-
-  @Override
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  @Override
-  public String getDefaultName() {
     return GctBundle.message("appengine.flex.user.specified.deploymentsource.name");
+  }
+
+  @Override
+  public String getProjectName() {
+    return projectName;
+  }
+
+  @Override
+  public void setProjectName(String projectName) {
+    this.projectName = projectName;
+  }
+
+  @Override
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public void setVersion(String version) {
+    this.version = version;
   }
 
   @Nullable

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSource.java
@@ -60,7 +60,7 @@ public class UserSpecifiedPathDeploymentSource extends ModuleDeploymentSourceImp
   @NotNull
   @Override
   public String getPresentableName() {
-    return String.format("[%s] ", DateTime.now().toString("HH:mm:ss")) + name;
+    return String.format("[%s] ", DateTime.now().toString("yyyy-MM-dd HH:mm:ss")) + name;
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSource.java
@@ -25,6 +25,7 @@ import com.intellij.remoteServer.impl.configuration.deployment.ModuleDeploymentS
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.joda.time.DateTime;
 
 import java.io.File;
 
@@ -59,7 +60,7 @@ public class UserSpecifiedPathDeploymentSource extends ModuleDeploymentSourceImp
   @NotNull
   @Override
   public String getPresentableName() {
-    return name;
+    return String.format("[%s] ", DateTime.now().toString("HH:mm:ss")) + name;
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSource.java
@@ -37,12 +37,12 @@ import javax.swing.Icon;
 public class UserSpecifiedPathDeploymentSource extends ModuleDeploymentSourceImpl
     implements AppEngineDeployable {
 
-  private String name =
-      GctBundle.message("appengine.flex.user.specified.deploymentsource.name");
+  private String name;
   private String userSpecifiedFilePath;
 
   public UserSpecifiedPathDeploymentSource(@NotNull ModulePointer pointer) {
     super(pointer);
+    setName(getDefaultName());
   }
 
   @Override
@@ -62,8 +62,14 @@ public class UserSpecifiedPathDeploymentSource extends ModuleDeploymentSourceImp
     return name;
   }
 
+  @Override
   public void setName(String name) {
     this.name = name;
+  }
+
+  @Override
+  public String getDefaultName() {
+    return GctBundle.message("appengine.flex.user.specified.deploymentsource.name");
   }
 
   @Nullable

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSourceType.java
@@ -79,6 +79,6 @@ public class UserSpecifiedPathDeploymentSourceType extends
 
   @Override
   public void save(@NotNull ModuleDeploymentSource source, @NotNull Element tag) {
-    tag.setAttribute(NAME_ATTRIBUTE, source.getModulePointer().getModuleName());
+    tag.setAttribute(NAME_ATTRIBUTE, ((AppEngineDeployable) source).getDefaultName());
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSourceType.java
@@ -28,7 +28,7 @@ import com.intellij.remoteServer.impl.configuration.deployment.DeployToServerRun
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.File;
+import java.nio.file.Paths;
 
 /**
  * A {@link DeploymentSourceType} that supports serialization for a {@link
@@ -65,7 +65,7 @@ public class UserSpecifiedPathDeploymentSourceType extends
         userSpecifiedSource.setName(
             GctBundle.message(
                 "appengine.flex.user.specified.deploymentsource.name") + " - "
-                + new File(filePath).getName());
+                + Paths.get(filePath).getFileName());
 
         return userSpecifiedSource;
       }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSourceType.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.tools.intellij.appengine.cloud;
 
-import com.google.cloud.tools.intellij.util.GctBundle;
-
 import com.intellij.openapi.module.ModulePointerManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
@@ -28,8 +26,6 @@ import com.intellij.remoteServer.impl.configuration.deployment.DeployToServerRun
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 
-import java.nio.file.Paths;
-
 /**
  * A {@link DeploymentSourceType} that supports serialization for a {@link
  * UserSpecifiedPathDeploymentSource}.
@@ -37,8 +33,9 @@ import java.nio.file.Paths;
 public class UserSpecifiedPathDeploymentSourceType extends
     DeploymentSourceType<ModuleDeploymentSource> {
 
-  private static final String NAME_ATTRIBUTE = "name";
   private static final String SOURCE_TYPE_ID = "filesystem-war-jar-module";
+  private static final String PROJECT_ATTRIBUTE = "project";
+  private static final String VERSION_ATTRIBUTE = "version";
 
   public UserSpecifiedPathDeploymentSourceType() {
     super(SOURCE_TYPE_ID);
@@ -53,7 +50,10 @@ public class UserSpecifiedPathDeploymentSourceType extends
   public ModuleDeploymentSource load(@NotNull Element tag, @NotNull Project project) {
     UserSpecifiedPathDeploymentSource userSpecifiedSource =
         new UserSpecifiedPathDeploymentSource(ModulePointerManager
-            .getInstance(project).create(tag.getAttributeValue(NAME_ATTRIBUTE)));
+            .getInstance(project).create(UserSpecifiedPathDeploymentSource.moduleName));
+
+    userSpecifiedSource.setProjectName(tag.getAttributeValue(PROJECT_ATTRIBUTE));
+    userSpecifiedSource.setVersion(tag.getAttributeValue(VERSION_ATTRIBUTE));
 
     Element settings = tag.getChild(DeployToServerRunConfiguration.SETTINGS_ELEMENT);
     if (settings != null) {
@@ -62,23 +62,27 @@ public class UserSpecifiedPathDeploymentSourceType extends
 
       if (!StringUtil.isEmpty(filePath)) {
         userSpecifiedSource.setFilePath(filePath);
-        userSpecifiedSource.setName(
-            GctBundle.message(
-                "appengine.flex.user.specified.deploymentsource.name") + " - "
-                + Paths.get(filePath).getFileName());
 
         return userSpecifiedSource;
       }
     }
 
-    userSpecifiedSource.setName(
-        GctBundle.message("appengine.flex.user.specified.deploymentsource.name"));
-
     return userSpecifiedSource;
   }
 
   @Override
-  public void save(@NotNull ModuleDeploymentSource source, @NotNull Element tag) {
-    tag.setAttribute(NAME_ATTRIBUTE, ((AppEngineDeployable) source).getDefaultName());
+  public void save(@NotNull ModuleDeploymentSource deploymentSource, @NotNull Element tag) {
+    if (deploymentSource instanceof AppEngineDeployable) {
+      AppEngineDeployable deployable = (AppEngineDeployable) deploymentSource;
+
+      if (deployable.getProjectName() != null) {
+        tag.setAttribute(PROJECT_ATTRIBUTE,
+            ((AppEngineDeployable) deploymentSource).getProjectName());
+      }
+
+      if (deployable.getVersion() != null) {
+        tag.setAttribute(VERSION_ATTRIBUTE, ((AppEngineDeployable) deploymentSource).getVersion());
+      }
+    }
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSourceType.java
@@ -64,8 +64,8 @@ public class UserSpecifiedPathDeploymentSourceType extends
         userSpecifiedSource.setFilePath(filePath);
         userSpecifiedSource.setName(
             GctBundle.message(
-                "appengine.flex.user.specified.deploymentsource.name.with.filename",
-                new File(filePath).getName()));
+                "appengine.flex.user.specified.deploymentsource.name") + " - "
+                + new File(filePath).getName());
 
         return userSpecifiedSource;
       }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
@@ -203,8 +203,8 @@ public class AppEngineUtil {
 
   private static UserSpecifiedPathDeploymentSource createUserSpecifiedPathDeploymentSource(
       @NotNull Project project) {
-    ModulePointer modulePointer =
-        ModulePointerManager.getInstance(project).create("userSpecifiedSource");
+    ModulePointer modulePointer = ModulePointerManager.getInstance(project)
+        .create(UserSpecifiedPathDeploymentSource.moduleName);
 
     return new UserSpecifiedPathDeploymentSource(modulePointer);
   }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelperTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelperTest.java
@@ -167,6 +167,16 @@ public class CloudSdkAppEngineHelperTest extends BasePluginTestCase {
       return null;
     }
 
+    @Override
+    public void setName(String name) {
+
+    }
+
+    @Override
+    public String getDefaultName() {
+      return null;
+    }
+
     @Nullable
     @Override
     public File getFile() {

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelperTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelperTest.java
@@ -168,13 +168,23 @@ public class CloudSdkAppEngineHelperTest extends BasePluginTestCase {
     }
 
     @Override
-    public void setName(String name) {
+    public String getProjectName() {
+      return null;
+    }
+
+    @Override
+    public void setProjectName(String projectName) {
 
     }
 
     @Override
-    public String getDefaultName() {
+    public String getVersion() {
       return null;
+    }
+
+    @Override
+    public void setVersion(String version) {
+
     }
 
     @Nullable


### PR DESCRIPTION
fixes #821 

Ensures that unique deployments (those that occur at different times) are displayed and handled as separate line items in the deployment UI.

Here is what the sources now look like. This is showing each deployment source type twice - once with an auto-increment version, and once with a custom version id. Before this PR, the deployment source of the same type would have been overwritten and not displayed twice.

![image](https://cloud.githubusercontent.com/assets/1735744/19571899/dabc3f96-96cd-11e6-8bba-05a22e09b957.png)