### PR TITLE
Fix for vanishing local dev run config

### DIFF
--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/run/AppEngineServerConfigurationType.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/run/AppEngineServerConfigurationType.java
@@ -72,12 +72,19 @@ public class AppEngineServerConfigurationType extends J2EEConfigurationType {
 
   @Override
   public ConfigurationFactory[] getConfigurationFactories() {
+    final ConfigurationFactory configurationFactory = super.getConfigurationFactories()[0];
+
     return new ConfigurationFactory[]{
         new ConfigurationFactory(this) {
+          @Override
+          public String getName() {
+            return configurationFactory.getName();
+          }
+
           @NotNull
           @Override
           public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
-            return createJ2EEConfigurationTemplate(this, project, true /*isLocal*/);
+            return configurationFactory.createTemplateConfiguration(project);
           }
 
           /**


### PR DESCRIPTION
Fixes #1147 

The problem was that the getName method in the ConfigurationFactory was not overriden. This is needed on project re-open so that the previously created one can be restored. 

Also updating the overriden methods to delegate to the already existing ConfigurationFactory's methods.