### PR TITLE
Revert "- sudo install gothub. (#1520)"

### DIFF
--- a/kokoro/ubuntu/release.sh
+++ b/kokoro/ubuntu/release.sh
@@ -62,7 +62,7 @@ if [ "$SOURCE_VERSION" != "$TAG_VERSION" ]
 fi
 
 echo "Installing itchio/gothub.."
-sudo go get github.com/itchio/gothub || { echo "Failed to install gothub"; exit 1; }
+go get github.com/itchio/gothub || { echo "Failed to install gothub"; exit 1; }
 echo "Building plugins"
 ./gradlew buildPlugin
 


### PR DESCRIPTION
This reverts commit 477cd846cfcfc34183ffcd8902fe1d0d36b06776.

This commit is causing the release to fail completely. Reverting this will at least get the artifacts uploaded to JB repositories. (There is still the issue of uploading them to GitHub)