### PR TITLE
Remove EAR as acceptable AE artifact type

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/standard/AppEngineStandardWebIntegration.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/standard/AppEngineStandardWebIntegration.java
@@ -66,14 +66,11 @@ public abstract class AppEngineStandardWebIntegration {
   @NotNull
   public List<ArtifactType> getAppEngineTargetArtifactTypes() {
     return ContainerUtil
-        .packNullables(getAppEngineWebArtifactType(), getAppEngineApplicationArtifactType());
+        .packNullables(getAppEngineWebArtifactType());
   }
 
   @NotNull
   public abstract ArtifactType getAppEngineWebArtifactType();
-
-  @Nullable
-  public abstract ArtifactType getAppEngineApplicationArtifactType();
 
   @NotNull
   public abstract List<FrameworkSupportInModuleProvider.FrameworkDependency>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/standard/impl/AppEngineStandardCommunityWebIntegration.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/standard/impl/AppEngineStandardCommunityWebIntegration.java
@@ -74,12 +74,6 @@ public class AppEngineStandardCommunityWebIntegration extends AppEngineStandardW
 
   @Nullable
   @Override
-  public ArtifactType getAppEngineApplicationArtifactType() {
-    return null;
-  }
-
-  @Nullable
-  @Override
   public String getUnderlyingFrameworkTypeId() {
     return null;
   }

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineStandardUltimateWebIntegration.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineStandardUltimateWebIntegration.java
@@ -33,7 +33,6 @@ import com.intellij.ide.util.frameworkSupport.FrameworkRole;
 import com.intellij.ide.util.frameworkSupport.FrameworkSupportModel;
 import com.intellij.javaee.JavaeePersistenceDescriptorsConstants;
 import com.intellij.javaee.appServerIntegrations.ApplicationServer;
-import com.intellij.javaee.artifact.JavaeeArtifactUtil;
 import com.intellij.javaee.facet.JavaeeFrameworkSupportInfoCollector;
 import com.intellij.javaee.framework.JavaeeProjectCategory;
 import com.intellij.javaee.oss.server.JavaeePersistentData;
@@ -74,12 +73,6 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
   @Override
   public ArtifactType getAppEngineWebArtifactType() {
     return WebArtifactUtil.getInstance().getExplodedWarArtifactType();
-  }
-
-  @Nullable
-  @Override
-  public ArtifactType getAppEngineApplicationArtifactType() {
-    return JavaeeArtifactUtil.getInstance().getExplodedEarArtifactType();
   }
 
   @Override


### PR DESCRIPTION
fixes #1190 

Before this fix exploded ears were listed as valid artifact targets in the local run dev server config. After this, they are excluded:

Before
![image](https://user-images.githubusercontent.com/1735744/28026324-ac9a3590-6563-11e7-97f8-e5c340828e3e.png)

After
![image](https://user-images.githubusercontent.com/1735744/28026248-7b69a79e-6563-11e7-8909-c1deced467e9.png)
