### PR TITLE
Removes unnecessary references to AppEngineFlexibleDeploymentConfiguration

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFacetConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFacetConfiguration.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.tools.intellij.appengine.facet.flexible;
 
-import com.google.cloud.tools.intellij.appengine.cloud.AppEngineDeploymentConfiguration;
-
 import com.intellij.facet.FacetConfiguration;
 import com.intellij.facet.ui.FacetEditorContext;
 import com.intellij.facet.ui.FacetEditorTab;
@@ -37,18 +35,14 @@ import org.jetbrains.annotations.Nullable;
 public class AppEngineFlexibleFacetConfiguration implements FacetConfiguration,
     PersistentStateComponent<AppEngineFlexibleFacetConfiguration> {
 
-  private String appYamlPath = "";
-  private String dockerfilePath = "";
+  private String appYamlPath;
+  private String dockerfilePath;
 
   @Override
   public FacetEditorTab[] createEditorTabs(FacetEditorContext editorContext,
       FacetValidatorsManager validatorsManager) {
-    AppEngineDeploymentConfiguration deploymentConfiguration =
-        new AppEngineDeploymentConfiguration();
-    deploymentConfiguration.setAppYamlPath(appYamlPath);
-    deploymentConfiguration.setDockerFilePath(dockerfilePath);
     return new FacetEditorTab[]{
-      new FlexibleFacetEditor(deploymentConfiguration, editorContext.getProject())
+      new FlexibleFacetEditor(this, editorContext.getProject())
     };
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/FlexibleFacetEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/FlexibleFacetEditor.java
@@ -80,7 +80,7 @@ public class FlexibleFacetEditor extends FacetEditorTab {
   private AppEngineFlexibleFacetConfiguration facetConfiguration;
   private AppEngineHelper appEngineHelper;
 
-  FlexibleFacetEditor(AppEngineFlexibleFacetConfiguration facetConfiguration,
+  FlexibleFacetEditor(@NotNull AppEngineFlexibleFacetConfiguration facetConfiguration,
       @NotNull Project project) {
     this.appEngineHelper = new CloudSdkAppEngineHelper(project);
     this.facetConfiguration = facetConfiguration;

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/FlexibleFacetEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/FlexibleFacetEditor.java
@@ -43,7 +43,6 @@ import com.intellij.ui.DocumentAdapter;
 
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -99,14 +98,14 @@ public class FlexibleFacetEditor extends FacetEditorTab {
       @Override
       protected void textChanged(DocumentEvent event) {
         toggleDockerfileSection();
-        toggleWarnings();
+        showWarnings();
       }
     });
 
     dockerfile.getTextField().getDocument().addDocumentListener(new DocumentAdapter() {
       @Override
       protected void textChanged(DocumentEvent event) {
-        toggleWarnings();
+        showWarnings();
       }
     });
 
@@ -119,11 +118,11 @@ public class FlexibleFacetEditor extends FacetEditorTab {
 
     genAppYamlButton.addActionListener(new GenerateConfigActionListener(project, "app.yaml",
         () -> appEngineHelper.defaultAppYaml(FlexibleRuntime.java), appYaml,
-        this::toggleWarnings));
+        this::showWarnings));
 
     genDockerfileButton.addActionListener(new GenerateConfigActionListener(project, "Dockerfile",
         () -> appEngineHelper.defaultDockerfile(AppEngineFlexibleDeploymentArtifactType.WAR),
-        dockerfile, this::toggleWarnings
+        dockerfile, this::showWarnings
     ));
 
     appYaml.setText(facetConfiguration.getAppYamlPath());
@@ -133,7 +132,7 @@ public class FlexibleFacetEditor extends FacetEditorTab {
     errorIcon.setVisible(false);
     errorMessage.setVisible(false);
 
-    toggleWarnings();
+    showWarnings();
     toggleDockerfileSection();
   }
 
@@ -159,7 +158,7 @@ public class FlexibleFacetEditor extends FacetEditorTab {
 
   @Override
   public void apply() throws ConfigurationException {
-    toggleWarnings();
+    showWarnings();
     if (!isValidConfigurationFile(appYaml.getText())) {
       throw new ConfigurationException(
           GctBundle.getString("appengine.deployment.error.staging.yaml"));
@@ -211,7 +210,7 @@ public class FlexibleFacetEditor extends FacetEditorTab {
   /**
    * Validates the configuration and turns on/off any necessary warnings.
    */
-  private void toggleWarnings() {
+  private void showWarnings() {
     boolean showError = false;
 
     if (!isValidConfigurationFile(appYaml.getText())) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/FlexibleFacetEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/FlexibleFacetEditor.java
@@ -80,7 +80,7 @@ public class FlexibleFacetEditor extends FacetEditorTab {
   private AppEngineFlexibleFacetConfiguration facetConfiguration;
   private AppEngineHelper appEngineHelper;
 
-  FlexibleFacetEditor(@Nullable AppEngineFlexibleFacetConfiguration facetConfiguration,
+  FlexibleFacetEditor(AppEngineFlexibleFacetConfiguration facetConfiguration,
       @NotNull Project project) {
     this.appEngineHelper = new CloudSdkAppEngineHelper(project);
     this.facetConfiguration = facetConfiguration;

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
@@ -242,7 +242,7 @@ public class AppEngineUtil {
 
     // TODO(joaomartins): Is a flexible facet check required here as well?
     return Arrays.stream(ArtifactManager.getInstance(project).getArtifacts())
-        .filter(artifactTypes::contains)
+        .filter(artifact -> artifactTypes.contains(artifact.getArtifactType()))
         .filter(artifact ->
             !withAppEngineFacetOnly || findAppEngineStandardFacet(project, artifact).isPresent())
         .sorted(ArtifactManager.ARTIFACT_COMPARATOR)

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/FlexibleFacetEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/FlexibleFacetEditorTest.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.tools.intellij.appengine.facet.flexible;
 
-import com.google.cloud.tools.intellij.appengine.cloud.AppEngineDeploymentConfiguration;
-
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.testFramework.PlatformTestCase;
 
@@ -30,7 +28,7 @@ public class FlexibleFacetEditorTest extends PlatformTestCase {
   private File invalidYaml;
   private File dockerfile;
   private FlexibleFacetEditor editor;
-  private AppEngineDeploymentConfiguration deploymentConfiguration;
+  private AppEngineFlexibleFacetConfiguration facetConfiguration;
 
   @Override
   public void setUp() throws Exception {
@@ -41,12 +39,12 @@ public class FlexibleFacetEditorTest extends PlatformTestCase {
     invalidYaml = createTempFile("invalid.yaml", "runtime: custom\nenv_variables:\n  'ASD");
     dockerfile = createTempFile("Dockerfile", "");
 
-    deploymentConfiguration = new AppEngineDeploymentConfiguration();
+    facetConfiguration = new AppEngineFlexibleFacetConfiguration();
   }
 
   public void testToggleDockerfileSection() throws ConfigurationException {
-    deploymentConfiguration.setAppYamlPath("");
-    editor = new FlexibleFacetEditor(deploymentConfiguration, getProject());
+    facetConfiguration.setAppYamlPath("");
+    editor = new FlexibleFacetEditor(facetConfiguration, getProject());
     // no yaml
     assertFalse(editor.getDockerfile().isEnabled());
     assertFalse(editor.getGenDockerfileButton().isEnabled());
@@ -64,8 +62,8 @@ public class FlexibleFacetEditorTest extends PlatformTestCase {
   }
 
   public void testValidateConfiguration_noYAML() {
-    deploymentConfiguration.setAppYamlPath("");
-    editor = new FlexibleFacetEditor(deploymentConfiguration, getProject());
+    facetConfiguration.setAppYamlPath("");
+    editor = new FlexibleFacetEditor(facetConfiguration, getProject());
     assertTrue(editor.getErrorIcon().isVisible());
     assertTrue(editor.getErrorMessage().isVisible());
     assertEquals("The specified app.yaml configuration file does not exist or is not a valid file.",
@@ -82,8 +80,8 @@ public class FlexibleFacetEditorTest extends PlatformTestCase {
   }
 
   public void testValidateConfiguration_nullYAML() {
-    deploymentConfiguration.setAppYamlPath(null);
-    editor = new FlexibleFacetEditor(deploymentConfiguration, getProject());
+    facetConfiguration.setAppYamlPath(null);
+    editor = new FlexibleFacetEditor(facetConfiguration, getProject());
     assertTrue(editor.getErrorIcon().isVisible());
     assertTrue(editor.getErrorMessage().isVisible());
     assertEquals("The specified app.yaml configuration file does not exist or is not a valid file.",
@@ -100,7 +98,7 @@ public class FlexibleFacetEditorTest extends PlatformTestCase {
   }
 
   public void testValidateConfiguration_malformedYAML() {
-    editor = new FlexibleFacetEditor(deploymentConfiguration, getProject());
+    editor = new FlexibleFacetEditor(facetConfiguration, getProject());
     editor.getAppYaml().setText(invalidYaml.getPath());
 
     try {
@@ -113,7 +111,7 @@ public class FlexibleFacetEditorTest extends PlatformTestCase {
   }
 
   public void testValidateConfiguration_YAMLIsDirectory() {
-    editor = new FlexibleFacetEditor(deploymentConfiguration, getProject());
+    editor = new FlexibleFacetEditor(facetConfiguration, getProject());
     editor.getAppYaml().setText(javaYaml.getParentFile().getPath());
     assertTrue(editor.getErrorIcon().isVisible());
     assertTrue(editor.getErrorMessage().isVisible());
@@ -131,7 +129,7 @@ public class FlexibleFacetEditorTest extends PlatformTestCase {
   }
 
   public void testValidateConfiguration_javaRuntime() throws ConfigurationException {
-    editor = new FlexibleFacetEditor(deploymentConfiguration, getProject());
+    editor = new FlexibleFacetEditor(facetConfiguration, getProject());
     editor.getAppYaml().setText(javaYaml.getPath());
     assertFalse(editor.getDockerfile().isEnabled());
     assertFalse(editor.getErrorIcon().isVisible());
@@ -141,7 +139,7 @@ public class FlexibleFacetEditorTest extends PlatformTestCase {
   }
 
   public void testValidateConfiguration_customRuntimeNoDockerfile() {
-    editor = new FlexibleFacetEditor(deploymentConfiguration, getProject());
+    editor = new FlexibleFacetEditor(facetConfiguration, getProject());
     editor.getAppYaml().setText(customYaml.getPath());
     editor.getDockerfile().setText("");
     assertTrue(editor.getDockerfile().isEnabled());
@@ -163,7 +161,7 @@ public class FlexibleFacetEditorTest extends PlatformTestCase {
   }
 
   public void testValidateConfiguration_customRuntimeNullDockerfile() {
-    editor = new FlexibleFacetEditor(deploymentConfiguration, getProject());
+    editor = new FlexibleFacetEditor(facetConfiguration, getProject());
     editor.getAppYaml().setText(customYaml.getPath());
     editor.getDockerfile().setText(null);
     assertTrue(editor.getDockerfile().isEnabled());
@@ -185,7 +183,7 @@ public class FlexibleFacetEditorTest extends PlatformTestCase {
   }
 
   public void testValidateConfiguration_customRuntimeDockerfileIsDirectory() {
-    editor = new FlexibleFacetEditor(deploymentConfiguration, getProject());
+    editor = new FlexibleFacetEditor(facetConfiguration, getProject());
     editor.getAppYaml().setText(customYaml.getPath());
     editor.getDockerfile().setText(dockerfile.getParentFile().getPath());
     assertTrue(editor.getDockerfile().isEnabled());
@@ -206,7 +204,7 @@ public class FlexibleFacetEditorTest extends PlatformTestCase {
   }
 
   public void testValidateConfiguration_customRuntime() throws ConfigurationException {
-    editor = new FlexibleFacetEditor(deploymentConfiguration, getProject());
+    editor = new FlexibleFacetEditor(facetConfiguration, getProject());
     editor.getAppYaml().setText(customYaml.getPath());
     editor.getDockerfile().setText(dockerfile.getPath());
     assertTrue(editor.getDockerfile().isEnabled());


### PR DESCRIPTION
I don't remember exactly why I went for this design, but I can clearly see now it wasn't a great decision.