### PR TITLE
Refactors logging around possible flaky test

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/CloudDebugProcessHandler.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/CloudDebugProcessHandler.java
@@ -23,7 +23,8 @@ import com.google.common.annotations.VisibleForTesting;
 
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.openapi.diagnostic.Logger;
-import com.sun.istack.NotNull;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.io.OutputStream;
 
@@ -35,7 +36,7 @@ public class CloudDebugProcessHandler extends ProcessHandler {
 
   private static final Logger LOG = Logger.getInstance(CloudDebugProcessHandler.class);
 
-  private final CloudDebugProcess process;
+  private CloudDebugProcess process;
 
   /**
    * Initialize the cloud debug process handler.
@@ -63,7 +64,6 @@ public class CloudDebugProcessHandler extends ProcessHandler {
 
   @VisibleForTesting
   CloudDebugProcessHandler() {
-    this.process = null;
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/CloudDebugProcessHandler.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/CloudDebugProcessHandler.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.intellij.debugger;
 import com.google.cloud.tools.intellij.debugger.ui.LogoutDebugProcessDetacher;
 import com.google.cloud.tools.intellij.login.CredentialedUser;
 import com.google.cloud.tools.intellij.login.Services;
-import com.google.common.annotations.VisibleForTesting;
 
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.openapi.diagnostic.Logger;
@@ -36,7 +35,7 @@ public class CloudDebugProcessHandler extends ProcessHandler {
 
   private static final Logger LOG = Logger.getInstance(CloudDebugProcessHandler.class);
 
-  private CloudDebugProcess process;
+  private final CloudDebugProcess process;
 
   /**
    * Initialize the cloud debug process handler.
@@ -60,10 +59,6 @@ public class CloudDebugProcessHandler extends ProcessHandler {
     } else {
       LOG.error("process state is null.");
     }
-  }
-
-  @VisibleForTesting
-  CloudDebugProcessHandler() {
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/CloudDebugProcessHandler.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/CloudDebugProcessHandler.java
@@ -19,9 +19,11 @@ package com.google.cloud.tools.intellij.debugger;
 import com.google.cloud.tools.intellij.debugger.ui.LogoutDebugProcessDetacher;
 import com.google.cloud.tools.intellij.login.CredentialedUser;
 import com.google.cloud.tools.intellij.login.Services;
+import com.google.common.annotations.VisibleForTesting;
 
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.openapi.diagnostic.Logger;
+import com.sun.istack.NotNull;
 
 import java.io.OutputStream;
 
@@ -38,9 +40,9 @@ public class CloudDebugProcessHandler extends ProcessHandler {
   /**
    * Initialize the cloud debug process handler.
    */
-  public CloudDebugProcessHandler(CloudDebugProcess process) {
+  public CloudDebugProcessHandler(@NotNull CloudDebugProcess process) {
     this.process = process;
-    if (process != null && process.getProcessState() != null) {
+    if (process.getProcessState() != null) {
       String userEmail = process.getProcessState().getUserEmail();
       if (userEmail != null) {
         final CredentialedUser user = Services.getLoginService().getAllUsers().get(userEmail);
@@ -55,8 +57,13 @@ public class CloudDebugProcessHandler extends ProcessHandler {
         LOG.error("userEmail is null. To launch a debug session user needs to be logged in");
       }
     } else {
-      LOG.error("process or process state is null. This should only happen in tests");
+      LOG.error("process state is null.");
     }
+  }
+
+  @VisibleForTesting
+  CloudDebugProcessHandler() {
+    this.process = null;
   }
 
   @Override

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/CloudDebugProcessHandlerTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/CloudDebugProcessHandlerTest.java
@@ -33,13 +33,15 @@ import java.util.LinkedHashMap;
 
 public class CloudDebugProcessHandlerTest extends BasePluginTestCase {
 
-    private CloudDebugProcessHandler handler = new CloudDebugProcessHandler();
+    private CloudDebugProcessHandler handler;
     private GoogleLoginService mockLoginService = mock(GoogleLoginService.class);
 
     @Before
     public void setUp() throws Exception {
         registerExtensionPoint(GoogleLoginListener.EP_NAME, GoogleLoginListener.class);
         registerService(GoogleLoginService.class, mockLoginService);
+
+        setupMocks();
     }
 
     @Test
@@ -57,8 +59,7 @@ public class CloudDebugProcessHandlerTest extends BasePluginTestCase {
         Assert.assertNull(handler.getProcessInput());
     }
 
-    @Test
-    public void testConstructorAddsLoginListenerIfUserFound() {
+    private void setupMocks() {
         GoogleLoginState googleLoginState = mock(GoogleLoginState.class);
         CredentialedUser credentialedUser = mock(CredentialedUser.class);
         when(credentialedUser.getGoogleLoginState()).thenReturn(googleLoginState);
@@ -73,6 +74,6 @@ public class CloudDebugProcessHandlerTest extends BasePluginTestCase {
         CloudDebugProcess cloudDebugProcess = mock(CloudDebugProcess.class);
         when(cloudDebugProcess.getProcessState()).thenReturn(cloudDebugProcessState);
 
-        new CloudDebugProcessHandler(cloudDebugProcess);
+        handler = new CloudDebugProcessHandler(cloudDebugProcess);
     }
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/CloudDebugProcessHandlerTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/CloudDebugProcessHandlerTest.java
@@ -19,44 +19,27 @@ package com.google.cloud.tools.intellij.debugger;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.tools.intellij.testing.BasePluginTestCase;
 import com.google.cloud.tools.intellij.login.CredentialedUser;
 import com.google.cloud.tools.intellij.login.GoogleLoginListener;
 import com.google.cloud.tools.intellij.login.GoogleLoginService;
+import com.google.cloud.tools.intellij.testing.BasePluginTestCase;
 import com.google.gdt.eclipse.login.common.GoogleLoginState;
 
-import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.testFramework.LoggedErrorProcessor;
-import com.intellij.testFramework.TestLoggerFactory;
-
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.LinkedHashMap;
 
 public class CloudDebugProcessHandlerTest extends BasePluginTestCase {
 
-    private CloudDebugProcessHandler handler = new CloudDebugProcessHandler(null);
+    private CloudDebugProcessHandler handler = new CloudDebugProcessHandler();
     private GoogleLoginService mockLoginService = mock(GoogleLoginService.class);
 
     @Before
     public void setUp() throws Exception {
         registerExtensionPoint(GoogleLoginListener.EP_NAME, GoogleLoginListener.class);
         registerService(GoogleLoginService.class, mockLoginService);
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-        LoggedErrorProcessor.setNewInstance(mock(LoggedErrorProcessor.class));
-        Logger.setFactory(TestLoggerFactory.class);
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-        LoggedErrorProcessor.restoreDefaultProcessor();
     }
 
     @Test


### PR DESCRIPTION
This test was relying on @BeforeClass to properly inject the TestLoggerFactory so that the log.error statement (in the constructor called by the test) does not throw an assertion error - depending on the type of factory, it may or may not throw an error - TestLoggerFactory does not. 

Regardless, we are occasionally seeing test failures in jenkins still, so this mechanism may be flaky.

This refactors it by not doing a log.error in the constructor called by the test, and getting rid of the factory injection altogether.