### PR TITLE
Fix for npe on findFirst with null facet

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
@@ -54,6 +54,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import javax.swing.JComboBox;
 import javax.swing.JList;
@@ -179,10 +180,13 @@ public class AppEngineUtil {
       @NotNull Project project, @NotNull Artifact artifact) {
     // TODO(joaomartins): Find out why the GAE facet isn't being added to Gradle projects.
     // https://github.com/GoogleCloudPlatform/gcloud-intellij/issues/835
-    return ArtifactUtil.getModulesIncludedInArtifacts(Collections.singletonList(artifact), project)
+    return ArtifactUtil
+        .getModulesIncludedInArtifacts(Collections.singletonList(artifact), project)
         .stream()
         .map(AppEngineStandardFacet::getAppEngineFacetByModule)
-        .findFirst();
+        .map(Optional::ofNullable)
+        .findFirst()
+        .flatMap(Function.identity());
   }
 
   /**

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
@@ -180,8 +180,7 @@ public class AppEngineUtil {
       @NotNull Project project, @NotNull Artifact artifact) {
     // TODO(joaomartins): Find out why the GAE facet isn't being added to Gradle projects.
     // https://github.com/GoogleCloudPlatform/gcloud-intellij/issues/835
-    return ArtifactUtil
-        .getModulesIncludedInArtifacts(Collections.singletonList(artifact), project)
+    return ArtifactUtil.getModulesIncludedInArtifacts(Collections.singletonList(artifact), project)
         .stream()
         .map(AppEngineStandardFacet::getAppEngineFacetByModule)
         .map(Optional::ofNullable)

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/util/AppEngineUtilTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/util/AppEngineUtilTest.java
@@ -74,12 +74,12 @@ public class AppEngineUtilTest extends PlatformTestCase {
     ArchivePackagingElement archivePackagingElement =
         new ArchivePackagingElement(module.getName() + ".jar");
 
-    final PackagingElement<?> moduleOutput =
+    PackagingElement<?> moduleOutput =
         PackagingElementFactory.getInstance().createModuleOutput(module);
     archivePackagingElement.addFirstChild(moduleOutput);
-    final ModifiableArtifact artifact =
+    ModifiableArtifact artifact =
         modifiableArtifactModel.addArtifact(
-            "Project Artifacts", JarArtifactType.getInstance(), archivePackagingElement);
+            "test-artifact", JarArtifactType.getInstance(), archivePackagingElement);
     artifact.setBuildOnMake(true);
     return artifact;
   }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/util/AppEngineUtilTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/util/AppEngineUtilTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.util;
+
+import com.google.cloud.tools.intellij.appengine.facet.standard.AppEngineStandardFacet;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.packaging.artifacts.Artifact;
+import com.intellij.packaging.artifacts.ArtifactManager;
+import com.intellij.packaging.artifacts.ModifiableArtifact;
+import com.intellij.packaging.artifacts.ModifiableArtifactModel;
+import com.intellij.packaging.elements.PackagingElement;
+import com.intellij.packaging.elements.PackagingElementFactory;
+import com.intellij.packaging.impl.artifacts.ArtifactManagerImpl;
+import com.intellij.packaging.impl.artifacts.JarArtifactType;
+import com.intellij.packaging.impl.elements.ArchivePackagingElement;
+import com.intellij.testFramework.PlatformTestCase;
+
+import java.util.Optional;
+
+/** Tests for {@link AppEngineUtil}. */
+public class AppEngineUtilTest extends PlatformTestCase {
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+  }
+
+  public void testMissingAppEngineStandardFacet() {
+    Optional<AppEngineStandardFacet> facet =
+        AppEngineUtil.findAppEngineStandardFacet(getProject(), createArtifactWithModule());
+    assertFalse(facet.isPresent());
+  }
+
+  private Artifact createArtifactWithModule() {
+    Module module = createModule("test");
+    ArtifactManager artifactManager = ArtifactManagerImpl.getInstance(getProject());
+    ModifiableArtifactModel modifiableArtifactModel = artifactManager.createModifiableModel();
+    ArchivePackagingElement archivePackagingElement =
+        new ArchivePackagingElement(module.getName() + ".jar");
+
+    final PackagingElement<?> moduleOutput =
+        PackagingElementFactory.getInstance().createModuleOutput(module);
+    archivePackagingElement.addFirstChild(moduleOutput);
+    final ModifiableArtifact artifact =
+        modifiableArtifactModel.addArtifact(
+            "Project Artifacts", JarArtifactType.getInstance(), archivePackagingElement);
+    artifact.setBuildOnMake(true);
+    return artifact;
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/util/AppEngineUtilTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/util/AppEngineUtilTest.java
@@ -18,6 +18,8 @@ package com.google.cloud.tools.intellij.appengine.util;
 
 import com.google.cloud.tools.intellij.appengine.facet.standard.AppEngineStandardFacet;
 
+import com.intellij.facet.FacetManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.packaging.artifacts.Artifact;
 import com.intellij.packaging.artifacts.ArtifactManager;
@@ -35,9 +37,13 @@ import java.util.Optional;
 /** Tests for {@link AppEngineUtil}. */
 public class AppEngineUtilTest extends PlatformTestCase {
 
+  private Module module;
+
   @Override
   protected void setUp() throws Exception {
     super.setUp();
+
+    module = createModule("testModule");
   }
 
   public void testMissingAppEngineStandardFacet() {
@@ -46,8 +52,23 @@ public class AppEngineUtilTest extends PlatformTestCase {
     assertFalse(facet.isPresent());
   }
 
+  public void testPresentAppEngineStandardFacet() {
+    ApplicationManager.getApplication()
+        .runWriteAction(
+            () -> {
+              FacetManager.getInstance(module)
+                  .addFacet(
+                      AppEngineStandardFacet.getFacetType(),
+                      "standard facet",
+                      null /* underlyingFacet */);
+            });
+
+    Optional<AppEngineStandardFacet> facet =
+        AppEngineUtil.findAppEngineStandardFacet(getProject(), createArtifactWithModule());
+    assertTrue(facet.isPresent());
+  }
+
   private Artifact createArtifactWithModule() {
-    Module module = createModule("test");
     ArtifactManager artifactManager = ArtifactManagerImpl.getInstance(getProject());
     ModifiableArtifactModel modifiableArtifactModel = artifactManager.createModifiableModel();
     ArchivePackagingElement archivePackagingElement =


### PR DESCRIPTION
Fixes #1525 

Fix for a few post-release reports we've seen. The problem is that findFirst() throws an NPE if the first element found in the stream is null, and the app engine standard facet could potentially be null.

To reproduce the error: open an ae standard project and then delete the standard facet. The checkConfiguration() method for the local run config (which is called periodically) will then try to load the standard facet (which is missing) and then throw an NPE.

After the fix, there is no error, and the run config shows up in an errored state as expected:

<img width="314" alt="screen shot 2017-06-29 at 11 21 21 am" src="https://user-images.githubusercontent.com/1735744/27695540-3100cf6a-5cbd-11e7-91d1-85bd789f8cb7.png">
