### PR TITLE
Bumps appengine-plugins-core version to 0.2.9.

### DIFF
--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     compile 'com.google.apis:google-api-services-appengine:v1-rev8-1.22.0'
     compile ('com.google.cloud.tools:appengine-plugins-core:' + toolsLibVersion) {
         exclude group: 'com.google.guava', module: 'guava'
+        exclude group: 'org.yaml', module: 'snakeyaml'
     }
     compile files('lib/google-api-services-source.jar')
     compile 'org.yaml:snakeyaml:1.18'

--- a/google-cloud-tools-plugin/ultimate/build.gradle
+++ b/google-cloud-tools-plugin/ultimate/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     compile files(project(':google-cloud-tools-plugin').sourceSets.main.output)
     compile files("${System.properties['java.home']}/../lib/tools.jar")
     compile ('com.google.cloud.tools:appengine-plugins-core:' + toolsLibVersion) {
-        exclude group: 'com.google.guava', module: 'guava'
+        exclude group: 'org.yaml', module: 'snakeyaml'
     }
     testCompile 'org.yaml:snakeyaml:1.18'
     testCompile project(path: ':google-account-plugin')

--- a/google-cloud-tools-plugin/ultimate/build.gradle
+++ b/google-cloud-tools-plugin/ultimate/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     compile files(project(':google-cloud-tools-plugin').sourceSets.main.output)
     compile files("${System.properties['java.home']}/../lib/tools.jar")
     compile ('com.google.cloud.tools:appengine-plugins-core:' + toolsLibVersion) {
+        exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'org.yaml', module: 'snakeyaml'
     }
     testCompile 'org.yaml:snakeyaml:1.18'

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -233,6 +233,12 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
   }
 
   @Override
+  public List<File> getServices() {
+    // Needed by devappserver1. Will be implemented when devappserver1 is integrated.
+    return null;
+  }
+
+  @Override
   public String getHost() {
     return settings.getHost();
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ ideaVersion = 2016.3
 javaVersion = 1.8
 ijPluginRepoChannel = alpha
 version = 17.2.2-SNAPSHOT
-toolsLibVersion = 0.2.6
+toolsLibVersion = 0.2.9


### PR DESCRIPTION
0.2.9 provides devappserver1 integration, which will be required by #1315 