### PR TITLE
Null safety when restoring configs from null flex module

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
@@ -215,8 +215,12 @@ public final class AppEngineFlexibleDeploymentEditor extends
   protected void resetEditorFrom(@NotNull AppEngineDeploymentConfiguration configuration) {
     commonConfig.resetEditorFrom(configuration);
 
-    appYamlCombobox.setSelectedItem(
-        AppEngineFlexibleFacet.getFacetByModuleName(configuration.getModuleName(), project));
+    if (!StringUtils.isEmpty(configuration.getModuleName())) {
+      appYamlCombobox.setSelectedItem(
+          AppEngineFlexibleFacet.getFacetByModuleName(configuration.getModuleName(), project));
+    } else {
+      appYamlCombobox.setSelectedIndex(-1);
+    }
     archiveSelector.setText(configuration.getUserSpecifiedArtifactPath());
 
     toggleDockerfileSection();

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
@@ -288,6 +288,11 @@ public class AppEngineFlexibleDeploymentEditorTest extends PlatformTestCase {
     assertEquals(customModuleFacet, editor.getAppYamlCombobox().getSelectedItem());
   }
 
+  public void testFlexibleConfig_unselectedWhenNullPersistedConfig() {
+    editor.resetEditorFrom(templateConfig);
+    assertNull(editor.getAppYamlCombobox().getSelectedItem());
+  }
+
   @Override
   public void tearDown() throws Exception {
     editor.getAppYamlCombobox().removeAllItems();

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
@@ -289,6 +289,7 @@ public class AppEngineFlexibleDeploymentEditorTest extends PlatformTestCase {
   }
 
   public void testFlexibleConfig_unselectedWhenNullPersistedConfig() {
+    templateConfig.setModuleName(null);
     editor.resetEditorFrom(templateConfig);
     assertNull(editor.getAppYamlCombobox().getSelectedItem());
   }


### PR DESCRIPTION
fixes #1498 

If the module name is not stored, then set the dropdown to be unselected