### PR TITLE
Convert the local run configuration type so that migration happens only once

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/migration/AppEngineRunConfigurationConverter.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/migration/AppEngineRunConfigurationConverter.java
@@ -40,10 +40,15 @@ public class AppEngineRunConfigurationConverter
       .put("google-app-engine-deploy", "gcp-app-engine-deploy")
       .build();
 
+  private static ImmutableMap<String, String> legacyLocalRunTypeToNewType
+      = ImmutableMap.<String, String>builder()
+      .put("GoogleAppEngineDevServer", "gcp-app-engine-local-run")
+      .build();
+
   private Predicate<Element> isLegacyDeployConfiguration
       = element -> legacyDeployTypeToNewType.containsKey(element.getAttributeValue("type"));
   private Predicate<Element> isLegacyLocalRunConfiguration
-      = element -> "GoogleAppEngineDevServer".equals(element.getAttributeValue("type"));
+      = element -> legacyLocalRunTypeToNewType.containsKey(element.getAttributeValue("type"));
 
   @Override
   public boolean isConversionNeeded(RunManagerSettings runManagerSettings) {
@@ -70,7 +75,12 @@ public class AppEngineRunConfigurationConverter
   }
 
   private void processLocalRunConfigurations(Stream<? extends Element> localRunConfigurations) {
-    localRunConfigurations.forEach(this::updateName);
+    localRunConfigurations
+        .forEach(element -> {
+          element.setAttribute("type",
+              legacyLocalRunTypeToNewType.get(element.getAttributeValue("type")));
+          updateName(element);
+        });
   }
 
   private void updateName(Element element) {

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/migration/AppEngineRunConfigurationConverterTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/migration/AppEngineRunConfigurationConverterTest.java
@@ -55,6 +55,16 @@ public class AppEngineRunConfigurationConverterTest extends PlatformTestCase {
     assertTrue(converter.isConversionNeeded(runManagerSettings));
   }
 
+  public void testConversionIsNotNeeded_whenNewRunConfigsPresent() {
+    Element element = mock(Element.class);
+    when(element.getAttributeValue("type")).thenReturn("gcp-app-engine-local-run");
+
+    Collection legacyConfig = Collections.singletonList(element);
+    when(runManagerSettings.getRunConfigurations()).thenReturn(legacyConfig);
+
+    assertFalse(converter.isConversionNeeded(runManagerSettings));
+  }
+
   public void testProcessDeployConfig() throws CannotConvertException {
     Element element = mock(Element.class);
     when(element.getAttributeValue("type")).thenReturn("google-app-engine-deploy");
@@ -77,6 +87,7 @@ public class AppEngineRunConfigurationConverterTest extends PlatformTestCase {
     when(runManagerSettings.getRunConfigurations()).thenReturn(legacyConfig);
 
     converter.process(runManagerSettings);
+    verify(element).setAttribute("type", "gcp-app-engine-local-run");
     verify(element).setAttribute("name", "My Old Run Name (migrated)");
   }
 }

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/run/AppEngineServerConfigurationType.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/run/AppEngineServerConfigurationType.java
@@ -114,6 +114,6 @@ public class AppEngineServerConfigurationType extends J2EEConfigurationType {
   @NotNull
   @Override
   public String getId() {
-    return "GoogleAppEngineDevServer";
+    return "gcp-app-engine-local-run";
   }
 }


### PR DESCRIPTION
fixes #1479 

The problem before was that the check that determines if migration of the local run config is needed was based on the "type" attribute of the run config which previously was the same between the old plugin on this plugin. The migration wasn't converting the type causing this to get triggered over an over again.

The fix is to not just update the name, but also migrate the type to a new key.