### PR TITLE
Allows specifying a JDK to CloudSdk objects (#1326)

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -43,6 +43,8 @@ import com.google.gson.Gson;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vcs.impl.CancellableRunnable;
@@ -62,6 +64,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A Cloud SDK (gcloud) based implementation of the {@link AppEngineHelper} interface.
@@ -217,7 +220,7 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
     CloudToolsPluginInfoService pluginInfoService =
         ServiceManager.getService(CloudToolsPluginInfoService.class);
 
-    return new CloudSdk.Builder()
+    CloudSdk.Builder sdkBuilder = new CloudSdk.Builder()
         .sdkPath(CloudSdkService.getInstance().getSdkHomePath())
         .async(true)
         .addStdErrLineListener(logListener)
@@ -227,8 +230,11 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
         .appCommandCredentialFile(credentialsPath.toFile())
         .appCommandMetricsEnvironment(pluginInfoService.getExternalPluginName())
         .appCommandMetricsEnvironmentVersion(pluginInfoService.getPluginVersion())
-        .appCommandOutputFormat("json")
-        .build();
+        .appCommandOutputFormat("json");
+
+    getProjectJavaSdk(project).ifPresent(sdkBuilder::javaHome);
+
+    return sdkBuilder.build();
   }
 
   private static final String CLIENT_ID_LABEL = "client_id";
@@ -356,6 +362,16 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
       throw new RuntimeException(ex);
     }
     return appYaml;
+  }
+
+  private Optional<Path> getProjectJavaSdk(Project project) {
+    Sdk projectJavaSdk = ProjectRootManager.getInstance(project).getProjectSdk();
+
+    if (projectJavaSdk == null || projectJavaSdk.getHomePath() == null) {
+      return Optional.empty();
+    }
+
+    return Optional.of(Paths.get(projectJavaSdk.getHomePath()));
   }
 
   @VisibleForTesting

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
@@ -237,9 +237,9 @@ public class DefaultCloudSdkService extends CloudSdkService {
     return jars.toArray(new File[jars.size()]);
   }
 
+  // TODO(joaomartins): This method should probably be extracted to CloudSdkAppEngineHelper.
   @VisibleForTesting
   CloudSdk buildCloudSdkWithPath(@NotNull Path path) {
     return new CloudSdk.Builder().sdkPath(path).build();
-
   }
 }

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineRunConfigurationEditor.java
@@ -122,8 +122,6 @@ public class AppEngineRunConfigurationEditor extends SettingsEditor<CommonModel>
     apiPort.setText(intToString(serverModel.getApiPort()));
     applicationLogLevel.setSelectedItem(serverModel.getLogLevel());
     cleadDatastoreCheckbox.setSelected(serverModel.getClearDatastore());
-
-    serverModel.initJdk();
   }
 
   @Override

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -236,6 +236,11 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
   }
 
   @Override
+  public List<File> getServices() {
+    return null;
+  }
+
+  @Override
   public String getHost() {
     return settings.getHost();
   }
@@ -430,11 +435,6 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
 
   public void setDefaultGcsBucketName(String defaultGcsBucketName) {
     settings.setDefaultGcsBucketName(defaultGcsBucketName);
-  }
-
-  @Override
-  public String getJavaHomeDir() {
-    return devAppServerJdk.getHomePath();
   }
 
   @Override

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineServerModel.java
@@ -39,6 +39,7 @@ import com.intellij.javaee.run.execution.OutputProcessor;
 import com.intellij.javaee.serverInstances.J2EEServerInstance;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.roots.ui.configuration.projectRoot.ProjectSdksModel;
 import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.Pair;
@@ -72,27 +73,11 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
   public static final String JVM_FLAG_DELIMITER = " ";
   private ArtifactPointer artifactPointer;
   private CommonModel commonModel;
-  private Sdk devAppServerJdk;
-  private ProjectSdksModel projectJdksModel;
   private AppEngineModelSettings settings = new AppEngineModelSettings();
