### PR TITLE
Move to IJ 2016 as the lowest supported version of IJ

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -13,17 +13,22 @@
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
     </wildcardResourcePatterns>
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="false">
+        <processorPath useClasspath="true" />
+      </profile>
+    </annotationProcessing>
     <bytecodeTargetLevel>
-      <module name="common-lib_main" target="1.7" />
-      <module name="common-lib_test" target="1.7" />
-      <module name="common-test-lib_main" target="1.7" />
-      <module name="common-test-lib_test" target="1.7" />
-      <module name="google-account-plugin_main" target="1.7" />
-      <module name="google-account-plugin_test" target="1.7" />
-      <module name="google-cloud-tools-plugin_main" target="1.7" />
-      <module name="google-cloud-tools-plugin_test" target="1.7" />
-      <module name="ultimate_main" target="1.7" />
-      <module name="ultimate_test" target="1.7" />
+      <module name="common-lib_main" target="1.8" />
+      <module name="common-lib_test" target="1.8" />
+      <module name="common-test-lib_main" target="1.8" />
+      <module name="common-test-lib_test" target="1.8" />
+      <module name="google-account-plugin_main" target="1.8" />
+      <module name="google-account-plugin_test" target="1.8" />
+      <module name="google-cloud-tools-plugin_main" target="1.8" />
+      <module name="google-cloud-tools-plugin_test" target="1.8" />
+      <module name="ultimate_main" target="1.8" />
+      <module name="ultimate_test" target="1.8" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,8 +103,5 @@ These are relatively small, self-contained changes that are good places to start
 
 ## FAQ
 
-### java.lang.OutOfMemoryError: PermGen space when running the tests inside IDEA
-
-From the Run menu select “Edit Configurations...” In the "VM options" field add -XX:MaxPermSize=256m (and if that doesn't work try 512m instead).
-
+Nothing here yet.
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.0.43'
+        classpath 'gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.1.10'
         classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8"
         classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.5"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.0.43'
+        classpath 'gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.1.10'
         classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8"
         classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.5"
     }
@@ -50,10 +50,6 @@ subprojects {
     assemble.dependsOn jarSources
 
     apply plugin: "net.ltgt.errorprone"
-    configurations.errorprone {
-        // 2.0.5 is the last version compatible with JDK 7
-        resolutionStrategy.force 'com.google.errorprone:error_prone_core:2.0.5'
-    }
 
     apply plugin: 'org.jetbrains.intellij'
     intellij {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.1.10'
+        classpath 'gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.0.43'
         classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8"
         classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.5"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
     intellij {
         type = ideaEdition
         version = ideaVersion
-        updateSinceUntilBuild = false
+        updateSinceUntilBuild = true
         downloadSources = true
         sandboxDirectory = "${rootProject.buildDir}/idea-sandbox"
 

--- a/google-account-plugin/resources/META-INF/plugin.xml
+++ b/google-account-plugin/resources/META-INF/plugin.xml
@@ -13,15 +13,13 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
+
 <idea-plugin version="2">
   <id>com.google.gct.login</id>
   <name>Google Account</name>
   <vendor>Google</vendor>
   <!-- "version" set by gradle-intellij-plugin -->
   <!-- "idea-version since-build" set by gradle-intellij-plugin -->
-  <!-- Workaround for gradle-intellij-plugin limitation: https://github.com/JetBrains/gradle-intellij-plugin/issues/66 -->
-  <!-- Setting version to 15.0.6 and up. https://confluence.jetbrains.com/display/IDEADEV/IDEA+15+EAP -->
-  <idea-version since-build="143.2370.31" />
 
   <description>
     Provides Google account setting and authentication for IntelliJ plugins that need it.

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -127,6 +127,7 @@ public class GoogleUsageTracker implements UsageTracker, SendsEvents {
   }
 
   /** Send a (virtual) "pageview" ping to the Cloud-platform-wide Google Analytics Property. */
+  @Override
   public void sendEvent(
       @NotNull String eventCategory,
       @NotNull String eventAction,
@@ -173,6 +174,8 @@ public class GoogleUsageTracker implements UsageTracker, SendsEvents {
     ApplicationManager.getApplication()
         .executeOnPooledThread(
             new Runnable() {
+
+              @Override
               public void run() {
                 CloseableHttpClient client =
                     HttpClientBuilder.create().setUserAgent(userAgent).build();

--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 The Android Open Source Project
+ * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ project.afterEvaluate {
     prepareSandboxTask.doLast {
         copy {
             from files(project('ultimate').jar)
-            into "$prepareSandboxTask.destinationDir/lib"
+            into "$prepareSandboxTask.destinationDir/$intellij.pluginName/lib"
         }
     }
 }

--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -31,9 +31,6 @@
   <vendor>Google</vendor>
   <!-- "version" set by gradle-intellij-plugin -->
   <!-- "idea-version since-build" set by gradle-intellij-plugin -->
-  <!-- Workaround for gradle-intellij-plugin limitation: https://github.com/JetBrains/gradle-intellij-plugin/issues/66 -->
-  <!-- Setting version to 15.0.6 and up. https://confluence.jetbrains.com/display/IDEADEV/IDEA+15+EAP -->
-  <idea-version since-build="143.2370.31" />
 
   <change-notes>
     <![CDATA[<html>

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/CloudBreakpointHandlerTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/CloudBreakpointHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 The Android Open Source Project
+ * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,14 +85,12 @@ public class CloudBreakpointHandlerTest extends UsefulTestCase {
   private CloudBreakpointHandler handler;
   private CloudDebugProcessStateController stateController;
   private boolean registrationShouldSucceed;
-
+  private XBreakpointManager breakpointManager;
+  private ServerToIdeFileResolver fileResolver;
   @SuppressWarnings("JUnitTestCaseWithNonTrivialConstructors")
   public CloudBreakpointHandlerTest() {
     IdeaTestCase.initPlatformPrefix();
   }
-
-  private XBreakpointManager breakpointManager;
-  private ServerToIdeFileResolver fileResolver;
 
   @Override
   protected void setUp() throws Exception {
@@ -214,7 +212,7 @@ public class CloudBreakpointHandlerTest extends UsefulTestCase {
     handler.deleteBreakpoint(addedBp.get());
 
     assertNotNull(removedBp.get());
-    assertTrue(removedBp.get() == addedBp.get().getId());
+    assertTrue(removedBp.get().equals(addedBp.get().getId()));
   }
 
   public void testServerCreation() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@
 #
 
 ideaEdition = IC
-ideaVersion = 15.0.6
-javaVersion = 1.7
+ideaVersion=2016.3
+javaVersion=1.8
 ijPluginRepoChannel = alpha
 version = 16.11.7-SNAPSHOT
 toolsLibVersion = 0.2.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@
 #
 
 ideaEdition = IC
-ideaVersion=2016.3
-javaVersion=1.8
+ideaVersion = 2016.3
+javaVersion = 1.8
 ijPluginRepoChannel = alpha
 version = 16.11.7-SNAPSHOT
 toolsLibVersion = 0.2.4


### PR DESCRIPTION
includes setting the project language level to java 8 since 2016 is java 8 based.

I had to upgrade the gradle-intellij-plugin to get this to build with the new config.

the random test case refactor is error-prone suddenly behaving slightly differently with the config change.