### PR TITLE
Don't recreate / overwrite flex deployment configs when migrating to new flex support

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleSupportProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleSupportProvider.java
@@ -204,7 +204,8 @@ public class AppEngineFlexibleSupportProvider extends FrameworkSupportInModulePr
   }
 
   private static boolean hasFlexibleDeploymentConfiguration(List<RunConfiguration> runConfigs) {
-    return runConfigs.stream()
+    return runConfigs
+        .stream()
         .anyMatch(runConfig -> {
           if (runConfig instanceof DeployToServerRunConfiguration) {
             DeploymentConfiguration deployConfig

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleSupportProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleSupportProvider.java
@@ -206,20 +206,14 @@ public class AppEngineFlexibleSupportProvider extends FrameworkSupportInModulePr
   private static boolean hasFlexibleDeploymentConfiguration(List<RunConfiguration> runConfigs) {
     return runConfigs
         .stream()
-        .anyMatch(runConfig -> {
-          if (runConfig instanceof DeployToServerRunConfiguration) {
-            DeploymentConfiguration deployConfig
-                = ((DeployToServerRunConfiguration) runConfig).getDeploymentConfiguration();
+        .filter(runConfig -> runConfig instanceof DeployToServerRunConfiguration)
+        .map(runConfig -> ((DeployToServerRunConfiguration) runConfig).getDeploymentConfiguration())
+        .filter(deployConfig -> deployConfig instanceof AppEngineDeploymentConfiguration)
+        .anyMatch(deployConfig -> {
+          String environment
+              = ((AppEngineDeploymentConfiguration) deployConfig).getEnvironment();
 
-            if (deployConfig instanceof AppEngineDeploymentConfiguration) {
-              String environment
-                  = ((AppEngineDeploymentConfiguration) deployConfig).getEnvironment();
-
-              return AppEngineEnvironment.APP_ENGINE_FLEX.name().equals(environment);
-            }
-          }
-
-          return false;
+          return AppEngineEnvironment.APP_ENGINE_FLEX.name().equals(environment);
         });
   }
 


### PR DESCRIPTION
fixes #1366 

The problem was that the existing flex run configuration was getting wiped out. This update changes it so that a new flex deploy run config is create only if one does not already exist.