### PR TITLE
Hides app.yaml edit (facet link) button when no app.yaml is selected

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
@@ -132,6 +132,7 @@ public final class AppEngineFlexibleDeploymentEditor extends
     appYamlCombobox.addItemListener(event -> {
       toggleDockerfileSection();
       resetRuntimeDisplay();
+      toggleYamlEditButton();
     });
     appYamlCombobox.setRenderer(
         new ListCellRendererWrapper<AppEngineFlexibleFacet>() {
@@ -158,7 +159,8 @@ public final class AppEngineFlexibleDeploymentEditor extends
   private void openModuleSettings() {
     AppEngineFlexibleFacet flexFacet = ((AppEngineFlexibleFacet) appYamlCombobox.getSelectedItem());
 
-    if (ModulesConfigurator.showFacetSettingsDialog(flexFacet, null /* tabNameToSelect */)) {
+    if (flexFacet != null
+        && ModulesConfigurator.showFacetSettingsDialog(flexFacet, null /* tabNameToSelect */)) {
       // The user may have updated the configuration, so we need to refresh it here too.
       reloadAppYamls(project);
       appYamlCombobox.setSelectedItem(flexFacet);
@@ -360,6 +362,14 @@ public final class AppEngineFlexibleDeploymentEditor extends
   }
 
   /**
+   * If there is no app.yaml selected (the dropdown selection is empty) then we want to hide the
+   * edit button since there is no associated facet to link to.
+   */
+  private void toggleYamlEditButton() {
+    editAppYamlButton.setVisible(appYamlCombobox.getSelectedItem() != null);
+  }
+
+  /**
    * Checks if a configuration file is valid by checking if it exists and is a regular file.
    */
   private boolean isValidConfigurationFile(String path) {
@@ -441,6 +451,11 @@ public final class AppEngineFlexibleDeploymentEditor extends
   @VisibleForTesting
   JPanel getDockerDirectoryPanel() {
     return dockerDirectoryPanel;
+  }
+
+  @VisibleForTesting
+  JButton getEditAppYamlButton() {
+    return editAppYamlButton;
   }
 
   @VisibleForTesting

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
@@ -294,6 +294,20 @@ public class AppEngineFlexibleDeploymentEditorTest extends PlatformTestCase {
     assertNull(editor.getAppYamlCombobox().getSelectedItem());
   }
 
+  public void testAppYamlEditButton_visibleWhenAppYamlSelected() {
+    templateConfig.setModuleName(javaModule.getName());
+    editor.resetEditorFrom(templateConfig);
+
+    assertTrue(editor.getEditAppYamlButton().isVisible());
+  }
+
+  public void testAppYamlEditButton_hiddenWhenNoAppYamlSelected() {
+    templateConfig.setModuleName(null);
+    editor.resetEditorFrom(templateConfig);
+
+    assertFalse(editor.getEditAppYamlButton().isVisible());
+  }
+
   @Override
   public void tearDown() throws Exception {
     editor.getAppYamlCombobox().removeAllItems();


### PR DESCRIPTION
Part of a few fixes for #1500 

This one hides the edit button when there is no app.yaml selected in the dropdown

no app.yaml:
![image](https://user-images.githubusercontent.com/1735744/27091143-49013c72-502d-11e7-9a34-620c83efbc9c.png)

app.yaml selected:
![image](https://user-images.githubusercontent.com/1735744/27091151-4e293a06-502d-11e7-972a-2dac4cdae68b.png)


An app.yaml may not be selected if there is no persisted config referencing it (indirectly via `AppEngineDeploymentConfiguration#getModuleName`)