### PR TITLE
Remove unnecessary method declaration.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineStandardFacetType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineStandardFacetType.java
@@ -56,12 +56,6 @@ public class AppEngineStandardFacetType
     return moduleType instanceof JavaModuleType;
   }
 
-  @NotNull
-  @Override
-  public String getDefaultFacetName() {
-    return "Google App Engine Standard";
-  }
-
   @Override
   public Icon getIcon() {
     return GoogleCloudToolsIcons.APP_ENGINE;


### PR DESCRIPTION
getDefaultFacetName() returns FacetType.myPresentableName, which we're initializing in the constructor as "Google App Engine Standard" (through GctBundle).