### PR TITLE
Fixes user icon size at higher DPI scales

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/GoogleLoginAction.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/GoogleLoginAction.java
@@ -20,31 +20,27 @@ import com.google.cloud.tools.intellij.login.CredentialedUser;
 import com.google.cloud.tools.intellij.login.Services;
 import com.google.cloud.tools.intellij.login.util.AccountMessageBundle;
 
-import com.intellij.openapi.actionSystem.ActionToolbar;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.actionSystem.RightAlignedToolbarAction;
-import com.intellij.openapi.actionSystem.ex.CustomComponentAction;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.ui.popup.ComponentPopupBuilder;
 import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
-import com.intellij.ui.awt.RelativePoint;
+import com.intellij.util.ui.JBUI;
 
 import java.awt.Image;
-import java.awt.Point;
 
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 
-/**
- * Action to open the Google Login panel.
- */
+/** Action to open the Google Login panel. */
 public class GoogleLoginAction extends AnAction implements DumbAware, RightAlignedToolbarAction {
 
-  private static final String SIGN_IN_MESSAGE = AccountMessageBundle.message(
-      "login.toolbar.button.sign.in.text");
+  private static final String SIGN_IN_MESSAGE =
+      AccountMessageBundle.message("login.toolbar.button.sign.in.text");
+  private static final int ICON_SIZE = 16;
 
   /** Returns a new instance with the icon set to {@link GoogleLoginIcons#DEFAULT_USER_AVATAR}. */
   public GoogleLoginAction() {
@@ -69,15 +65,14 @@ public class GoogleLoginAction extends AnAction implements DumbAware, RightAlign
       if (image == null) {
         presentation.setIcon(GoogleLoginIcons.DEFAULT_USER_AVATAR);
       } else {
-        Image scaledImage = image.getScaledInstance(16, 16, Image.SCALE_SMOOTH);
+        int size = (int) JBUI.pixScale(ICON_SIZE);
+        Image scaledImage = image.getScaledInstance(size, size, Image.SCALE_SMOOTH);
         presentation.setIcon(new ImageIcon(scaledImage));
       }
     }
   }
 
-  /**
-   * Opens up the Google Login panel as a popup.
-   */
+  /** Opens up the Google Login panel as a popup. */
   private static void showPopup(AnActionEvent event) {
     GoogleLoginUsersPanel usersPanel = new GoogleLoginUsersPanel();
     ComponentPopupBuilder popupBuilder =


### PR DESCRIPTION
Fixes #1391.

Can anyone verify this on a HiDPI monitor? I can't locally verify but judging by the code in the `JBUI.pixScale()` method, it should fix the issue.

**Problem:** The user's image is scaled manually to 16x16, regardless of the calculated pixel scale (which takes into account user settings and system settings).

**Solution:** Use the provided `JBUI.pixScale()` method to determine the appropriate size of this icon before scaling it down.