### PR TITLE
Show invalid SDK warning when opening CloudSdkPanel

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
@@ -167,7 +167,7 @@ public class CloudSdkPanel {
   }
 
   private void invokePanelValidationUpdate(Runnable runnable) {
-    ApplicationManager.getApplication().invokeLater(runnable, ModalityState.current());
+    ApplicationManager.getApplication().invokeLater(runnable, ModalityState.any());
   }
 
   @VisibleForTesting

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
@@ -148,7 +148,6 @@ public class CloudSdkPanel {
       public void run() {
         warningMessage.setText(message);
         warningMessage.setVisible(true);
-        warningMessage.updateUI();
         warningIcon.setVisible(true);
         cloudSdkDirectoryField.getTextField().setForeground(JBColor.red);
       }
@@ -162,16 +161,13 @@ public class CloudSdkPanel {
       public void run() {
         cloudSdkDirectoryField.getTextField().setForeground(JBColor.black);
         warningIcon.setVisible(false);
-        warningIcon.setVisible(false);
         warningMessage.setVisible(false);
-        cloudSdkPanel.updateUI();
       }
     });
   }
 
   private void invokePanelValidationUpdate(Runnable runnable) {
-    ApplicationManager.getApplication().invokeLater(runnable,
-        ModalityState.stateForComponent(cloudSdkPanel));
+    ApplicationManager.getApplication().invokeLater(runnable, ModalityState.current());
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Changes warning message modality.

Coupled with https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/277 so that a lingering empty message warning disappears.

Fixes #1135