### PR TITLE
Uses freshest Project SDK in dev_appserver runs and prevents running dev_appserver without a Project SDK.

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -124,6 +124,7 @@ appengine.facet.converter.description=Deprecated Google App Engine facets will b
 appengine.run.server.name=Google App Engine Standard Local Server
 appengine.run.server.sdk.misconfigured.panel.message=The Cloud SDK is misconfigured. To fix, click the 'Configure' button next to the application server.
 appengine.run.server.sdk.misconfigured.message=The Cloud SDK is misconfigured. To fix, reconfigure the application server.
+appengine.run.server.nosdk=Project SDK must be set to run the App Engine Standard Local Server.
 appengine.run.startupscript=Running dev_appserver.py.
 appengine.run.startupscript.name=App Engine Plugins Core library
 appengine.run.shutdownscript=Terminating dev_appserver.py.

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineRunConfigurationEditor.java
@@ -122,6 +122,8 @@ public class AppEngineRunConfigurationEditor extends SettingsEditor<CommonModel>
     apiPort.setText(intToString(serverModel.getApiPort()));
     applicationLogLevel.setSelectedItem(serverModel.getLogLevel());
     cleadDatastoreCheckbox.setSelected(serverModel.getClearDatastore());
+
+    serverModel.initJdk();
   }
 
   @Override

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -80,17 +80,9 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
     projectJdksModel = new ProjectSdksModel();
   }
 
-  @Nullable
-  private Sdk getCurrentProjectJdk() {
+  void initJdk() {
     projectJdksModel.reset(commonModel.getProject());
-    return projectJdksModel.getProjectSdk();
-  }
-
-  private void initDefaultJdk() {
-    Sdk projectJdk = getCurrentProjectJdk();
-    if (projectJdk != null) {
-      setDevAppServerJdk(projectJdk);
-    }
+    setDevAppServerJdk(projectJdksModel.getProjectSdk());
   }
 
   @Override
@@ -98,7 +90,11 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
     // TODO(alexsloan): This keeps the dev_appserver's jdk in sync with the project jdk on behalf of
     // the user. This behavior should be removed once
     // https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/926 is completed.
-    initDefaultJdk();
+    initJdk();
+
+    if (devAppServerJdk == null) {
+      throw new ExecutionException(GctBundle.getString("appengine.run.server.nosdk"));
+    }
 
     return new AppEngineServerInstance(commonModel);
   }
@@ -163,6 +159,10 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
     if (!CloudSdkService.getInstance().isValidCloudSdk()) {
       throw new RuntimeConfigurationError(
           GctBundle.message("appengine.run.server.sdk.misconfigured.panel.message"));
+    }
+
+    if (devAppServerJdk == null) {
+      throw new RuntimeConfigurationError(GctBundle.getString("appengine.run.server.nosdk"));
     }
   }
 


### PR DESCRIPTION
Fixes #1214 