### PR TITLE
Fixes module combo box and button state

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
@@ -158,6 +158,9 @@ public class AppEngineFlexibleDeploymentEditor extends
     appYamlOverrideCheckBox.addActionListener(event -> {
       boolean isAppYamlOverrideSelected = ((JCheckBox) event.getSource()).isSelected();
       appYamlTextField.setVisible(isAppYamlOverrideSelected);
+
+      setModuleComboBoxAndButtonEnabled(
+          !(isAppYamlOverrideSelected && dockerfileOverrideCheckBox.isSelected()));
       toggleDockerfileSection();
     });
 
@@ -174,6 +177,9 @@ public class AppEngineFlexibleDeploymentEditor extends
             dockerfileOverride = dockerfileTextField.getText();
             dockerfileTextField.setText(getDockerfilePath());
           }
+
+          setModuleComboBoxAndButtonEnabled(
+              !(isDockerfileOverrideSelected && appYamlOverrideCheckBox.isSelected()));
         }
     );
 
@@ -300,7 +306,9 @@ public class AppEngineFlexibleDeploymentEditor extends
         || modulesWithFlexFacetComboBox.getItemCount() == 0);
     dockerfileOverrideCheckBox.setSelected(configuration.isOverrideDockerfile()
         || modulesWithFlexFacetComboBox.getItemCount() == 0);
-    modulesWithFlexFacetComboBox.setEnabled(!configuration.isOverrideAppYaml());
+
+    setModuleComboBoxAndButtonEnabled(
+        !(configuration.isOverrideAppYaml() && configuration.isOverrideDockerfile()));
 
     toggleDockerfileSection();
     updateServiceName();
@@ -507,6 +515,16 @@ public class AppEngineFlexibleDeploymentEditor extends
       ((AppEngineDeployable) deploymentSource).setVersion(
           Strings.isNullOrEmpty(version.getText()) ? "auto" : version.getText());
     }
+  }
+
+  /**
+   * Enables or disables the modules combo box and module settings button. Ideally, they get
+   * disabled if both app.yaml and Dockerfile override check boxes are checked and enabled
+   * otherwise.
+   */
+  private void setModuleComboBoxAndButtonEnabled(boolean enabled) {
+    modulesWithFlexFacetComboBox.setEnabled(enabled);
+    moduleSettingsButton.setEnabled(enabled);
   }
 
   @VisibleForTesting

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
@@ -159,8 +159,7 @@ public class AppEngineFlexibleDeploymentEditor extends
       boolean isAppYamlOverrideSelected = ((JCheckBox) event.getSource()).isSelected();
       appYamlTextField.setVisible(isAppYamlOverrideSelected);
 
-      setModuleComboBoxAndButtonEnabled(
-          !(isAppYamlOverrideSelected && dockerfileOverrideCheckBox.isSelected()));
+      setModuleControls(!(isAppYamlOverrideSelected && dockerfileOverrideCheckBox.isSelected()));
       updateServiceName();
       toggleDockerfileSection();
     });
@@ -179,7 +178,7 @@ public class AppEngineFlexibleDeploymentEditor extends
             dockerfileTextField.setText(getDockerfilePath());
           }
 
-          setModuleComboBoxAndButtonEnabled(
+          setModuleControls(
               !(isDockerfileOverrideSelected && appYamlOverrideCheckBox.isSelected()));
         }
     );
@@ -308,8 +307,7 @@ public class AppEngineFlexibleDeploymentEditor extends
     dockerfileOverrideCheckBox.setSelected(configuration.isOverrideDockerfile()
         || modulesWithFlexFacetComboBox.getItemCount() == 0);
 
-    setModuleComboBoxAndButtonEnabled(
-        !(configuration.isOverrideAppYaml() && configuration.isOverrideDockerfile()));
+    setModuleControls(!(configuration.isOverrideAppYaml() && configuration.isOverrideDockerfile()));
 
     toggleDockerfileSection();
     updateServiceName();
@@ -523,7 +521,7 @@ public class AppEngineFlexibleDeploymentEditor extends
    * disabled if both app.yaml and Dockerfile override check boxes are checked and enabled
    * otherwise.
    */
-  private void setModuleComboBoxAndButtonEnabled(boolean enabled) {
+  private void setModuleControls(boolean enabled) {
     modulesWithFlexFacetComboBox.setEnabled(enabled);
     moduleSettingsButton.setEnabled(enabled);
   }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
@@ -159,7 +159,8 @@ public class AppEngineFlexibleDeploymentEditor extends
       boolean isAppYamlOverrideSelected = ((JCheckBox) event.getSource()).isSelected();
       appYamlTextField.setVisible(isAppYamlOverrideSelected);
 
-      setModuleControls(!(isAppYamlOverrideSelected && dockerfileOverrideCheckBox.isSelected()));
+      setModuleControlsEnabled(
+          !(isAppYamlOverrideSelected && dockerfileOverrideCheckBox.isSelected()));
       updateServiceName();
       toggleDockerfileSection();
     });
@@ -178,7 +179,7 @@ public class AppEngineFlexibleDeploymentEditor extends
             dockerfileTextField.setText(getDockerfilePath());
           }
 
-          setModuleControls(
+          setModuleControlsEnabled(
               !(isDockerfileOverrideSelected && appYamlOverrideCheckBox.isSelected()));
         }
     );
@@ -307,7 +308,8 @@ public class AppEngineFlexibleDeploymentEditor extends
     dockerfileOverrideCheckBox.setSelected(configuration.isOverrideDockerfile()
         || modulesWithFlexFacetComboBox.getItemCount() == 0);
 
-    setModuleControls(!(configuration.isOverrideAppYaml() && configuration.isOverrideDockerfile()));
+    setModuleControlsEnabled(
+        !(configuration.isOverrideAppYaml() && configuration.isOverrideDockerfile()));
 
     toggleDockerfileSection();
     updateServiceName();
@@ -521,7 +523,7 @@ public class AppEngineFlexibleDeploymentEditor extends
    * disabled if both app.yaml and Dockerfile override check boxes are checked and enabled
    * otherwise.
    */
-  private void setModuleControls(boolean enabled) {
+  private void setModuleControlsEnabled(boolean enabled) {
     modulesWithFlexFacetComboBox.setEnabled(enabled);
     moduleSettingsButton.setEnabled(enabled);
   }


### PR DESCRIPTION
Correctly disables the modules combo box and module settings button if both app.yaml and Dockerfile overrides are turned on, and enables them if otherwise.