### PR TITLE
Handle null breakpoint timestamp before parsing

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/CloudDebugProcess.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/CloudDebugProcess.java
@@ -335,8 +335,14 @@ public class CloudDebugProcess extends XDebugProcess implements CloudBreakpointL
   private void navigateToBreakpoint(@NotNull Breakpoint target) {
     Date snapshotTime;
     try {
-      snapshotTime = ISODateTimeFormat.dateTime().parseDateTime(target.getFinalTime()).toDate();
+      if (target.getFinalTime() == null) {
+        LOG.warn("Could not resolve final time from breakpoint.");
+        snapshotTime = new Date();
+      } else {
+        snapshotTime = ISODateTimeFormat.dateTime().parseDateTime(target.getFinalTime()).toDate();
+      }
     } catch (IllegalArgumentException iae) {
+      LOG.warn("Could not parse breakpoint timestamp using ISO8601.");
       snapshotTime = new Date();
     }
 


### PR DESCRIPTION
fixes #1537 

I'm not sure what the root cause of why it was null in the first place, but since `Breakpoint#getFinalTime` is nullable, then the null should be handled to avoid NPE's during the parsing.