### PR TITLE
Add error message to deploy metrics label

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -156,8 +156,8 @@ public class GoogleUsageTracker implements UsageTracker, SendsEvents {
           Map<String, String> escapedMap = metadataMap.entrySet()
               .stream()
               .collect(Collectors.toMap(
-                  key -> METADATA_ESCAPER.escape(key.getKey()),
-                  val -> METADATA_ESCAPER.escape(val.getValue())));
+                  entry -> METADATA_ESCAPER.escape(entry.getKey()),
+                  entry -> METADATA_ESCAPER.escape(entry.getValue())));
 
           fullMetadataString = fullMetadataString + "," + METADATA_JOINER.join(escapedMap);
         }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -132,7 +132,8 @@ public class GoogleUsageTracker implements UsageTracker, SendsEvents {
       @NotNull String eventCategory,
       @NotNull String eventAction,
       @Nullable String eventLabel,
-      @Nullable Integer eventValue) {
+      @Nullable Integer eventValue,
+      @Nullable String eventMessage) {
     if (!ApplicationManager.getApplication().isUnitTestMode()) {
       if (UsageTrackerManager.getInstance().isTrackingEnabled()) {
         // For the semantics of each parameter, consult the followings:
@@ -159,6 +160,11 @@ public class GoogleUsageTracker implements UsageTracker, SendsEvents {
           eventMetadataMap.put(METADATA_ESCAPER.escape(eventLabel), eventValue);
           fullMetadataString = fullMetadataString + "," + METADATA_JOINER.join(eventMetadataMap);
         }
+        if (eventMessage != null) {
+          Map<String, String> eventMessageMap =
+              ImmutableMap.of("Message", METADATA_ESCAPER.escape(eventMessage));
+          fullMetadataString = fullMetadataString + "," + METADATA_JOINER.join(eventMessageMap);
+        }
         postData.add(new BasicNameValuePair(PAGE_TITLE_KEY, fullMetadataString));
         sendPing(postData);
       }
@@ -166,7 +172,7 @@ public class GoogleUsageTracker implements UsageTracker, SendsEvents {
   }
 
   @Override
-  public FluentTrackingEventWithLabel trackEvent(String action) {
+  public FluentTrackingEventWithMetadata trackEvent(String action) {
     return new TrackingEventBuilder(this, externalPluginName, action);
   }
 

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/KeyedExtensionUsageTrackerProvider.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/KeyedExtensionUsageTrackerProvider.java
@@ -22,6 +22,8 @@ import com.intellij.util.PlatformUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
+
 /**
  * Implementation of {@link UsageTrackerProvider} for obtaining {@link UsageTracker} implementations
  * declared in plugin.xml with {@link UsageTrackerExtensionPointBean}.
@@ -64,7 +66,7 @@ public final class KeyedExtensionUsageTrackerProvider extends UsageTrackerProvid
 
     @Override
     public void sendEvent(@NotNull String eventCategory, @NotNull String eventAction,
-        @Nullable String eventLabel, @Nullable Integer eventValue, @Nullable String eventMessage) {
+        @Nullable Map<String, String> metadataMap) {
       // Do nothing
     }
 

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/KeyedExtensionUsageTrackerProvider.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/KeyedExtensionUsageTrackerProvider.java
@@ -64,12 +64,12 @@ public final class KeyedExtensionUsageTrackerProvider extends UsageTrackerProvid
 
     @Override
     public void sendEvent(@NotNull String eventCategory, @NotNull String eventAction,
-        @Nullable String eventLabel, @Nullable Integer eventValue) {
+        @Nullable String eventLabel, @Nullable Integer eventValue, @Nullable String eventMessage) {
       // Do nothing
     }
 
     @Override
-    public FluentTrackingEventWithLabel trackEvent(String action) {
+    public FluentTrackingEventWithMetadata trackEvent(String action) {
       return new TrackingEventBuilder(this, "no-category", action);
     }
   }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/SendsEvents.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/SendsEvents.java
@@ -31,5 +31,6 @@ interface SendsEvents {
   void sendEvent(@NotNull String eventCategory,
       @NotNull String eventAction,
       @Nullable String eventLabel,
-      @Nullable Integer eventValue);
+      @Nullable Integer eventValue,
+      @Nullable String eventMessage);
 }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/SendsEvents.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/SendsEvents.java
@@ -19,6 +19,8 @@ package com.google.cloud.tools.intellij.stats;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
+
 /**
  * Package internal only interface used for providing multiple ping implementations to the
  * {@link TrackingEventBuilder}.
@@ -30,7 +32,5 @@ interface SendsEvents {
    */
   void sendEvent(@NotNull String eventCategory,
       @NotNull String eventAction,
-      @Nullable String eventLabel,
-      @Nullable Integer eventValue,
-      @Nullable String eventMessage);
+      @Nullable Map<String, String> metadataMap);
 }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/TrackingEventBuilder.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/TrackingEventBuilder.java
@@ -17,7 +17,10 @@
 package com.google.cloud.tools.intellij.stats;
 
 import com.google.api.client.repackaged.com.google.common.base.Preconditions;
+import com.google.api.client.util.Maps;
 import com.google.cloud.tools.intellij.stats.UsageTracker.FluentTrackingEventWithMetadata;
+
+import java.util.Map;
 
 /**
  * Implements the fluent interface exposed for tracking by {@link UsageTracker}.
@@ -27,9 +30,7 @@ class TrackingEventBuilder implements FluentTrackingEventWithMetadata {
   private SendsEvents eventSender;
   private String category;
   private String action;
-  private String label;
-  private String message;
-  private Integer value;
+  private Map<String, String> metadataMap = Maps.newHashMap();
 
   TrackingEventBuilder(SendsEvents eventSender, String category, String action) {
     this.eventSender = Preconditions.checkNotNull(eventSender);
@@ -38,26 +39,13 @@ class TrackingEventBuilder implements FluentTrackingEventWithMetadata {
   }
 
   @Override
-  public FluentTrackingEventWithMetadata withLabel(String label) {
-    this.label = Preconditions.checkNotNull(label);
-    return this;
-  }
-
-  @Override
-  public FluentTrackingEventWithMetadata withLabel(String label, int value) {
-    this.label = Preconditions.checkNotNull(label);
-    this.value = Preconditions.checkNotNull(value);
-    return this;
-  }
-
-  @Override
-  public FluentTrackingEventWithMetadata withMessage(String message) {
-    this.message = message;
+  public FluentTrackingEventWithMetadata withMetadata(String key, String value) {
+    metadataMap.put(Preconditions.checkNotNull(key), Preconditions.checkNotNull(value));
     return this;
   }
 
   @Override
   public void ping() {
-    eventSender.sendEvent(category, action, label, value, message);
+    eventSender.sendEvent(category, action, metadataMap);
   }
 }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/TrackingEventBuilder.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/TrackingEventBuilder.java
@@ -39,7 +39,7 @@ class TrackingEventBuilder implements FluentTrackingEventWithMetadata {
   }
 
   @Override
-  public FluentTrackingEventWithMetadata withMetadata(String key, String value) {
+  public FluentTrackingEventWithMetadata addMetadata(String key, String value) {
     metadataMap.put(Preconditions.checkNotNull(key), Preconditions.checkNotNull(value));
     return this;
   }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/TrackingEventBuilder.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/TrackingEventBuilder.java
@@ -17,19 +17,18 @@
 package com.google.cloud.tools.intellij.stats;
 
 import com.google.api.client.repackaged.com.google.common.base.Preconditions;
-import com.google.cloud.tools.intellij.stats.UsageTracker.FluentTrackingEventWithLabel;
-import com.google.cloud.tools.intellij.stats.UsageTracker.FluentTrackingEventWithLabel.FluentTrackingEventWithValue;
-import com.google.cloud.tools.intellij.stats.UsageTracker.PingsAnalytics;
+import com.google.cloud.tools.intellij.stats.UsageTracker.FluentTrackingEventWithMetadata;
 
 /**
  * Implements the fluent interface exposed for tracking by {@link UsageTracker}.
  */
-class TrackingEventBuilder implements FluentTrackingEventWithLabel, FluentTrackingEventWithValue {
+class TrackingEventBuilder implements FluentTrackingEventWithMetadata {
 
   private SendsEvents eventSender;
   private String category;
   private String action;
   private String label;
+  private String message;
   private Integer value;
 
   TrackingEventBuilder(SendsEvents eventSender, String category, String action) {
@@ -39,19 +38,26 @@ class TrackingEventBuilder implements FluentTrackingEventWithLabel, FluentTracki
   }
 
   @Override
-  public FluentTrackingEventWithValue withLabel(String label) {
+  public FluentTrackingEventWithMetadata withLabel(String label) {
     this.label = Preconditions.checkNotNull(label);
     return this;
   }
 
   @Override
-  public PingsAnalytics setValue(Integer value) {
+  public FluentTrackingEventWithMetadata withLabel(String label, int value) {
+    this.label = Preconditions.checkNotNull(label);
     this.value = Preconditions.checkNotNull(value);
     return this;
   }
 
   @Override
+  public FluentTrackingEventWithMetadata withMessage(String message) {
+    this.message = message;
+    return this;
+  }
+
+  @Override
   public void ping() {
-    eventSender.sendEvent(category, action, label, value);
+    eventSender.sendEvent(category, action, label, value, message);
   }
 }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTracker.java
@@ -51,35 +51,12 @@ public interface UsageTracker {
   interface FluentTrackingEventWithMetadata extends PingsAnalytics {
 
     /**
-     * Sets the optional 'label' field without a corresponding scalar 'value'.
+     * Sets an arbitrary key/value pair representing metadata for this event.
      *
-     * @param label adds metadata about the 'action' being performed. For example an action of
-     *              'appengine.deploy', could qualify the deployment as a flex deployment by passing
-     *              'flex' as the {@code label} value.
+     * @param key the key used for this event metadata
+     * @param value the value used for this event metadata
      * @return this fluent interface for further setting of event metadata
      */
-    FluentTrackingEventWithMetadata withLabel(String label);
-
-
-    /**
-     * Sets the optional 'label' field together with a corresponding scalar value to be associated
-     * with this tracking ping.
-     *
-     * @param label adds metadata about the 'action' being performed. For example an action of
-     *              'appengine.deploy', could qualify the deployment as a flex deployment by passing
-     *              'flex' as the {@code label} value.
-     * @param value an optional scalar value to be associated with this tracking event.
-     * @return this fluent interface for further setting of event metadata
-     */
-    FluentTrackingEventWithMetadata withLabel(String label, int value);
-
-    /**
-     * Sets the optional 'message' field.
-     *
-     * @param message a message metadata such as an error message to be associated with the tracked
-     *                event.
-     * @return this fluent interface for further setting of event metadata
-     */
-    FluentTrackingEventWithMetadata withMessage(String message);
+    FluentTrackingEventWithMetadata withMetadata(String key, String value);
   }
 }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTracker.java
@@ -31,7 +31,7 @@ public interface UsageTracker {
    *               often prefixed with a domain such as 'appengine.' or 'clouddebugger.'
    * @return a fluent interface for setting the remaining parameters of a tracking ping
    */
-  FluentTrackingEventWithLabel trackEvent(String action);
+  FluentTrackingEventWithMetadata trackEvent(String action);
 
   /**
    * Part of the tracking event fluent API. Denotes steps in the API where the event has enough data
@@ -46,34 +46,33 @@ public interface UsageTracker {
   }
 
   /**
-   * Interface that accepts the 'label' optional field for pinging tracking events.
+   * Interface that accepts the 'label' or 'message' optional fields for pinging tracking events.
    */
-  interface FluentTrackingEventWithLabel extends PingsAnalytics {
+  interface FluentTrackingEventWithMetadata extends PingsAnalytics {
 
     /**
-     * Sets the optional 'label' field.
+     * Sets the optional 'label' field without a corresponding scalar 'value'.
      *
      * @param label adds metadata about the 'action' being performed. For example an action of
      *              'appengine.deploy', could qualify the deployment as a flex deployment by passing
      *              'flex' as the {@code label} value.
-     * @return a fluent interface for setting a scalar value attributed to the parameters of the
-     *         tracking ping
+     * @return this fluent interface for further setting of event metadata
      */
-    FluentTrackingEventWithValue withLabel(String label);
+    FluentTrackingEventWithMetadata withLabel(String label);
+
 
     /**
-     * Interface that accepts a scalar Integer value as a metric for the analytics ping.
+     * Sets the optional 'label' together with a corresponding scalar value to be associated with
+     * this tracking ping.
+     *
+     * @param label adds metadata about the 'action' being performed. For example an action of
+     *              'appengine.deploy', could qualify the deployment as a flex deployment by passing
+     *              'flex' as the {@code label} value.
+     * @param value an optional scalar value to be associated with this tracking event.
+     * @return this fluent interface for further setting of event metadata
      */
-    interface FluentTrackingEventWithValue extends PingsAnalytics {
+    FluentTrackingEventWithMetadata withLabel(String label, int value);
 
-      /**
-       * Sets the optional scalar value to be associated with this tracking event.
-       *
-       * @param value an optional scalar value that will be recorded as a metric against this
-       *              tracking event
-       * @return a fluent interface for sending the tracking event ping
-       */
-      PingsAnalytics setValue(Integer value);
-    }
+    FluentTrackingEventWithMetadata withMessage(String message);
   }
 }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTracker.java
@@ -57,6 +57,6 @@ public interface UsageTracker {
      * @param value the value used for this event metadata
      * @return this fluent interface for further setting of event metadata
      */
-    FluentTrackingEventWithMetadata withMetadata(String key, String value);
+    FluentTrackingEventWithMetadata addMetadata(String key, String value);
   }
 }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTracker.java
@@ -46,7 +46,7 @@ public interface UsageTracker {
   }
 
   /**
-   * Interface that accepts the 'label' or 'message' optional fields for pinging tracking events.
+   * Interface that accepts a key/value metadata pair for pinging tracking events.
    */
   interface FluentTrackingEventWithMetadata extends PingsAnalytics {
 

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTracker.java
@@ -62,8 +62,8 @@ public interface UsageTracker {
 
 
     /**
-     * Sets the optional 'label' together with a corresponding scalar value to be associated with
-     * this tracking ping.
+     * Sets the optional 'label' field together with a corresponding scalar value to be associated
+     * with this tracking ping.
      *
      * @param label adds metadata about the 'action' being performed. For example an action of
      *              'appengine.deploy', could qualify the deployment as a flex deployment by passing
@@ -73,6 +73,13 @@ public interface UsageTracker {
      */
     FluentTrackingEventWithMetadata withLabel(String label, int value);
 
+    /**
+     * Sets the optional 'message' field.
+     *
+     * @param message a message metadata such as an error message to be associated with the tracked
+     *                event.
+     * @return this fluent interface for further setting of event metadata
+     */
     FluentTrackingEventWithMetadata withMessage(String message);
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -327,7 +327,7 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
       public Deployment succeeded(@NotNull DeploymentRuntime deploymentRuntime) {
         UsageTrackerProvider.getInstance()
             .trackEvent(GctTracking.APP_ENGINE_DEPLOY_SUCCESS)
-            .withMetadata(GctTracking.METADATA_LABEL_KEY, eventLabel)
+            .addMetadata(GctTracking.METADATA_LABEL_KEY, eventLabel)
             .ping();
         return deploymentCallback.succeeded(deploymentRuntime);
       }
@@ -336,8 +336,8 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
       public void errorOccurred(@NotNull String errorMessage) {
         UsageTrackerProvider.getInstance()
             .trackEvent(GctTracking.APP_ENGINE_DEPLOY_FAIL)
-            .withMetadata(GctTracking.METADATA_LABEL_KEY, eventLabel)
-            .withMetadata(GctTracking.METADATA_MESSAGE_KEY, errorMessage)
+            .addMetadata(GctTracking.METADATA_LABEL_KEY, eventLabel)
+            .addMetadata(GctTracking.METADATA_MESSAGE_KEY, errorMessage)
             .ping();
         deploymentCallback.errorOccurred(errorMessage);
       }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -327,7 +327,7 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
       public Deployment succeeded(@NotNull DeploymentRuntime deploymentRuntime) {
         UsageTrackerProvider.getInstance()
             .trackEvent(GctTracking.APP_ENGINE_DEPLOY_SUCCESS)
-            .withLabel(eventLabel)
+            .withMetadata(GctTracking.METADATA_LABEL_KEY, eventLabel)
             .ping();
         return deploymentCallback.succeeded(deploymentRuntime);
       }
@@ -336,8 +336,8 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
       public void errorOccurred(@NotNull String errorMessage) {
         UsageTrackerProvider.getInstance()
             .trackEvent(GctTracking.APP_ENGINE_DEPLOY_FAIL)
-            .withLabel(eventLabel)
-            .withMessage(errorMessage)
+            .withMetadata(GctTracking.METADATA_LABEL_KEY, eventLabel)
+            .withMetadata(GctTracking.METADATA_MESSAGE_KEY, errorMessage)
             .ping();
         deploymentCallback.errorOccurred(errorMessage);
       }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -336,7 +336,8 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
       public void errorOccurred(@NotNull String errorMessage) {
         UsageTrackerProvider.getInstance()
             .trackEvent(GctTracking.APP_ENGINE_DEPLOY_FAIL)
-            .withLabel(eventLabel + ":" + errorMessage)
+            .withLabel(eventLabel)
+            .withMessage(errorMessage)
             .ping();
         deploymentCallback.errorOccurred(errorMessage);
       }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -336,7 +336,7 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
       public void errorOccurred(@NotNull String errorMessage) {
         UsageTrackerProvider.getInstance()
             .trackEvent(GctTracking.APP_ENGINE_DEPLOY_FAIL)
-            .withLabel(eventLabel)
+            .withLabel(eventLabel + ":" + errorMessage)
             .ping();
         deploymentCallback.errorOccurred(errorMessage);
       }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineFlexibleDeployTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineFlexibleDeployTask.java
@@ -50,7 +50,7 @@ public class AppEngineFlexibleDeployTask extends AppEngineTask {
   public void execute(ProcessStartListener startListener) {
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_DEPLOY)
-        .withMetadata(GctTracking.METADATA_LABEL_KEY,
+        .addMetadata(GctTracking.METADATA_LABEL_KEY,
             "flex." + (deploy.getDeploymentConfiguration().isAuto() ? "auto" : "custom"))
         .ping();
 
@@ -97,7 +97,7 @@ public class AppEngineFlexibleDeployTask extends AppEngineTask {
   void onCancel() {
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_DEPLOY_CANCEL)
-        .withMetadata(GctTracking.METADATA_LABEL_KEY, "flex")
+        .addMetadata(GctTracking.METADATA_LABEL_KEY, "flex")
         .ping();
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineFlexibleDeployTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineFlexibleDeployTask.java
@@ -50,7 +50,8 @@ public class AppEngineFlexibleDeployTask extends AppEngineTask {
   public void execute(ProcessStartListener startListener) {
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_DEPLOY)
-        .withLabel("flex." + (deploy.getDeploymentConfiguration().isAuto() ? "auto" : "custom"))
+        .withMetadata(GctTracking.METADATA_LABEL_KEY,
+            "flex." + (deploy.getDeploymentConfiguration().isAuto() ? "auto" : "custom"))
         .ping();
 
     Path stagingDirectory;
@@ -96,7 +97,7 @@ public class AppEngineFlexibleDeployTask extends AppEngineTask {
   void onCancel() {
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_DEPLOY_CANCEL)
-        .withLabel("flex")
+        .withMetadata(GctTracking.METADATA_LABEL_KEY, "flex")
         .ping();
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineStandardDeployTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineStandardDeployTask.java
@@ -63,7 +63,7 @@ public class AppEngineStandardDeployTask extends AppEngineTask {
   public void execute(ProcessStartListener startListener) {
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_DEPLOY)
-        .withLabel(isFlexCompat ? "flex-compat" : "standard")
+        .withMetadata(GctTracking.METADATA_LABEL_KEY, isFlexCompat ? "flex-compat" : "standard")
         .ping();
 
     Path stagingDirectory;
@@ -135,7 +135,7 @@ public class AppEngineStandardDeployTask extends AppEngineTask {
   void onCancel() {
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_DEPLOY_CANCEL)
-        .withLabel(isFlexCompat ? "flex-compat" : "standard")
+        .withMetadata(GctTracking.METADATA_LABEL_KEY, isFlexCompat ? "flex-compat" : "standard")
         .ping();
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineStandardDeployTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineStandardDeployTask.java
@@ -63,7 +63,7 @@ public class AppEngineStandardDeployTask extends AppEngineTask {
   public void execute(ProcessStartListener startListener) {
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_DEPLOY)
-        .withMetadata(GctTracking.METADATA_LABEL_KEY, isFlexCompat ? "flex-compat" : "standard")
+        .addMetadata(GctTracking.METADATA_LABEL_KEY, isFlexCompat ? "flex-compat" : "standard")
         .ping();
 
     Path stagingDirectory;
@@ -135,7 +135,7 @@ public class AppEngineStandardDeployTask extends AppEngineTask {
   void onCancel() {
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_DEPLOY_CANCEL)
-        .withMetadata(GctTracking.METADATA_LABEL_KEY, isFlexCompat ? "flex-compat" : "standard")
+        .addMetadata(GctTracking.METADATA_LABEL_KEY, isFlexCompat ? "flex-compat" : "standard")
         .ping();
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineStandardRunTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineStandardRunTask.java
@@ -67,7 +67,7 @@ public class AppEngineStandardRunTask extends AppEngineTask {
 
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_RUN)
-        .withLabel(Strings.nullToEmpty(runnerId))
+        .withMetadata(GctTracking.METADATA_LABEL_KEY, Strings.nullToEmpty(runnerId))
         .ping();
 
   }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineStandardRunTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineStandardRunTask.java
@@ -67,7 +67,7 @@ public class AppEngineStandardRunTask extends AppEngineTask {
 
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_RUN)
-        .withMetadata(GctTracking.METADATA_LABEL_KEY, Strings.nullToEmpty(runnerId))
+        .addMetadata(GctTracking.METADATA_LABEL_KEY, Strings.nullToEmpty(runnerId))
         .ping();
 
   }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineFrameworkDetector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineFrameworkDetector.java
@@ -51,7 +51,7 @@ public class AppEngineFrameworkDetector extends
 
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_ADD_STANDARD_FACET)
-        .withMetadata(GctTracking.METADATA_LABEL_KEY, "frameworkDetect")
+        .addMetadata(GctTracking.METADATA_LABEL_KEY, "frameworkDetect")
         .ping();
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineFrameworkDetector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineFrameworkDetector.java
@@ -51,7 +51,7 @@ public class AppEngineFrameworkDetector extends
 
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_ADD_STANDARD_FACET)
-        .withLabel("frameworkDetect")
+        .withMetadata(GctTracking.METADATA_LABEL_KEY, "frameworkDetect")
         .ping();
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineStandardFacetEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineStandardFacetEditor.java
@@ -144,7 +144,7 @@ public class AppEngineStandardFacetEditor extends FacetEditorTab {
     // Framework discovered "Configure" popup.
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_ADD_STANDARD_FACET)
-        .withMetadata(GctTracking.METADATA_LABEL_KEY, "setOnModule")
+        .addMetadata(GctTracking.METADATA_LABEL_KEY, "setOnModule")
         .ping();
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineStandardFacetEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineStandardFacetEditor.java
@@ -144,7 +144,7 @@ public class AppEngineStandardFacetEditor extends FacetEditorTab {
     // Framework discovered "Configure" popup.
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.APP_ENGINE_ADD_STANDARD_FACET)
-        .withLabel("setOnModule")
+        .withMetadata(GctTracking.METADATA_LABEL_KEY, "setOnModule")
         .ping();
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineSupportProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineSupportProvider.java
@@ -192,7 +192,7 @@ public class AppEngineSupportProvider extends FrameworkSupportInModuleProvider {
 
               UsageTrackerProvider.getInstance()
                   .trackEvent(GctTracking.APP_ENGINE_ADD_LIBRARY)
-                  .withLabel(libraryToAdd.name())
+                  .withMetadata(GctTracking.METADATA_LABEL_KEY, libraryToAdd.name())
                   .ping();
             } else {
               LOG.warn("Failed to load library: " + libraryToAdd.getDisplayName());

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineSupportProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineSupportProvider.java
@@ -192,7 +192,7 @@ public class AppEngineSupportProvider extends FrameworkSupportInModuleProvider {
 
               UsageTrackerProvider.getInstance()
                   .trackEvent(GctTracking.APP_ENGINE_ADD_LIBRARY)
-                  .withMetadata(GctTracking.METADATA_LABEL_KEY, libraryToAdd.name())
+                  .addMetadata(GctTracking.METADATA_LABEL_KEY, libraryToAdd.name())
                   .ping();
             } else {
               LOG.warn("Failed to load library: " + libraryToAdd.getDisplayName());

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/util/GctTracking.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/util/GctTracking.java
@@ -62,4 +62,7 @@ public class GctTracking {
       "appengine.oldplugin.deactivated";
 
   public static final String CLOUD_SDK_MALFORMED_PATH = "cloudsdk.malformedpath";
+
+  public static final String METADATA_LABEL_KEY = "label";
+  public static final String METADATA_MESSAGE_KEY = "message";
 }


### PR DESCRIPTION
The deploy error message (e.g. "error creating stage directory", or "no cloud sdk was found ...") is currently not being tracked via our metrics. The error message was being shown to the user, but we had no way of digging into the deployment failure to determine more details.

This PR appends the error message to the metrics label.

@chanseokoh do you mind taking a quick look to see if this makes sense to you on the metrics side? i.e is this an ok place to put the message?