### PR TITLE
Fix indentation of runtime / dockerfile sections in deploy ux

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="0" y="0" width="1168" height="667"/>
+      <xy x="0" y="0" width="1168" height="697"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -101,7 +101,7 @@
           </grid>
           <nested-form id="3413a" form-file="com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleRuntimePanel.form" binding="runtimePanel">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="1" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </nested-form>
           <component id="35a0f" class="javax.swing.JComboBox" binding="appYamlCombobox">
@@ -113,7 +113,7 @@
           <grid id="3714c" binding="dockerDirectoryPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="1" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>


### PR DESCRIPTION
Simple indentation fix to make things consistent with the flex facet ux.

Before:
![image](https://user-images.githubusercontent.com/1735744/27299300-e3338996-54f9-11e7-8189-6b7ed5fb2974.png)

After:
![image](https://user-images.githubusercontent.com/1735744/27299284-d6ebe944-54f9-11e7-9e31-8b7e06f8fc14.png)
