### PR TITLE
Fills the app.yaml text field at UI construction time

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
@@ -252,6 +252,8 @@ public class AppEngineFlexibleDeploymentEditor extends
       dockerfileOverrideCheckBox.setSelected(true);
     }
 
+    appYamlTextField.setText(getAppYamlPath());
+
     moduleSettingsButton.addActionListener(event -> {
       AppEngineFlexibleFacet flexFacet =
           FacetManager.getInstance(((Module) modulesWithFlexFacetComboBox.getSelectedItem()))


### PR DESCRIPTION
Fixes #1285 

When the user presses the app.yaml override button for the first time, it contains a suggestion.