### PR TITLE
Show full unit test failure info in gradle test task output

### DIFF
--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -79,6 +79,8 @@ artifacts {
 test {
     testLogging {
         events "skipped", "failed"
+        exceptionFormat "full"
+        showCauses true
     }
     doLast{
        println "View report at file://$buildDir/reports/tests/index.html"


### PR DESCRIPTION
workaround for kokoro limitation of not being able to view structured junit results. This will show the following in the console output:

![image](https://cloud.githubusercontent.com/assets/1735744/25675485/9cd76ace-300c-11e7-921a-bec87a4113c4.png)
