### PR TITLE
Adds YAML parsing for app.yaml.

### DIFF
--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -54,6 +54,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     compile files('lib/google-api-services-source.jar')
+    compile 'org.yaml:snakeyaml:1.18'
 
     testCompile(project(':common-test-lib'))
     testRuntime files('../google-account-plugin/lib/google-gct-login-context-ij-pg.jar')

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/project/DefaultAppEngineProjectService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/project/DefaultAppEngineProjectService.java
@@ -41,8 +41,11 @@ import org.jetbrains.idea.maven.project.MavenProjectsManager;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -229,7 +232,8 @@ public class DefaultAppEngineProjectService extends AppEngineProjectService {
       @NotNull String key) {
     Yaml yamlParser = new Yaml();
     try {
-      Object parseResult = yamlParser.load(new FileReader(appYamlPathString));
+      Object parseResult = yamlParser.load(
+          Files.newBufferedReader(Paths.get(appYamlPathString), Charset.defaultCharset()));
 
       if (!(parseResult instanceof Map)) {
         return Optional.empty();
@@ -240,7 +244,7 @@ public class DefaultAppEngineProjectService extends AppEngineProjectService {
       Map<String, String> yamlMap = (Map<String, String>) parseResult;
 
       return yamlMap.containsKey(key) ? Optional.of(yamlMap.get(key)) : Optional.empty();
-    } catch (FileNotFoundException fnfe) {
+    } catch (InvalidPathException | IOException ioe) {
       return Optional.empty();
     }
   }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/project/DefaultAppEngineProjectService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/project/DefaultAppEngineProjectService.java
@@ -235,6 +235,8 @@ public class DefaultAppEngineProjectService extends AppEngineProjectService {
         return Optional.empty();
       }
 
+      // It's possible to get rid of this unchecked cast using a loadAs(file,
+      // AppEngineYamlWebApp.class) sort of approach.
       Map<String, String> yamlMap = (Map<String, String>) parseResult;
 
       return yamlMap.containsKey(key) ? Optional.of(yamlMap.get(key)) : Optional.empty();

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/project/DefaultAppEngineProjectService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/project/DefaultAppEngineProjectService.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
@@ -232,8 +233,13 @@ public class DefaultAppEngineProjectService extends AppEngineProjectService {
       @NotNull String key) {
     Yaml yamlParser = new Yaml();
     try {
-      Object parseResult = yamlParser.load(
-          Files.newBufferedReader(Paths.get(appYamlPathString), Charset.defaultCharset()));
+      Path appYamlPath = Paths.get(appYamlPathString);
+      if (!Files.isRegularFile(appYamlPath)) {
+        return Optional.empty();
+      }
+
+      Object parseResult =
+          yamlParser.load(Files.newBufferedReader(appYamlPath, Charset.defaultCharset()));
 
       if (!(parseResult instanceof Map)) {
         return Optional.empty();

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/project/DefaultAppEngineProjectService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/project/DefaultAppEngineProjectService.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.intellij.appengine.cloud.AppEngineEnvironment;
 import com.google.cloud.tools.intellij.appengine.cloud.standard.AppEngineStandardRuntime;
 import com.google.cloud.tools.intellij.appengine.facet.flexible.AppEngineFlexibleFacetType;
 import com.google.cloud.tools.intellij.appengine.facet.standard.AppEngineStandardFacet;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 import com.intellij.facet.FacetManager;
@@ -38,13 +39,12 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.project.MavenProject;
 import org.jetbrains.idea.maven.project.MavenProjectsManager;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
+import org.yaml.snakeyaml.Yaml;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -52,9 +52,8 @@ import java.util.Optional;
  */
 public class DefaultAppEngineProjectService extends AppEngineProjectService {
 
-  private static final String AE_WEB_XML_RUNTIME_TAG = "runtime";
-  private static final String SERVICE_TAG_YAML = "service:";
-  private static final String RUNTIME_TAG_YAML = "runtime:";
+  private static final String RUNTIME_TAG_NAME = "runtime";
+  private static final String SERVICE_TAG_NAME = "service";
   private static final String DEFAULT_SERVICE = "default";
 
   private AppEngineAssetProvider assetProvider;
@@ -197,7 +196,7 @@ public class DefaultAppEngineProjectService extends AppEngineProjectService {
     if (appengineWebXml == null || (rootTag = appengineWebXml.getRootTag()) == null) {
       return null;
     }
-    String runtime = rootTag.getSubTagText(AE_WEB_XML_RUNTIME_TAG);
+    String runtime = rootTag.getSubTagText(RUNTIME_TAG_NAME);
     if (runtime == null) {
       return null;
     }
@@ -212,14 +211,14 @@ public class DefaultAppEngineProjectService extends AppEngineProjectService {
 
   @Override
   public Optional<String> getServiceNameFromAppYaml(@NotNull String appYamlPathString) {
-    return getValueFromAppYaml(appYamlPathString, SERVICE_TAG_YAML);
+    return getValueFromAppYaml(appYamlPathString, SERVICE_TAG_NAME);
   }
 
   @Override
   public Optional<FlexibleRuntime> getFlexibleRuntimeFromAppYaml(
       @NotNull String appYamlPathString) {
     try {
-      return getValueFromAppYaml(appYamlPathString, RUNTIME_TAG_YAML)
+      return getValueFromAppYaml(appYamlPathString, RUNTIME_TAG_NAME)
           .map(FlexibleRuntime::valueOf);
     } catch (IllegalArgumentException iae) {
       return Optional.empty();
@@ -228,19 +227,18 @@ public class DefaultAppEngineProjectService extends AppEngineProjectService {
 
   private Optional<String> getValueFromAppYaml(@NotNull String appYamlPathString,
       @NotNull String key) {
-    Path appYamlPath;
+    Yaml yamlParser = new Yaml();
     try {
-      appYamlPath = Paths.get(appYamlPathString);
-    } catch (InvalidPathException ipe) {
-      return Optional.empty();
-    }
+      Object parseResult = yamlParser.load(new FileReader(appYamlPathString));
 
-    try {
-      return Files.readAllLines(appYamlPath).stream()
-          .filter(line -> line.startsWith(key))
-          .map(line -> line.substring(key.length()).trim())
-          .findFirst();
-    } catch (IOException ioe) {
+      if (!(parseResult instanceof Map)) {
+        return Optional.empty();
+      }
+
+      Map<String, String> yamlMap = (Map<String, String>) parseResult;
+
+      return yamlMap.containsKey(key) ? Optional.of(yamlMap.get(key)) : Optional.empty();
+    } catch (FileNotFoundException fnfe) {
       return Optional.empty();
     }
   }
@@ -249,6 +247,12 @@ public class DefaultAppEngineProjectService extends AppEngineProjectService {
   public String getServiceNameFromAppEngineWebXml(
       Project project, DeploymentSource deploymentSource) {
     XmlFile appengineWebXml = loadAppEngineStandardWebXml(project, deploymentSource);
+
+    return getServiceNameFromAppEngineWebXml(appengineWebXml);
+  }
+
+  @VisibleForTesting
+  String getServiceNameFromAppEngineWebXml(XmlFile appengineWebXml) {
 
     if (appengineWebXml != null) {
       XmlTag root = appengineWebXml.getRootTag();

--- a/google-cloud-tools-plugin/testData/descriptor/appengine-web_runtime-java8-module.xml
+++ b/google-cloud-tools-plugin/testData/descriptor/appengine-web_runtime-java8-module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2016 Google Inc. All Rights Reserved.
+  ~ Copyright 2017 Google Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -19,5 +19,5 @@
     <application>app</application>
     <version>1</version>
     <runtime>java8</runtime>
-    <service>java8Service</service>
+    <module>java8Service</module>
 </appengine-web-app>

--- a/google-cloud-tools-plugin/testData/descriptor/appengine-web_runtime-java8-serviceandmodule.xml
+++ b/google-cloud-tools-plugin/testData/descriptor/appengine-web_runtime-java8-serviceandmodule.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2016 Google Inc. All Rights Reserved.
+  ~ Copyright 2017 Google Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -20,4 +20,5 @@
     <version>1</version>
     <runtime>java8</runtime>
     <service>java8Service</service>
+    <module>java8Service2</module>
 </appengine-web-app>

--- a/google-cloud-tools-plugin/testData/project/custom.yaml
+++ b/google-cloud-tools-plugin/testData/project/custom.yaml
@@ -1,0 +1,25 @@
+runtime: custom
+service: customService
+api_version: 1
+threadsafe: true
+
+handlers:
+- url: /
+  script: home.app
+
+- url: /index\.html
+  script: home.app
+
+- url: /stylesheets
+  static_dir: stylesheets
+
+- url: /(.*\.(gif|png|jpg))$
+  static_files: static/\1
+  upload: static/.*\.(gif|png|jpg)$
+
+- url: /admin/.*
+  script: admin.app
+  login: admin
+
+- url: /.*
+  script: not_found.app

--- a/google-cloud-tools-plugin/testData/project/custom.yaml
+++ b/google-cloud-tools-plugin/testData/project/custom.yaml
@@ -1,25 +1,15 @@
 runtime: custom
 service: customService
-api_version: 1
-threadsafe: true
+env: flex
 
 handlers:
-- url: /
-  script: home.app
-
-- url: /index\.html
-  script: home.app
-
-- url: /stylesheets
-  static_dir: stylesheets
-
-- url: /(.*\.(gif|png|jpg))$
-  static_files: static/\1
-  upload: static/.*\.(gif|png|jpg)$
-
-- url: /admin/.*
-  script: admin.app
-  login: admin
-
 - url: /.*
-  script: not_found.app
+  script: this field is required, but ignored
+  secure: always  # Require HTTPS
+
+runtime_config:  # Optional
+  jdk: openjdk8
+  server: jetty9
+
+manual_scaling:
+  instances: 1

--- a/google-cloud-tools-plugin/testData/project/java.yaml
+++ b/google-cloud-tools-plugin/testData/project/java.yaml
@@ -1,0 +1,25 @@
+runtime: java
+service: javaService
+api_version: 1
+threadsafe: true
+
+handlers:
+- url: /
+  script: home.app
+
+- url: /index\.html
+  script: home.app
+
+- url: /stylesheets
+  static_dir: stylesheets
+
+- url: /(.*\.(gif|png|jpg))$
+  static_files: static/\1
+  upload: static/.*\.(gif|png|jpg)$
+
+- url: /admin/.*
+  script: admin.app
+  login: admin
+
+- url: /.*
+  script: not_found.app

--- a/google-cloud-tools-plugin/testData/project/java.yaml
+++ b/google-cloud-tools-plugin/testData/project/java.yaml
@@ -1,25 +1,15 @@
 runtime: java
 service: javaService
-api_version: 1
-threadsafe: true
+env: flex
 
 handlers:
-- url: /
-  script: home.app
-
-- url: /index\.html
-  script: home.app
-
-- url: /stylesheets
-  static_dir: stylesheets
-
-- url: /(.*\.(gif|png|jpg))$
-  static_files: static/\1
-  upload: static/.*\.(gif|png|jpg)$
-
-- url: /admin/.*
-  script: admin.app
-  login: admin
-
 - url: /.*
-  script: not_found.app
+  script: this field is required, but ignored
+  secure: always  # Require HTTPS
+
+runtime_config:  # Optional
+  jdk: openjdk8
+  server: jetty9
+
+manual_scaling:
+  instances: 1

--- a/google-cloud-tools-plugin/testData/project/noservice.yaml
+++ b/google-cloud-tools-plugin/testData/project/noservice.yaml
@@ -1,24 +1,14 @@
 runtime: java
-api_version: 1
-threadsafe: true
+env: flex
 
 handlers:
-- url: /
-  script: home.app
-
-- url: /index\.html
-  script: home.app
-
-- url: /stylesheets
-  static_dir: stylesheets
-
-- url: /(.*\.(gif|png|jpg))$
-  static_files: static/\1
-  upload: static/.*\.(gif|png|jpg)$
-
-- url: /admin/.*
-  script: admin.app
-  login: admin
-
 - url: /.*
-  script: not_found.app
+  script: this field is required, but ignored
+  secure: always  # Require HTTPS
+
+runtime_config:  # Optional
+  jdk: openjdk8
+  server: jetty9
+
+manual_scaling:
+  instances: 1

--- a/google-cloud-tools-plugin/testData/project/noservice.yaml
+++ b/google-cloud-tools-plugin/testData/project/noservice.yaml
@@ -1,0 +1,24 @@
+runtime: java
+api_version: 1
+threadsafe: true
+
+handlers:
+- url: /
+  script: home.app
+
+- url: /index\.html
+  script: home.app
+
+- url: /stylesheets
+  static_dir: stylesheets
+
+- url: /(.*\.(gif|png|jpg))$
+  static_files: static/\1
+  upload: static/.*\.(gif|png|jpg)$
+
+- url: /admin/.*
+  script: admin.app
+  login: admin
+
+- url: /.*
+  script: not_found.app


### PR DESCRIPTION
There is a way to get rid of the unchecked cast `Map<String, String> yamlMap = (Map<String, String>) parseResult;`.

However, it requires a Java object that mirrors an app.yaml which, at this point, I think requires a bit more discussion about whether we want to have and maintain.