### PR TITLE
Extract malformed SDK path check to new method.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkService.java
@@ -64,11 +64,11 @@ public abstract class CloudSdkService {
       return ImmutableSet.of(CloudSdkValidationResult.CLOUD_SDK_NOT_FOUND);
     }
 
-    try {
-      return validateCloudSdk(Paths.get(path));
-    } catch (InvalidPathException ipe) {
+    if (isMalformedCloudSdkPath(path)) {
       return ImmutableSet.of(CloudSdkValidationResult.MALFORMED_PATH);
     }
+
+    return validateCloudSdk(Paths.get(path));
   }
 
   /**
@@ -83,6 +83,18 @@ public abstract class CloudSdkService {
    */
   public boolean isValidCloudSdk() {
     return validateCloudSdk(getSdkHomePath()).isEmpty();
+  }
+
+  /**
+   * Checks for invalid characters that trigger a {@link InvalidPathException} on Windows.
+   */
+  public boolean isMalformedCloudSdkPath(String sdkPath) {
+    try {
+      Paths.get(sdkPath);
+    } catch (InvalidPathException ipe) {
+      return true;
+    }
+    return false;
   }
 
   @Nullable

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.appengine.cloudsdk.CloudSdkNotFoundException;
 import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerException;
 import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
 import com.google.cloud.tools.intellij.flags.PropertiesFileFlagReader;
+import com.google.cloud.tools.intellij.stats.UsageTrackerProvider;
 import com.google.common.annotations.VisibleForTesting;
 
 import com.intellij.execution.configurations.ParametersList;
@@ -84,9 +85,10 @@ public class DefaultCloudSdkService extends CloudSdkService {
   @Nullable
   @Override
   public Path getSdkHomePath() {
-    // For Windows users that persisted the old malformed path.
-    if (validateCloudSdk(propertiesComponent.getValue(CLOUD_SDK_PROPERTY_KEY))
-        .contains(CloudSdkValidationResult.MALFORMED_PATH)) {
+    // To let Windows users that persisted the old malformed path save a new one.
+    // TODO(joaomartins): Delete this after a while so gets are faster.
+    if (isMalformedCloudSdkPath(propertiesComponent.getValue(CLOUD_SDK_PROPERTY_KEY))) {
+      UsageTrackerProvider.getInstance().trackEvent("malformedPath").ping();
       return null;
     }
 


### PR DESCRIPTION
 Only check for path malformedness on `DefaultCloudSdkService.getCloudSdkPath()`.