### PR TITLE
Force servlet 2.5 on new App Engine Standard apps

### DIFF
--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
@@ -67,25 +67,27 @@ public class AppEngineJavaeeSupportContributor extends JavaeeFrameworkSupportCon
     StartupManager.getInstance(module.getProject()).runWhenProjectIsInitialized(() -> {
       for (WebFacet webFacet : WebFacet.getInstances(module)) {
         final WebApp webApp = webFacet.getRoot();
-        if (webApp != null) {
-          new WriteCommandAction.Simple(module.getProject()) {
-            @Override
-            protected void run() throws Throwable {
-              webApp.getVersion().setStringValue(SERVLET_VERSION);
-
-              XmlTag webAppTag = webApp.getXmlTag();
-              XmlAttribute xmlns = webAppTag.getAttribute("xmlns");
-              XmlAttribute schemaLocation = webAppTag.getAttribute("xsi:schemaLocation");
-
-              if (xmlns != null) {
-                xmlns.setValue(SERVLET_NAMESPACE);
-              }
-              if (schemaLocation != null) {
-                schemaLocation.setValue(SERVLET_SCHEMA_URL);
-              }
-            }
-          }.execute();
+        if (webApp == null) {
+          return;
         }
+
+        new WriteCommandAction.Simple(module.getProject()) {
+          @Override
+          protected void run() throws Throwable {
+            webApp.getVersion().setStringValue(SERVLET_VERSION);
+
+            XmlTag webAppTag = webApp.getXmlTag();
+            XmlAttribute xmlns = webAppTag.getAttribute("xmlns");
+            XmlAttribute schemaLocation = webAppTag.getAttribute("xsi:schemaLocation");
+
+            if (xmlns != null) {
+              xmlns.setValue(SERVLET_NAMESPACE);
+            }
+            if (schemaLocation != null) {
+              schemaLocation.setValue(SERVLET_SCHEMA_URL);
+            }
+          }
+        }.execute();
       }
     });
   }

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
@@ -68,7 +68,7 @@ public class AppEngineJavaeeSupportContributor extends JavaeeFrameworkSupportCon
       for (WebFacet webFacet : WebFacet.getInstances(module)) {
         final WebApp webApp = webFacet.getRoot();
         if (webApp == null) {
-          return;
+          continue;
         }
 
         new WriteCommandAction.Simple(module.getProject()) {

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
@@ -40,10 +40,6 @@ public class AppEngineJavaeeSupportContributor extends JavaeeFrameworkSupportCon
   private static final String SERVLET_SCHEMA_URL
       = "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd";
 
-  public AppEngineJavaeeSupportContributor() {
-
-  }
-
   @Override
   public void setupFrameworkSupport(JavaeeFrameworkSupportContributionModel model) {
     AppEngineStandardFacet appEngineStandardFacet = model.getFacet(AppEngineStandardFacet.ID);

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
@@ -19,14 +19,29 @@ package com.google.cloud.tools.intellij.appengine.facet.impl;
 import com.google.cloud.tools.intellij.appengine.facet.AppEngineStandardFacet;
 import com.google.cloud.tools.intellij.appengine.facet.AppEngineStandardWebIntegration;
 
+import com.intellij.javaee.model.xml.web.WebApp;
 import com.intellij.javaee.supportProvider.JavaeeFrameworkSupportContributionModel;
 import com.intellij.javaee.supportProvider.JavaeeFrameworkSupportContributor;
+import com.intellij.javaee.web.facet.WebFacet;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.startup.StartupManager;
 import com.intellij.packaging.artifacts.Artifact;
+import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.psi.xml.XmlTag;
 
 /**
  * @author nik
  */
 public class AppEngineJavaeeSupportContributor extends JavaeeFrameworkSupportContributor {
+
+  private static final String SERVLET_NAMESPACE = "http://java.sun.com/xml/ns/javaee";
+  private static final String SERVLET_SCHEMA_URL
+      = "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd";
+
+  public AppEngineJavaeeSupportContributor() {
+
+  }
 
   @Override
   public void setupFrameworkSupport(JavaeeFrameworkSupportContributionModel model) {
@@ -34,6 +49,8 @@ public class AppEngineJavaeeSupportContributor extends JavaeeFrameworkSupportCon
     if (appEngineStandardFacet == null) {
       return;
     }
+
+    setWebXmlServletVersion(model.getModule());
 
     Artifact artifactToDeploy = model.getExplodedEarArtifact();
     if (artifactToDeploy == null) {
@@ -43,5 +60,36 @@ public class AppEngineJavaeeSupportContributor extends JavaeeFrameworkSupportCon
       AppEngineStandardWebIntegration.getInstance().setupRunConfigurations(
           artifactToDeploy, model.getProject(), model.getRunConfiguration());
     }
+  }
+
+  /**
+   * App Engine standard apps with the default runtime (Java7) require Servlet 2.5. This updates
+   * web.xml to the correct version.
+   */
+  private void setWebXmlServletVersion(Module module) {
+    StartupManager.getInstance(module.getProject()).runWhenProjectIsInitialized(() -> {
+      for (WebFacet webFacet : WebFacet.getInstances(module)) {
+        final WebApp webApp = webFacet.getRoot();
+        if (webApp != null) {
+          new WriteCommandAction.Simple(module.getProject()) {
+            @Override
+            protected void run() throws Throwable {
+              webApp.getVersion().setStringValue("2.5");
+
+              XmlTag webAppTag = webApp.getXmlTag();
+              XmlAttribute xmlns = webAppTag.getAttribute("xmlns");
+              XmlAttribute schemaLocation = webAppTag.getAttribute("xsi:schemaLocation");
+
+              if (xmlns != null) {
+                xmlns.setValue(SERVLET_NAMESPACE);
+              }
+              if (schemaLocation != null) {
+                schemaLocation.setValue(SERVLET_SCHEMA_URL);
+              }
+            }
+          }.execute();
+        }
+      }
+    });
   }
 }

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
@@ -35,6 +35,7 @@ import com.intellij.psi.xml.XmlTag;
  */
 public class AppEngineJavaeeSupportContributor extends JavaeeFrameworkSupportContributor {
 
+  private static final String SERVLET_VERSION = "2.5";
   private static final String SERVLET_NAMESPACE = "http://java.sun.com/xml/ns/javaee";
   private static final String SERVLET_SCHEMA_URL
       = "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd";
@@ -74,7 +75,7 @@ public class AppEngineJavaeeSupportContributor extends JavaeeFrameworkSupportCon
           new WriteCommandAction.Simple(module.getProject()) {
             @Override
             protected void run() throws Throwable {
-              webApp.getVersion().setStringValue("2.5");
+              webApp.getVersion().setStringValue(SERVLET_VERSION);
 
               XmlTag webAppTag = webApp.getXmlTag();
               XmlAttribute xmlns = webAppTag.getAttribute("xmlns");


### PR DESCRIPTION
fixes #1194

This automatically, behind the scenes, updates the generated web.xml for new AE standard projects to use Servlet 2.5.

Soon, once we allow customizable runtimes to be selected, this should be enhanced to:
- Contain a mapping between selected java runtime and allowable servlet versions
- Listen to changes on appengine-web.xml / web.xml to suggest/correct servlet version mismatches
- Add user warning prior to making modifications to web.xml (do we want this for this PR?).