### PR TITLE
Fixes for IJ 2017.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,10 +57,10 @@ subprojects {
     intellij {
         type = ideaEdition
         version = ideaVersion
-        updateSinceUntilBuild = true
+        updateSinceUntilBuild = false
         downloadSources = true
         sandboxDirectory = "${rootProject.buildDir}/idea-sandbox"
-//        intellijRepo = "https://storage.googleapis.com/cloud-tools-for-java-team-kokoro-build-cache/idea-distributions"
+        intellijRepo = "https://storage.googleapis.com/cloud-tools-for-java-team-kokoro-build-cache/idea-distributions"
         publish {
             username System.getenv('IJ_REPO_USERNAME')
             password System.getenv('IJ_REPO_PASSWORD')

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ subprojects {
         updateSinceUntilBuild = true
         downloadSources = true
         sandboxDirectory = "${rootProject.buildDir}/idea-sandbox"
-        intellijRepo = "https://storage.googleapis.com/cloud-tools-for-java-team-kokoro-build-cache/idea-distributions"
+//        intellijRepo = "https://storage.googleapis.com/cloud-tools-for-java-team-kokoro-build-cache/idea-distributions"
         publish {
             username System.getenv('IJ_REPO_USERNAME')
             password System.getenv('IJ_REPO_PASSWORD')

--- a/google-account-plugin/resources/META-INF/plugin.xml
+++ b/google-account-plugin/resources/META-INF/plugin.xml
@@ -18,8 +18,9 @@
   <id>com.google.gct.login</id>
   <name>Google Account</name>
   <vendor>Google</vendor>
-  <!-- "version" set by gradle-intellij-plugin -->
-  <!-- "idea-version since-build" set by gradle-intellij-plugin -->
+  <!-- "idea-version since-build" set to cover 2017.1 - 2017.2 -->
+  <!-- Set manually because the gradle-intellij-plugin cannot span across major release versions -->
+  <idea-version since-build="171.3780" until-build="172.*"/>
 
   <description>
     Provides Google account setting and authentication for IntelliJ plugins that need it.

--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -29,8 +29,9 @@
     </html>]]>
   </description>
   <vendor>Google</vendor>
-  <!-- "version" set by gradle-intellij-plugin -->
-  <!-- "idea-version since-build" set by gradle-intellij-plugin -->
+  <!-- "idea-version since-build" set to cover 2017.1 - 2017.2 -->
+  <!-- Set manually because the gradle-intellij-plugin cannot span across major release versions -->
+  <idea-version since-build="171.3780" until-build="172.*"/>
 
   <change-notes>
     <![CDATA[

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineStandardMavenLibrary.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AppEngineStandardMavenLibrary.java
@@ -25,7 +25,6 @@ import com.intellij.openapi.roots.DependencyScope;
 import org.apache.commons.lang.WordUtils;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.utils.library.RepositoryLibraryProperties;
-import org.jetbrains.idea.maven.utils.library.RepositoryUtils;
 
 import java.util.Arrays;
 
@@ -39,28 +38,27 @@ public enum AppEngineStandardMavenLibrary {
       DependencyScope.PROVIDED),
   JSTL(
       GctBundle.message("appengine.library.jstl.api.name"),
-      new RepositoryLibraryProperties("javax.servlet", "jstl", RepositoryUtils.ReleaseVersionId),
-      DependencyScope.PROVIDED),
+      new RepositoryLibraryProperties("javax.servlet", "jstl",
+          AppEngineStandardMavenLibrary.RELEASE_VERSION_ID), DependencyScope.PROVIDED),
   APP_ENGINE_API(
       GctBundle.message("appengine.library.app.engine.api.name"),
       new RepositoryLibraryProperties("com.google.appengine", "appengine-api-1.0-sdk",
-          RepositoryUtils.ReleaseVersionId),
-      DependencyScope.COMPILE),
+          AppEngineStandardMavenLibrary.RELEASE_VERSION_ID), DependencyScope.COMPILE),
   ENDPOINTS(
       GctBundle.message("appengine.library.endpoints.api.name"),
       new RepositoryLibraryProperties("com.google.appengine", "appengine-endpoints",
-          RepositoryUtils.ReleaseVersionId),
-      DependencyScope.COMPILE),
+          AppEngineStandardMavenLibrary.RELEASE_VERSION_ID), DependencyScope.COMPILE),
   OBJECTIFY(
       GctBundle.message("appengine.library.objectify.api.name"),
       new RepositoryLibraryProperties("com.googlecode.objectify", "objectify",
-          RepositoryUtils.ReleaseVersionId),
-      DependencyScope.COMPILE);
+          AppEngineStandardMavenLibrary.RELEASE_VERSION_ID), DependencyScope.COMPILE);
 
   private final String displayName;
   // TODO(paflynn): RepositoryLibraryProperties is a mutable type and should not be used in an enum.
   private final RepositoryLibraryProperties libraryProperties;
   private final DependencyScope scope;
