### PR TITLE
Removes call to deleted "cleanup()" method

### DIFF
--- a/google-cloud-tools-plugin/ultimate/testSrc/com/google/cloud/tools/intellij/javaee/supportProvider/JavaeeFrameworkSupportProviderTestCase.java
+++ b/google-cloud-tools-plugin/ultimate/testSrc/com/google/cloud/tools/intellij/javaee/supportProvider/JavaeeFrameworkSupportProviderTestCase.java
@@ -31,16 +31,12 @@ public abstract class JavaeeFrameworkSupportProviderTestCase extends
   public static void deleteApplicationServers() {
     final ApplicationServersManager manager = ApplicationServersManager.getInstance();
     final List<ApplicationServer> servers = manager.getApplicationServers();
-    final ApplicationServersManager.ApplicationServersManagerModifiableModel model = manager.createModifiableModel();
+    final ApplicationServersManager.ApplicationServersManagerModifiableModel model =
+        manager.createModifiableModel();
     for (ApplicationServer server : servers) {
       model.deleteApplicationServer(server);
     }
-    ApplicationManager.getApplication().runWriteAction(new Runnable() {
-      @Override
-      public void run() {
-        model.commit();
-      }
-    });
+    ApplicationManager.getApplication().runWriteAction(model::commit);
   }
 
 

--- a/google-cloud-tools-plugin/ultimate/testSrc/com/google/cloud/tools/intellij/javaee/supportProvider/JavaeeFrameworkSupportProviderTestCase.java
+++ b/google-cloud-tools-plugin/ultimate/testSrc/com/google/cloud/tools/intellij/javaee/supportProvider/JavaeeFrameworkSupportProviderTestCase.java
@@ -20,14 +20,14 @@ import com.google.cloud.tools.intellij.debugger.CloudDebugProcessWatcher;
 
 import com.intellij.ide.util.frameworkSupport.FrameworkSupportProviderTestCase;
 import com.intellij.javaee.appServerIntegrations.ApplicationServer;
-import com.intellij.javaee.module.components.FrameworkVirtualFileSystem;
 import com.intellij.javaee.serverInstances.ApplicationServersManager;
 import com.intellij.openapi.application.ApplicationManager;
 
 import java.util.List;
 
 //todo: this class is copied from javaee_tests module. We need to create a separate artifact from that module and use it instead.
-public abstract class JavaeeFrameworkSupportProviderTestCase extends FrameworkSupportProviderTestCase {
+public abstract class JavaeeFrameworkSupportProviderTestCase extends
+    FrameworkSupportProviderTestCase {
   public static void deleteApplicationServers() {
     final ApplicationServersManager manager = ApplicationServersManager.getInstance();
     final List<ApplicationServer> servers = manager.getApplicationServers();
@@ -46,7 +46,6 @@ public abstract class JavaeeFrameworkSupportProviderTestCase extends FrameworkSu
 
   @Override
   protected void tearDown() throws Exception {
-    FrameworkVirtualFileSystem.getJ2EEInstance().cleanup();
     deleteApplicationServers();
     CloudDebugProcessWatcher.getInstance().removeWatcher();
     super.tearDown();


### PR DESCRIPTION
Fixes #1253 

Searched for a similar call in the same class, but couldn't find any.

Tried running the tests again locally and they all pass, so I'm assuming this method, or a similar one, is now called automatically.

I'm not too sure what the todo in this file refers to.