### PR TITLE
More verbose output for nightly publish task

### DIFF
--- a/kokoro/ubuntu/nightly.sh
+++ b/kokoro/ubuntu/nightly.sh
@@ -42,4 +42,4 @@
 cd github/google-cloud-intellij
 
 echo "Publishing plugin to Jetbrains plugin repository nightly channel"
-./gradlew publishPlugin -PijPluginRepoChannel=nightly
+./gradlew publishPlugin -PijPluginRepoChannel=nightly --info


### PR DESCRIPTION
the nightly task is executing properly according to schedule, however the artifacts in the JB repo are not getting updated. I suspect its because the version hasn't changed. Adding --info for more output.