+
+  private static final String RELEASE_VERSION_ID = "RELEASE";
 
   AppEngineStandardMavenLibrary(String displayName, RepositoryLibraryProperties libraryProperties,
       DependencyScope scope) {

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/CloudDebugProcessStateCollectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/CloudDebugProcessStateCollectorTest.java
@@ -185,8 +185,6 @@ public class CloudDebugProcessStateCollectorTest extends BasePluginTestCase {
   private Project createProject(int inProgressDebugSessions,
                                 int backgroundListeningDebugsSessions,
                                 int notListeningDebugSessions) {
-    Project project = mock(Project.class);
-
     XDebuggerManager debuggerManager = mock(XDebuggerManager.class);
     XDebugSession[] debugSessions = new XDebugSession[inProgressDebugSessions];
     List<RunnerAndConfigurationSettings> allRunnerSettings =
@@ -198,7 +196,8 @@ public class CloudDebugProcessStateCollectorTest extends BasePluginTestCase {
     }
 
     when(debuggerManager.getDebugSessions()).thenReturn(debugSessions);
-    when(project.getComponent(XDebuggerManager.class)).thenReturn(debuggerManager);
+    applicationContainer.unregisterComponent(XDebuggerManager.class.getName());
+    registerService(XDebuggerManager.class, debuggerManager);
 
     for (int i = 0; i < backgroundListeningDebugsSessions; i++) {
       createBackgroundListeningDebugSettings(allRunnerSettings);
@@ -209,8 +208,9 @@ public class CloudDebugProcessStateCollectorTest extends BasePluginTestCase {
     }
 
     RunManager runManager = mock(RunManager.class);
-    when(project.getComponent(RunManager.class)).thenReturn(runManager);
     when(runManager.getAllSettings()).thenReturn(allRunnerSettings);
+    applicationContainer.unregisterComponent(RunManager.class.getName());
+    registerService(RunManager.class, runManager);
 
     return project;
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 ideaEdition = IC
-ideaVersion = 2017.1
+ideaVersion = 172.2103.15
 javaVersion = 1.8
 ijPluginRepoChannel = alpha
 version = 17.2.6_2017-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 ideaEdition = IC
-ideaVersion = 172.2103.15
+ideaVersion = 2017.1
 javaVersion = 1.8
 ijPluginRepoChannel = alpha
 version = 17.2.6_2017-SNAPSHOT


### PR DESCRIPTION
Updates for Intellij 2017.2

These changes _are_ backwards compatible with 2017.1.

We need to decide if we release this as:

1) A new branch / release targeting 2017.2 EAP and up, keeping the 2017.1 release as is. This release would then target a range:   `<idea-version since-build="172.2103" until-build="172.*"/>` which is 2017.2 EAP and up: this is how its currently configured in this PR. If we do this, then we'd need to upload the IJ binary to the GCS so I can comment the `intellijRepo` line back in.

2) Merge this into the 2017 branch and create a new 2017 release (this will work because it backwards compatible). Caveat: we'd have to update the version to range from 2017.1 to 2017.2*; there is no way with the gradle intellij plugin to have a since/until versioning scheme that spans major releases, so we'd have to disable the auto versioning and hardcode this range into the plugin.xml's.

