### PR TITLE
Bumps appengine-plugins-core version to 0.2.10

### DIFF
--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -236,6 +236,11 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
   }
 
   @Override
+  public List<File> getServices() {
+    return null;
+  }
+
+  @Override
   public String getHost() {
     return settings.getHost();
   }
@@ -430,11 +435,6 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
 
   public void setDefaultGcsBucketName(String defaultGcsBucketName) {
     settings.setDefaultGcsBucketName(defaultGcsBucketName);
-  }
-
-  @Override
-  public String getJavaHomeDir() {
-    return devAppServerJdk.getHomePath();
   }
 
   @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ ideaVersion = 2017.1
 javaVersion = 1.8
 ijPluginRepoChannel = alpha
 version = 17.2.2_2017-SNAPSHOT
-toolsLibVersion = 0.2.6
+toolsLibVersion = 0.2.10


### PR DESCRIPTION
This will enable passing a javaHome directory to CloudSdk so it is used in standard staging and devappserver runs.