### PR TITLE
Add the java-google-format gradle plugin to apply java style to our project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Other useful targets while developing include:
     1. Configure the IDE to automatically reformat your code and optimize imports.
         1. Hint - you can do this by configuring it to do so on git push. 
     1. If you're not using IntelliJ you can run reformat from the command line using 
-    `gradlew spotlessApply`.
+    `gradlew googleJavaFormat`.
 1. Fork the repository into your own Github account.
 1. Please include unit tests for all new code. (Yes, we know not all
    existing code has tests. We're slowly fixing that, and contributions of tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,13 @@ Other useful targets while developing include:
    If you're a Googler or other corporate contributor, 
    use your corporate email address here, not your personal address.
 1. Read the [Google Java Style Guide](http://google.github.io/styleguide/javaguide.html)
+1. Install the [Google-java-style IntelliJ plugin](https://github.com/google/google-java-format)
+    1. Make sure to run Code -> Reformat with google-java-format at the beginning of every IDE 
+    session.
+    1. Configure the IDE to automatically reformat your code and optimize imports.
+        1. Hint - you can do this by configuring it to do so on git push. 
+    1. If you're not using IntelliJ you can run reformat from the command line using 
+    `gradlew spotlessApply`.
 1. Fork the repository into your own Github account.
 1. Please include unit tests for all new code. (Yes, we know not all
    existing code has tests. We're slowly fixing that, and contributions of tests

--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,15 @@ subprojects {
     }
 
 
+    apply plugin: 'pmd'
+    pmd {
+        ignoreFailures = false
+        sourceSets = [sourceSets.main]
+        // Don't use the default ruleset but use a custom ruleset to exclude some PMD rules.
+        ruleSets = []
+        ruleSetFiles = rootProject.files('custom-pmd-ruleset.xml');
+    }
+
     apply plugin: 'jdepend'
     configurations.all {
         resolutionStrategy {
@@ -126,6 +135,41 @@ subprojects {
     apply plugin: "com.github.sherter.google-java-format"
     verifyGoogleJavaFormat {
         ignoreFailures true
+    }
+
+    apply plugin: 'checkstyle'
+    configurations {
+        checkstyleConfig
+    }
+    def versions = [
+            checkstyle: '6.17',
+    ]
+    dependencies {
+        checkstyleConfig ("com.puppycrawl.tools:checkstyle:${versions.checkstyle}") {
+            transitive = false
+        }
+        checkstyle "com.puppycrawl.tools:checkstyle:${versions.checkstyle}"
+    }
+    checkstyle {
+        configFile = rootProject.file('google_checks.xml')
+        showViolations true
+        sourceSets = [project.sourceSets.main]
+    }
+
+    // The checkstyle plugin does not provide a way to fail the build on warnings, and
+    // the google_checks.xml sets the severity level to "warning" for all violations. The
+    // following is the workaround.
+    tasks.withType(Checkstyle).each { checkstyleTask ->
+        checkstyleTask.doLast {
+            reports.all { report ->
+                if(report.name == "xml") {
+                    def outputFile = report.destination
+                    if (outputFile.exists() && outputFile.text.contains("<error ")) {
+                        throw new GradleException("There were checkstyle warnings! For more info check $outputFile")
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -113,14 +113,6 @@ subprojects {
         }
     }
 
-    apply plugin: 'pmd'
-    pmd {
-        ignoreFailures = false
-        sourceSets = [sourceSets.main]
-        // Don't use the default ruleset but use a custom ruleset to exclude some PMD rules.
-        ruleSets = []
-        ruleSetFiles = rootProject.files('custom-pmd-ruleset.xml')
-    }
 
     apply plugin: 'jdepend'
     configurations.all {
@@ -132,40 +124,8 @@ subprojects {
     }
 
     apply plugin: "com.github.sherter.google-java-format"
-    
-    apply plugin: 'checkstyle'
-    configurations {
-        checkstyleConfig
-    }
-    def versions = [
-            checkstyle: '6.17',
-    ]
-    dependencies {
-        checkstyleConfig ("com.puppycrawl.tools:checkstyle:${versions.checkstyle}") {
-            transitive = false
-        }
-        checkstyle "com.puppycrawl.tools:checkstyle:${versions.checkstyle}"
-    }
-    checkstyle {
-        configFile = rootProject.file('google_checks.xml')
-        showViolations true
-        sourceSets = [project.sourceSets.main]
-    }
-
-    // The checkstyle plugin does not provide a way to fail the build on warnings, and
-    // the google_checks.xml sets the severity level to "warning" for all violations. The
-    // following is the workaround.
-    tasks.withType(Checkstyle).each { checkstyleTask ->
-        checkstyleTask.doLast {
-            reports.all { report ->
-                if(report.name == "xml") {
-                    def outputFile = report.destination
-                    if (outputFile.exists() && outputFile.text.contains("<error ")) {
-                        throw new GradleException("There were checkstyle warnings! For more info check $outputFile")
-                    }
-                }
-            }
-        }
+    verifyGoogleJavaFormat {
+        ignoreFailures true
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,10 @@ subprojects {
         }
     }
 
+    test {
+        jvmArgs += ["-XX:MaxPermSize=256m"] // For our Java 7 test runs.
+    }
+
     dependencies {
         testCompile 'junit:junit:4.+'
         testCompile ('org.mockito:mockito-core:1.9.5') {

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
     }
     dependencies {
         classpath 'gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.0.43'
+        classpath "com.diffplug.gradle.spotless:spotless:2.4.0"
     }
 }
 
@@ -118,7 +119,7 @@ subprojects {
         sourceSets = [sourceSets.main]
         // Don't use the default ruleset but use a custom ruleset to exclude some PMD rules.
         ruleSets = []
-        ruleSetFiles = rootProject.files('custom-pmd-ruleset.xml');
+        ruleSetFiles = rootProject.files('custom-pmd-ruleset.xml')
     }
 
     apply plugin: 'jdepend'
@@ -128,6 +129,13 @@ subprojects {
             force "jdepend:jdepend:${project.jdepend.toolVersion}"
         }
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    }
+
+    apply plugin: "com.diffplug.gradle.spotless"
+    spotless {
+        java {
+            googleJavaFormat()
+        }
     }
 
     apply plugin: 'checkstyle'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     }
     dependencies {
         classpath 'gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.0.43'
-        classpath "com.diffplug.gradle.spotless:spotless:2.4.0"
+        classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.5"
     }
 }
 
@@ -131,13 +131,8 @@ subprojects {
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     }
 
-    apply plugin: "com.diffplug.gradle.spotless"
-    spotless {
-        java {
-            googleJavaFormat()
-        }
-    }
-
+    apply plugin: "com.github.sherter.google-java-format"
+    
     apply plugin: 'checkstyle'
     configurations {
         checkstyleConfig

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ subprojects {
     }
 
     apply plugin: 'findbugs'
+
     findbugs {
         ignoreFailures = false
         sourceSets = [sourceSets.main]

--- a/google_checks.xml
+++ b/google_checks.xml
@@ -22,9 +22,12 @@
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
     that can be found at https://google.github.io/styleguide/javaguide.html.
+
     Checkstyle is very configurable. Be sure to read the documentation at
     http://checkstyle.sf.net (or in your downloaded distribution).
+
     To completely disable a check, just comment it out or delete it from the file.
+
     Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
  -->
 
@@ -40,7 +43,9 @@
         <property name="eachLine" value="true"/>
     </module>
 
+    <module name="SuppressWarningsFilter"/>
     <module name="TreeWalker">
+        <module name="SuppressWarningsHolder"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
@@ -115,14 +120,7 @@
                      value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="ParameterName">
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
-            <property name="excludeScope" value="public"/>
-            <message key="name.invalidPattern"
-                     value="Parameter name ''{0}'' must match pattern ''{1}''."/>
-        </module>
-        <module name="ParameterName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
-            <property name="scope" value="public"/>
             <message key="name.invalidPattern"
                      value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
@@ -179,15 +177,16 @@
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
+            <property name="specialImportsRegExp" value="com.google"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+            <property name="customImportOrderRules"
+                      value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">
             <property name="option" value="NL"/>
             <property name="tokens"
-                      value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+                      value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
         </module>
         <module name="AnnotationLocation">
             <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
@@ -200,6 +199,7 @@
         <module name="JavadocTagContinuationIndentation"/>
         <module name="SummaryJavadoc">
             <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+            <property name="period" value=""/>
         </module>
         <module name="JavadocParagraph"/>
         <module name="AtclauseOrder">
@@ -208,6 +208,7 @@
         </module>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
+            <property name="allowMissingJavadoc" value="true"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>

--- a/google_checks.xml
+++ b/google_checks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (C) 2016 The Android Open Source Project
+  ~ Copyright 2016 Google Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@
 
     <property name="severity" value="warning"/>
 
-    <property name="fileExtensions" value="java, properties, xml"/>
+    <property name="fileExtensions" value="properties, xml"/>
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
     <module name="FileTabCharacter">

--- a/google_checks.xml
+++ b/google_checks.xml
@@ -22,12 +22,9 @@
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
     that can be found at https://google.github.io/styleguide/javaguide.html.
-
     Checkstyle is very configurable. Be sure to read the documentation at
     http://checkstyle.sf.net (or in your downloaded distribution).
-
     To completely disable a check, just comment it out or delete it from the file.
-
     Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
  -->
 
@@ -43,9 +40,7 @@
         <property name="eachLine" value="true"/>
     </module>
 
-    <module name="SuppressWarningsFilter" />
     <module name="TreeWalker">
-        <module name="SuppressWarningsHolder" />
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
@@ -120,7 +115,14 @@
                      value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="ParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <property name="excludeScope" value="public"/>
+            <message key="name.invalidPattern"
+                     value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="scope" value="public"/>
             <message key="name.invalidPattern"
                      value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
@@ -177,14 +179,15 @@
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
-            <property name="specialImportsRegExp" value="com.google"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">
             <property name="option" value="NL"/>
-            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
+            <property name="tokens"
+                      value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
         </module>
         <module name="AnnotationLocation">
             <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
@@ -197,7 +200,6 @@
         <module name="JavadocTagContinuationIndentation"/>
         <module name="SummaryJavadoc">
             <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
-            <property name="period" value=""/>
         </module>
         <module name="JavadocParagraph"/>
         <module name="AtclauseOrder">
@@ -206,7 +208,6 @@
         </module>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
-            <property name="allowMissingJavadoc" value="true"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>


### PR DESCRIPTION
https://github.com/google/google-java-format is now **the** way to reliably enforce the Google Java style guide.  This PR adds a plugin that is capable of reformating the project code with:`gradlew googleJavaFormat`.

I'll update our CI to use `gradlew verifyGoogleJavaFormat` to verify that the code is the right style which is why I've removed java as a filetype for checkstyle plugin.
  
I've also updated our contributing instructions to instruct users to add the intellij plugin so that IntelliJ formats their code using google-java-format.

related to #1140 