### PR TITLE
Pin to ideaVersion 2017.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 ideaEdition = IC
-ideaVersion = 171.3780.95
+ideaVersion = 2017.1
 javaVersion = 1.8
 ijPluginRepoChannel = alpha
 version = 17.2.2_2017-SNAPSHOT


### PR DESCRIPTION
So we pin to the latest 2017.1 build, rather than a specific one.