### PR TITLE
Generate env flex

### DIFF
--- a/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/app.yaml
+++ b/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/app.yaml
@@ -1,4 +1,4 @@
 runtime: custom
-vm: true
+env: flex
 env_variables:
   'DBG_ENABLE': 'true'

--- a/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/jar.dockerfile
+++ b/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/jar.dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google_appengine/openjdk8
+FROM gcr.io/google_appengine/openjdk
 ADD target.jar /app/
 ENTRYPOINT ["/docker-entrypoint.bash"]
 CMD ["java","-jar","/app/target.jar"]

--- a/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/war.dockerfile
+++ b/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/war.dockerfile
@@ -1,2 +1,2 @@
-FROM gcr.io/google_appengine/jetty9
+FROM gcr.io/google_appengine/jetty
 ADD target.war $JETTY_BASE/webapps/root.war


### PR DESCRIPTION
see also #451

This PR updates the app.yaml template to deploy to env: flex. Ideally, this would be fixed by using `gcloud gen-config` to generate app.yaml, but gen-config is currently in flux, and does not give us a way to specify the output directory for generated files.

I think we should make this change in order to start using env: flex in the upcoming 16.11 release, and then later use gcloud when it is ready.