### PR TITLE
Fix cloud sdk validation error message flash

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
@@ -200,8 +200,14 @@ public class CloudSdkPanel {
     return cloudSdkDirectoryField.getText();
   }
 
+  /**
+   * Sets the Cloud SDK directory text. Performs no action if the current value of the Cloud SDK
+   * directory field is already equal to the path.
+   */
   public void setCloudSdkDirectoryText(String path) {
-    cloudSdkDirectoryField.setText(path);
+    if (!cloudSdkDirectoryField.getText().equals(path)) {
+      cloudSdkDirectoryField.setText(path);
+    }
   }
 
   @NotNull

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
@@ -32,6 +32,7 @@ import com.intellij.ui.JBColor;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -205,7 +206,7 @@ public class CloudSdkPanel {
    * directory field is already equal to the path.
    */
   public void setCloudSdkDirectoryText(String path) {
-    if (!cloudSdkDirectoryField.getText().equals(path)) {
+    if (!Objects.equals(cloudSdkDirectoryField.getText(), path)) {
       cloudSdkDirectoryField.setText(path);
     }
   }


### PR DESCRIPTION
fixes #1109

When `cloudSdkDirectoryField.setText` is called, it causes two DocumentEvents to be fired, one that removes the old text, and one that adds the new text. Since we validate on every DocumentEvent, this causes the message to flash.  Simply preventing unnecessary updates removes the issue.