### PR TITLE
Allows specifying a JDK to CloudSdk objects

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -232,7 +232,7 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
         .appCommandMetricsEnvironmentVersion(pluginInfoService.getPluginVersion())
         .appCommandOutputFormat("json");
 
-    getProjectJavaSdk(project).ifPresent(sdkBuilder::javaSdkPath);
+    getProjectJavaSdk(project).ifPresent(sdkBuilder::javaHome);
 
     return sdkBuilder.build();
   }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineStandardRunTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/executor/AppEngineStandardRunTask.java
@@ -70,7 +70,7 @@ public class AppEngineStandardRunTask extends AppEngineTask {
         .startListener(startListener);
 
     if (javaSdk.getHomePath() != null) {
-      sdkBuilder.javaSdkPath(Paths.get(javaSdk.getHomePath()));
+      sdkBuilder.javaHome(Paths.get(javaSdk.getHomePath()));
     }
 
     CloudSdkAppEngineDevServer devServer = new CloudSdkAppEngineDevServer(sdkBuilder.build());

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
@@ -237,9 +237,9 @@ public class DefaultCloudSdkService extends CloudSdkService {
     return jars.toArray(new File[jars.size()]);
   }
 
+  // TODO(joaomartins): This method should probably be extracted to CloudSdkAppEngineHelper.
   @VisibleForTesting
   CloudSdk buildCloudSdkWithPath(@NotNull Path path) {
     return new CloudSdk.Builder().sdkPath(path).build();
-
   }
 }

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -236,6 +236,11 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
   }
 
   @Override
+  public List<File> getServices() {
+    return null;
+  }
+
+  @Override
   public String getHost() {
     return settings.getHost();
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,5 @@ ideaEdition = IC
 ideaVersion = 171.3780.95
 javaVersion = 1.8
 ijPluginRepoChannel = alpha
-version = 17.2.1_2017
+version = 17.2.2_2017-SNAPSHOT
 toolsLibVersion = 0.2.6


### PR DESCRIPTION
This change depends on an appengine-plugins-core 0.2.10 version, where specifying a JDK at CloudSdk construction time will be possible.

This fixes #1316 