### PR TITLE
Revert "GAE framework support no longer adds local devserver library to dependencies list"

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineSupportProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineSupportProvider.java
@@ -154,6 +154,8 @@ public class AppEngineSupportProvider extends FrameworkSupportInModuleProvider {
       }
     }
 
+    webIntegration.addDevServerToModuleDependencies(rootModel);
+
     addMavenLibraries(librariesToAdd, module, rootModel, webArtifact);
   }
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/google-cloud-intellij#956

Nikolay confirmed a while ago that a fix was submitted for this issue, via email, and that it would be applied to the 163 builds. He didn't mention what the fix was, but I suspect IJ Application Servers are just not adding any local dev servers.

I tested locally with IJ 163 and couldn't reproduce the case where a JavaEE project is created with GAE Standard support and yields two copies of the Local Server library.