### PR TITLE
Post-filter deleted projects

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/GoogleUserModelItem.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/GoogleUserModelItem.java
@@ -37,7 +37,6 @@ import java.awt.Image;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -54,6 +53,7 @@ class GoogleUserModelItem extends DefaultMutableTreeNode {
 
   private static final Logger LOG = Logger.getInstance(GoogleUserModelItem.class);
   private static final int PROJECTS_MAX_PAGE_SIZE = 300;
+  private static final String PROJECT_DELETE_REQUESTED = "DELETE_REQUESTED";
 
   private final CredentialedUser user;
   private final DefaultTreeModel treeModel;
@@ -110,15 +110,12 @@ class GoogleUserModelItem extends DefaultMutableTreeNode {
     }
     isSynchronizing = true;
 
-    ApplicationManager.getApplication().executeOnPooledThread(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          loadUserProjects();
-          needsSynchronizing = false;
-        } finally {
-          isSynchronizing = false;
-        }
+    ApplicationManager.getApplication().executeOnPooledThread(() -> {
+      try {
+        loadUserProjects();
+        needsSynchronizing = false;
+      } finally {
+        isSynchronizing = false;
       }
     });
   }
@@ -140,7 +137,7 @@ class GoogleUserModelItem extends DefaultMutableTreeNode {
   }
 
   private void loadUserProjects() {
-    final List<DefaultMutableTreeNode> result = new ArrayList<DefaultMutableTreeNode>();
+    final List<DefaultMutableTreeNode> result = new ArrayList<>();
 
     try {
 
@@ -148,14 +145,16 @@ class GoogleUserModelItem extends DefaultMutableTreeNode {
           .setPageSize(PROJECTS_MAX_PAGE_SIZE).execute();
 
       if (response != null && response.getProjects() != null) {
-        // Sorts the projects list by project ID.
-        Set<Project> allProjects = new TreeSet<Project>(new Comparator<Project>() {
-          @Override
-          public int compare(Project p1, Project p2) {
-            return p1.getName().toLowerCase().compareTo(p2.getName().toLowerCase());
-          }
-        });
-        allProjects.addAll(response.getProjects());
+        // Create a sorted set to sort the projects list by project ID.
+        Set<Project> allProjects = new TreeSet<>((Project p1, Project p2) ->
+            p1.getName().toLowerCase().compareTo(p2.getName().toLowerCase()));
+
+        response.getProjects().stream()
+            // Filter out any projects that are scheduled for deletion.
+            .filter((project) -> !PROJECT_DELETE_REQUESTED.equals(project.getLifecycleState()))
+            // Add remaining projects to the set.
+            .forEach(allProjects::add);
+
         while (!Strings.isNullOrEmpty(response.getNextPageToken())) {
           response = cloudResourceManagerClient.projects().list()
               .setPageToken(response.getNextPageToken())


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/1119. I decided to take care of this now, since this bug causes some issues for #1169. 

Since the Cloud Resource Manager API doesn't support filtering projects on their lifecycle status, we need to post-filter the results we get before displaying to the user. I also took the liberty of converting some code to take advantage of Java 8 features while I was in the neighborhood.