### PR TITLE
Adds null control for Cloud SDK paths form check

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
@@ -171,7 +171,7 @@ public class CloudSdkPanel {
 
   private void invokePanelValidationUpdate(Runnable runnable) {
     ApplicationManager.getApplication().invokeLater(runnable,
-        ModalityState.defaultModalityState());//.stateForComponent(cloudSdkPanel));
+        ModalityState.stateForComponent(cloudSdkPanel));
   }
 
   @VisibleForTesting

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
@@ -171,7 +171,7 @@ public class CloudSdkPanel {
 
   private void invokePanelValidationUpdate(Runnable runnable) {
     ApplicationManager.getApplication().invokeLater(runnable,
-        ModalityState.stateForComponent(cloudSdkPanel));
+        ModalityState.defaultModalityState());//.stateForComponent(cloudSdkPanel));
   }
 
   @VisibleForTesting

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkService.java
@@ -86,9 +86,13 @@ public abstract class CloudSdkService {
   }
 
   /**
-   * Checks for invalid characters that trigger a {@link InvalidPathException} on Windows.
+   * Checks for invalid characters that trigger an {@link InvalidPathException} on Windows.
    */
-  public boolean isMalformedCloudSdkPath(String sdkPath) {
+  public boolean isMalformedCloudSdkPath(@Nullable String sdkPath) {
+    if (sdkPath == null) {
+      return false;
+    }
+
     try {
       Paths.get(sdkPath);
     } catch (InvalidPathException ipe) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkService.java
@@ -89,14 +89,12 @@ public abstract class CloudSdkService {
    * Checks for invalid characters that trigger an {@link InvalidPathException} on Windows.
    */
   public boolean isMalformedCloudSdkPath(@Nullable String sdkPath) {
-    if (sdkPath == null) {
-      return false;
-    }
-
-    try {
-      Paths.get(sdkPath);
-    } catch (InvalidPathException ipe) {
-      return true;
+    if (sdkPath != null) {
+      try {
+        Paths.get(sdkPath);
+      } catch (InvalidPathException ipe) {
+        return true;
+      }
     }
     return false;
   }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerE
 import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
 import com.google.cloud.tools.intellij.flags.PropertiesFileFlagReader;
 import com.google.cloud.tools.intellij.stats.UsageTrackerProvider;
+import com.google.cloud.tools.intellij.util.GctTracking;
 import com.google.common.annotations.VisibleForTesting;
 
 import com.intellij.execution.configurations.ParametersList;
@@ -85,14 +86,13 @@ public class DefaultCloudSdkService extends CloudSdkService {
   @Nullable
   @Override
   public Path getSdkHomePath() {
-    // To let Windows users that persisted the old malformed path save a new one.
-    // TODO(joaomartins): Delete this after a while so gets are faster.
-    if (isMalformedCloudSdkPath(propertiesComponent.getValue(CLOUD_SDK_PROPERTY_KEY))) {
-      UsageTrackerProvider.getInstance().trackEvent("malformedPath").ping();
-      return null;
-    }
-
     if (propertiesComponent.getValue(CLOUD_SDK_PROPERTY_KEY) != null) {
+      // To let Windows users that persisted the old malformed path save a new one.
+      // TODO(joaomartins): Delete this after a while so gets are faster.
+      if (isMalformedCloudSdkPath(propertiesComponent.getValue(CLOUD_SDK_PROPERTY_KEY))) {
+        UsageTrackerProvider.getInstance().trackEvent(GctTracking.CLOUD_SDK_MALFORMED_PATH).ping();
+        return null;
+      }
       return Paths.get(propertiesComponent.getValue(CLOUD_SDK_PROPERTY_KEY));
     }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/util/GctTracking.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/util/GctTracking.java
@@ -55,4 +55,6 @@ public class GctTracking {
       "appengine.oldplugin.notification.link.click";
   public static final String APP_ENGINE_OLD_PLUGIN_DEACTIVATED =
       "appengine.oldplugin.deactivated";
+
+  public static final String CLOUD_SDK_MALFORMED_PATH = "cloudsdk.malformedpath";
 }


### PR DESCRIPTION
propertiesComponent.getValue(CLOUD_SDK_PROPERTY_KEY) is returning null, generating an NPE on CloudSdkService.isMalformedPath() at Paths.get().