-
-  public AppEngineServerModel() {
-    projectJdksModel = new ProjectSdksModel();
-  }
-
-  void initJdk() {
-    projectJdksModel.reset(commonModel.getProject());
-    setDevAppServerJdk(projectJdksModel.getProjectSdk());
-  }
 
   @Override
   public J2EEServerInstance createServerInstance() throws ExecutionException {
-    // TODO(alexsloan): This keeps the dev_appserver's jdk in sync with the project jdk on behalf of
-    // the user. This behavior should be removed once
-    // https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/926 is completed.
-    initJdk();
-
-    if (devAppServerJdk == null) {
+    if (ProjectRootManager.getInstance(commonModel.getProject()).getProjectSdk() == null) {
       throw new ExecutionException(GctBundle.getString("appengine.run.server.nosdk"));
     }
 
@@ -161,7 +146,7 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
           GctBundle.message("appengine.run.server.sdk.misconfigured.panel.message"));
     }
 
-    if (devAppServerJdk == null) {
+    if (ProjectRootManager.getInstance(commonModel.getProject()).getProjectSdk() == null) {
       throw new RuntimeConfigurationError(GctBundle.getString("appengine.run.server.nosdk"));
     }
   }
@@ -444,10 +429,6 @@ public class AppEngineServerModel implements ServerModel, DeploysArtifactsOnStar
 
   public void setClearDatastore(Boolean clearDatastore) {
     settings.setClearDatastore(clearDatastore);
-  }
-
-  private void setDevAppServerJdk(Sdk devAppServerJdk) {
-    this.devAppServerJdk = devAppServerJdk;
   }
 
   /**

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/run/CloudSdkStartupPolicy.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/run/CloudSdkStartupPolicy.java
@@ -31,6 +31,8 @@ import com.intellij.javaee.run.localRun.ExecutableObject;
 import com.intellij.javaee.run.localRun.ExecutableObjectStartupPolicy;
 import com.intellij.javaee.run.localRun.ScriptHelper;
 import com.intellij.javaee.run.localRun.ScriptsHelper;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ProjectRootManager;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -68,6 +70,11 @@ public class CloudSdkStartupPolicy implements ExecutableObjectStartupPolicy {
                   GctBundle.message("appengine.run.server.sdk.misconfigured.message"));
             }
 
+            Sdk javaSdk = ProjectRootManager.getInstance(commonModel.getProject()).getProjectSdk();
+            if (javaSdk == null || javaSdk.getHomePath() == null) {
+              throw new ExecutionException(GctBundle.message("appengine.run.server.nosdk"));
+            }
+
             AppEngineServerModel runConfiguration;
 
             try {
@@ -91,7 +98,8 @@ public class CloudSdkStartupPolicy implements ExecutableObjectStartupPolicy {
             }
 
             AppEngineStandardRunTask runTask =
-                new AppEngineStandardRunTask(runConfiguration, programRunner.getRunnerId());
+                new AppEngineStandardRunTask(
+                    runConfiguration, javaSdk, programRunner.getRunnerId());
             AppEngineExecutor executor = new AppEngineExecutor(runTask);
             executor.run();
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ ideaVersion = 2016.3
 javaVersion = 1.8
 ijPluginRepoChannel = alpha
 version = 17.2.1
-toolsLibVersion = 0.2.6
+toolsLibVersion = 0.2.10


### PR DESCRIPTION
cherry picked from 2017 branch commits 3c714c4, and https://github.com/GoogleCloudPlatform/google-cloud-intellij/commit/17cfb71137fcd4c3986c0a68af45d64b798d65ab. updates core lib in preparation for devappserver updates, and moves specification of JDK to the CloudSdk

Note the branching for this PR:

target branch : v17.2.2 -> branched off of the last release tag for 2016
we will release a interim maintenance release from v17.2.2.