### PR TITLE
Don't perform duplicate version checks that are handled by appengine-plugins-core

### DIFF
--- a/google-cloud-tools-plugin/resources/config.properties
+++ b/google-cloud-tools-plugin/resources/config.properties
@@ -19,5 +19,3 @@ feature.appengine.flex=true
 
 # Should be used in any Notifications explicitly produced by the plugin.
 notifications.plugin.groupdisplayid=Google App Engine plugin
-
-cloudsdk.min.version=131.0.0

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkValidationResult.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkValidationResult.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.intellij.appengine.sdk;
 
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.intellij.util.GctBundle;
 
 /**
@@ -26,7 +27,7 @@ public enum CloudSdkValidationResult {
   CLOUD_SDK_NOT_FOUND(GctBundle.message("appengine.cloudsdk.location.invalid.message"), true),
   CLOUD_SDK_VERSION_NOT_SUPPORTED(
       GctBundle.message("appengine.cloudsdk.version.support.message",
-          DefaultCloudSdkService.getMinimumRequiredCloudSdkVersion().toString()), false),
+          CloudSdk.MINIMUM_VERSION), false),
   MALFORMED_PATH(GctBundle.message("appengine.cloudsdk.location.badchars.message"), true),
   NO_APP_ENGINE_COMPONENT(
       GctBundle.message("appengine.cloudsdk.java.components.missing") + "\n"

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
@@ -21,9 +21,7 @@ import com.google.cloud.tools.appengine.api.whitelist.AppEngineJreWhitelist;
 import com.google.cloud.tools.appengine.cloudsdk.AppEngineJavaComponentsNotInstalledException;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkNotFoundException;
-import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerException;
-import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
-import com.google.cloud.tools.intellij.flags.PropertiesFileFlagReader;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkOutOfDateException;
 import com.google.common.annotations.VisibleForTesting;
 
 import com.intellij.execution.configurations.ParametersList;
@@ -63,7 +61,6 @@ public class DefaultCloudSdkService extends CloudSdkService {
 
   private PropertiesComponent propertiesComponent = PropertiesComponent.getInstance();
   private static final String CLOUD_SDK_PROPERTY_KEY = "GCT_CLOUD_SDK_HOME_PATH";
-  private static final String CLOUD_SDK_REQUIRED_VERSION_KEY = "cloudsdk.min.version";
   private static final Path JAVA_TOOLS_RELATIVE_PATH
       = Paths.get("platform", "google_appengine", "google", "appengine", "tools", "java");
 
@@ -72,14 +69,6 @@ public class DefaultCloudSdkService extends CloudSdkService {
       = Paths.get("lib", "appengine-tools-api.jar");
 
   private Map<String, Set<String>> myMethodsBlackList;
-
-  /**
-   * Return the minimum version of the Cloud SDK that is supported by this plugin.
-   */
-  public static CloudSdkVersion getMinimumRequiredCloudSdkVersion() {
-    String version = new PropertiesFileFlagReader().getFlagString(CLOUD_SDK_REQUIRED_VERSION_KEY);
-    return new CloudSdkVersion(version);
-  }
 
   @Nullable
   @Override
@@ -113,6 +102,7 @@ public class DefaultCloudSdkService extends CloudSdkService {
 
     if (path == null) {
       validationResults.add(CloudSdkValidationResult.CLOUD_SDK_NOT_FOUND);
+      // If the Cloud SDK is not found, don't bother checking anything else
       return validationResults;
     }
 
@@ -121,10 +111,9 @@ public class DefaultCloudSdkService extends CloudSdkService {
       sdk.validateCloudSdk();
     } catch (CloudSdkNotFoundException exception) {
       validationResults.add(CloudSdkValidationResult.CLOUD_SDK_NOT_FOUND);
+      // If the Cloud SDK is not found, don't bother checking anything else
       return validationResults;
-    }
-
-    if (!isCloudSdkVersionSupported(sdk)) {
+    } catch (CloudSdkOutOfDateException exception) {
       validationResults.add(CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED);
     }
 
@@ -211,21 +200,6 @@ public class DefaultCloudSdkService extends CloudSdkService {
         vmParameters.add("-Xbootclasspath/p:" + patchPath.getAbsolutePath());
       }
     }
-  }
-
-  private boolean isCloudSdkVersionSupported(CloudSdk sdk) {
-    sdk.validateCloudSdk();
-
-    CloudSdkVersion requiredVersion = getMinimumRequiredCloudSdkVersion();
-    CloudSdkVersion actualVersion;
-    try {
-      actualVersion = sdk.getVersion();
-    } catch (ProcessRunnerException exception) {
-      logger.warn("Exception encountered when calling the cloud SDK", exception);
-      return false;
-    }
-
-    return actualVersion.compareTo(requiredVersion) >= 0;
   }
 
   private Map<String, Set<String>> loadBlackList() throws IOException {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ ideaVersion = 15.0.6
 javaVersion = 1.7
 ijPluginRepoChannel = alpha
 version = 16.11.3-SNAPSHOT
-toolsLibVersion = 0.2.3
+toolsLibVersion = 0.2.4


### PR DESCRIPTION
fixes #1132
fixes #1127

This PR depends on https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/276, which allows us to offload the version checking logic to the core library. 

This should not be merged until we merge https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/276 and update gradle.properties with the new release version.