### PR TITLE
Fixes flashing in CloudSdkPanel.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
@@ -75,8 +75,6 @@ public class CloudSdkPanel {
             checkSdkInBackground();
           }
         });
-
-    checkSdkInBackground();
   }
 
   private void checkSdkInBackground() {


### PR DESCRIPTION
checkCloudSdkInBackground() is automatically called when reset() kicks in, so I don't think there's any need for that call.

Tested that it fixes the flashing for the New Project dialog.