### PR TITLE
Don't throw a runtime exception for missing artifact in deploy config

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -124,7 +124,6 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
 
     if (!(source instanceof AppEngineDeployable)) {
       callback.errorOccurred(GctBundle.message("appengine.deployment.invalid.source.error"));
-      throw new RuntimeException("Invalid deployment source selected for deployment");
     }
 
     if (CloudSdkService.getInstance().validateCloudSdk().contains(

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -124,6 +124,7 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
 
     if (!(source instanceof AppEngineDeployable)) {
       callback.errorOccurred(GctBundle.message("appengine.deployment.invalid.source.error"));
+      return null;
     }
 
     if (CloudSdkService.getInstance().validateCloudSdk().contains(

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelperTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelperTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.intellij.appengine.cloud;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -108,17 +107,15 @@ public class CloudSdkAppEngineHelperTest extends BasePluginTestCase {
   }
 
   @Test
-  public void testCreateDeployRunnerInvalidDeploymentSourceType_throwsException() {
-    try {
-      helper.createDeployRunner(
-          loggingHandler,
-          new SimpleDeploymentSource(),
-          deploymentConfiguration,
-          callback);
-      fail("Expected RuntimeException");
-    } catch (RuntimeException re) {
-      verify(callback, times(1)).errorOccurred("Invalid deployment source.");
-    }
+  public void testCreateDeployRunnerInvalidDeploymentSourceType_returnsNull() {
+    Runnable runner = helper.createDeployRunner(
+        loggingHandler,
+        new SimpleDeploymentSource(),
+        deploymentConfiguration,
+        callback);
+
+    assertNull(runner);
+    verify(callback, times(1)).errorOccurred("Invalid deployment source.");
   }
 
   @Test


### PR DESCRIPTION
fixes #1428 

We shouldn't be throwing an exception here as this occurs when migrating from the old plugin. Instead the user is now shown this in the console output for the deployment:

![image](https://cloud.githubusercontent.com/assets/1735744/25813443/8e1f1e8a-33e7-11e7-8aef-02c709b2efd4.png)

Upon editing the deploy config and filling in all the details, the deploy works as expected.
