### PR TITLE
Clean up flex deploy UI management

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
@@ -133,6 +133,7 @@ public final class AppEngineFlexibleDeploymentEditor extends
       toggleDockerfileSection();
       resetRuntimeDisplay();
       toggleYamlEditButton();
+      updateServiceName();
     });
     appYamlCombobox.setRenderer(
         new ListCellRendererWrapper<AppEngineFlexibleFacet>() {
@@ -154,6 +155,8 @@ public final class AppEngineFlexibleDeploymentEditor extends
 
     updateSelectors();
     toggleDockerfileSection();
+    toggleYamlEditButton();
+    updateServiceName();
   }
 
   private void openModuleSettings() {
@@ -224,9 +227,6 @@ public final class AppEngineFlexibleDeploymentEditor extends
       appYamlCombobox.setSelectedIndex(-1);
     }
     archiveSelector.setText(configuration.getUserSpecifiedArtifactPath());
-
-    toggleDockerfileSection();
-    updateServiceName();
   }
 
   @Override

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguratorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguratorTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.intellij.appengine.cloud;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.when;
 
@@ -67,6 +68,7 @@ public class AppEngineDeploymentConfiguratorTest extends BasePluginTestCase {
         .thenReturn("service");
     when(projectService.getFlexibleRuntimeFromAppYaml(isA(String.class))).thenReturn(
         Optional.of(FlexibleRuntime.JAVA));
+    when(projectService.getServiceNameFromAppYaml(anyString())).thenReturn(Optional.empty());
     when(project.getComponent(ModuleManager.class)).thenReturn(moduleManager);
     when(moduleManager.getModules()).thenReturn(new Module[]{module});
     when(module.getComponent(FacetManager.class)).thenReturn(facetManager);

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
@@ -67,8 +67,8 @@ public class AppEngineFlexibleDeploymentEditorTest extends PlatformTestCase {
   public void setUp() throws Exception {
     super.setUp();
 
-    customYaml = createTempFile("custom.yaml", "runtime: custom\nservice: flexService");
-    javaYaml = createTempFile("java.yaml", "runtime: java");
+    customYaml = createTempFile("custom.yaml", "runtime: custom\nservice: customService");
+    javaYaml = createTempFile("java.yaml", "runtime: java\nservice: javaService");
     dockerfile = createTempFile("Dockerfile", "FROM gcr.io/google_appengine/jetty\n"
         + "ADD target.war $JETTY_BASE/webapps/root.war");
 
@@ -306,6 +306,19 @@ public class AppEngineFlexibleDeploymentEditorTest extends PlatformTestCase {
     editor.resetEditorFrom(templateConfig);
 
     assertFalse(editor.getEditAppYamlButton().isVisible());
+  }
+
+  public void testServiceNameIsUpdated_whenAppYamlSelectionChanges() {
+    templateConfig.setModuleName(javaModule.getName());
+    editor.resetEditorFrom(templateConfig);
+
+    assertEquals("javaService", editor.getCommonConfig().getServiceLabel().getText());
+
+    // Now update to custom service
+    AppEngineFlexibleFacet facet = AppEngineFlexibleFacet.getFacetByModule(customModule);
+    editor.getAppYamlCombobox().setSelectedItem(facet);
+
+    assertEquals("customService", editor.getCommonConfig().getServiceLabel().getText());
   }
 
   @Override


### PR DESCRIPTION
More minor refactoring after flex deployment UX updates.

- Remove UX toggling calls from `resetEditorFrom` as this method should focus on deserializing state only. This also fixes a previously duplicated call to toggle the Dockerfile panel
- Fixes missing invocation of update to the service label (+ test coverage).