### PR TITLE
Fixes all error-prone errors and some compiler warnings.

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/GoogleLoginUsersPanel.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/GoogleLoginUsersPanel.java
@@ -64,8 +64,8 @@ public class GoogleLoginUsersPanel extends JPanel implements ListSelectionListen
       AccountMessageBundle.message("login.panel.sign.out.button.text");
   private static final int MAX_VISIBLE_ROW_COUNT = 3;
 
-  private JBList list;
-  private DefaultListModel listModel;
+  private JBList<UsersListItem> list;
+  private DefaultListModel<UsersListItem> listModel;
   private JButton signOutButton;
   private boolean valueChanged;
   private boolean ignoreSelection;
@@ -73,14 +73,14 @@ public class GoogleLoginUsersPanel extends JPanel implements ListSelectionListen
   /**
    * Initializes the user login panel.
    */
-  public GoogleLoginUsersPanel() {
+  GoogleLoginUsersPanel() {
     super(new BorderLayout());
 
     int indexToSelect = initializeUsers();
     final UsersListCellRenderer usersListCellRenderer = new UsersListCellRenderer();
 
     //Create the list that displays the users and put it in a scroll pane.
-    list = new JBList(listModel) {
+    list = new JBList<UsersListItem>(listModel) {
       @Override
       public Dimension getPreferredScrollableViewportSize() {
         int numUsers = listModel.size();
@@ -242,7 +242,7 @@ public class GoogleLoginUsersPanel extends JPanel implements ListSelectionListen
         signOutButton.setEnabled(true);
 
         // Make newly selected value the active value
-        UsersListItem selectedUser = (UsersListItem) listModel.get(list.getSelectedIndex());
+        UsersListItem selectedUser = listModel.get(list.getSelectedIndex());
         if (!selectedUser.isActiveUser()) {
           Services.getLoginService().setActiveUser(selectedUser.getUserEmail());
         }
@@ -269,7 +269,7 @@ public class GoogleLoginUsersPanel extends JPanel implements ListSelectionListen
 
   private int initializeUsers() {
     Map<String, CredentialedUser> allUsers = Services.getLoginService().getAllUsers();
-    listModel = new DefaultListModel();
+    listModel = new DefaultListModel<>();
 
     int activeUserIndex = allUsers.size();
     for (CredentialedUser user : allUsers.values()) {
@@ -285,7 +285,7 @@ public class GoogleLoginUsersPanel extends JPanel implements ListSelectionListen
     } else if ((activeUserIndex != 0) && (activeUserIndex < listModel.getSize())) {
       // Change order of elements in the list so that the
       // active user becomes the first element in the list
-      UsersListItem activeUser = (UsersListItem) listModel.remove(activeUserIndex);
+      UsersListItem activeUser = listModel.remove(activeUserIndex);
       listModel.add(0, activeUser);
       activeUserIndex = 0;
     }
@@ -314,7 +314,7 @@ public class GoogleLoginUsersPanel extends JPanel implements ListSelectionListen
         : MAX_VISIBLE_ROW_COUNT;
 
     for (int i = 0; i < max; i++) {
-      if (((UsersListItem) listModel.get(i)).isActiveUser()) {
+      if (listModel.get(i).isActiveUser()) {
         return true;
       }
     }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/NoUsersListItem.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/NoUsersListItem.java
@@ -16,13 +16,36 @@
 
 package com.google.cloud.tools.intellij.login.ui;
 
+import java.awt.Image;
+
 /**
  * A place holder for when no user exist. This allows us to create a customized panel
  * when no users exist.
  */
-public class NoUsersListItem {
+public class NoUsersListItem extends UsersListItem {
   public static final NoUsersListItem INSTANCE = new NoUsersListItem();
 
   private NoUsersListItem() {
+    super(null);
+  }
+
+  @Override
+  public String getUserEmail() {
+    return null;
+  }
+
+  @Override
+  public boolean isActiveUser() {
+    return false;
+  }
+
+  @Override
+  public String getUserName() {
+    return null;
+  }
+
+  @Override
+  public Image getUserPicture() {
+    return null;
   }
 }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/UsersListCellRenderer.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/UsersListCellRenderer.java
@@ -54,7 +54,7 @@ import javax.swing.UIManager;
  * A custom cell render for {@link GoogleLoginUsersPanel#list} that manages how each user item in
  * the Google Login panel would be displayed.
  */
-public class UsersListCellRenderer extends JComponent implements ListCellRenderer {
+public class UsersListCellRenderer extends JComponent implements ListCellRenderer<UsersListItem> {
 
   private static final String CLOUD_LABEL_TEXT = AccountMessageBundle
       .message("login.panel.play.console.link.text");
@@ -122,16 +122,16 @@ public class UsersListCellRenderer extends JComponent implements ListCellRendere
 
   @Nullable
   @Override
-  public Component getListCellRendererComponent(JList list, Object value, int index,
-      boolean isSelected, boolean cellHasFocus) {
-    if (value instanceof NoUsersListItem) {
+  public Component getListCellRendererComponent(
+      JList<? extends UsersListItem> list,
+      UsersListItem usersListItem,
+      int index,
+      boolean isSelected,
+      boolean cellHasFocus) {
+    if (usersListItem instanceof NoUsersListItem) {
       return createNoUserDisplay();
     }
-    if (!(value instanceof UsersListItem)) {
-      return null;
-    }
 
-    final UsersListItem usersListItem = (UsersListItem) value;
     final CredentialedUser activeUser = Services.getLoginService().getActiveUser();
     final boolean isActiveUserSelected =
         activeUser != null && usersListItem.getUserEmail().equals(activeUser.getEmail());

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployTest.java
@@ -50,8 +50,8 @@ public class AppEngineDeployTest {
 
     AppEngineDeploy.DeployOutput deployOutput =
         AppEngineDeploy.parseDeployOutput(jsonOutput);
-    assertEquals(deployOutput.getVersion(), "20160429t112518");
-    assertEquals(deployOutput.getService(), "default");
+    assertEquals("20160429t112518", deployOutput.getVersion());
+    assertEquals("default", deployOutput.getService());
   }
 
   @Test

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguratorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguratorTest.java
@@ -46,7 +46,7 @@ import java.util.Optional;
 @RunWith(MockitoJUnitRunner.class)
 public class AppEngineDeploymentConfiguratorTest extends BasePluginTestCase {
   @Mock
-  Project project;
+  Project myProject;
   @Mock
   AppEngineDeployable deployable;
   @Mock
@@ -64,12 +64,12 @@ public class AppEngineDeploymentConfiguratorTest extends BasePluginTestCase {
   public void setUp() throws MalformedYamlFileException {
     registerService(AppEngineProjectService.class, projectService);
 
-    when(projectService.getServiceNameFromAppEngineWebXml(project, deployable))
+    when(projectService.getServiceNameFromAppEngineWebXml(myProject, deployable))
         .thenReturn("service");
     when(projectService.getFlexibleRuntimeFromAppYaml(isA(String.class))).thenReturn(
         Optional.of(FlexibleRuntime.JAVA));
     when(projectService.getServiceNameFromAppYaml(anyString())).thenReturn(Optional.empty());
-    when(project.getComponent(ModuleManager.class)).thenReturn(moduleManager);
+    when(myProject.getComponent(ModuleManager.class)).thenReturn(moduleManager);
     when(moduleManager.getModules()).thenReturn(new Module[]{module});
     when(module.getComponent(FacetManager.class)).thenReturn(facetManager);
     when(facetManager.getFacetByType(AppEngineFlexibleFacetType.ID)).thenReturn(null);
@@ -78,7 +78,7 @@ public class AppEngineDeploymentConfiguratorTest extends BasePluginTestCase {
   @Test
   public void testCreateEditor_flexible() {
     when(deployable.getEnvironment()).thenReturn(AppEngineEnvironment.APP_ENGINE_FLEX);
-    AppEngineDeploymentConfigurator configurator = new AppEngineDeploymentConfigurator(project);
+    AppEngineDeploymentConfigurator configurator = new AppEngineDeploymentConfigurator(myProject);
 
     assertTrue(configurator.createEditor(deployable, server) instanceof AppEngineFlexibleDeploymentEditor);
   }
@@ -86,7 +86,7 @@ public class AppEngineDeploymentConfiguratorTest extends BasePluginTestCase {
   @Test
   public void testCreateEditor_standard() {
     when(deployable.getEnvironment()).thenReturn(AppEngineEnvironment.APP_ENGINE_STANDARD);
-    AppEngineDeploymentConfigurator configurator = new AppEngineDeploymentConfigurator(project);
+    AppEngineDeploymentConfigurator configurator = new AppEngineDeploymentConfigurator(myProject);
 
     assertTrue(configurator.createEditor(deployable, server) instanceof AppEngineStandardDeploymentEditor);
   }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguratorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguratorTest.java
@@ -44,33 +44,27 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.Optional;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AppEngineDeploymentConfiguratorTest extends BasePluginTestCase {
-  @Mock
-  Project myProject;
-  @Mock
-  AppEngineDeployable deployable;
-  @Mock
-  RemoteServer<AppEngineServerConfiguration> server;
-  @Mock
-  AppEngineProjectService projectService;
-  @Mock
-  ModuleManager moduleManager;
-  @Mock
-  Module module;
-  @Mock
-  FacetManager facetManager;
+public final class AppEngineDeploymentConfiguratorTest extends BasePluginTestCase {
+
+  @Mock private Project mockProject;
+  @Mock private AppEngineDeployable deployable;
+  @Mock private RemoteServer<AppEngineServerConfiguration> server;
+  @Mock private AppEngineProjectService projectService;
+  @Mock private ModuleManager moduleManager;
+  @Mock private Module module;
+  @Mock private FacetManager facetManager;
 
   @Before
   public void setUp() throws MalformedYamlFileException {
     registerService(AppEngineProjectService.class, projectService);
 
-    when(projectService.getServiceNameFromAppEngineWebXml(myProject, deployable))
+    when(projectService.getServiceNameFromAppEngineWebXml(mockProject, deployable))
         .thenReturn("service");
-    when(projectService.getFlexibleRuntimeFromAppYaml(isA(String.class))).thenReturn(
-        Optional.of(FlexibleRuntime.JAVA));
+    when(projectService.getFlexibleRuntimeFromAppYaml(isA(String.class)))
+        .thenReturn(Optional.of(FlexibleRuntime.JAVA));
     when(projectService.getServiceNameFromAppYaml(anyString())).thenReturn(Optional.empty());
-    when(myProject.getComponent(ModuleManager.class)).thenReturn(moduleManager);
-    when(moduleManager.getModules()).thenReturn(new Module[]{module});
+    when(mockProject.getComponent(ModuleManager.class)).thenReturn(moduleManager);
+    when(moduleManager.getModules()).thenReturn(new Module[] {module});
     when(module.getComponent(FacetManager.class)).thenReturn(facetManager);
     when(facetManager.getFacetByType(AppEngineFlexibleFacetType.ID)).thenReturn(null);
   }
@@ -78,16 +72,18 @@ public class AppEngineDeploymentConfiguratorTest extends BasePluginTestCase {
   @Test
   public void testCreateEditor_flexible() {
     when(deployable.getEnvironment()).thenReturn(AppEngineEnvironment.APP_ENGINE_FLEX);
-    AppEngineDeploymentConfigurator configurator = new AppEngineDeploymentConfigurator(myProject);
+    AppEngineDeploymentConfigurator configurator = new AppEngineDeploymentConfigurator(mockProject);
 
-    assertTrue(configurator.createEditor(deployable, server) instanceof AppEngineFlexibleDeploymentEditor);
+    assertTrue(
+        configurator.createEditor(deployable, server) instanceof AppEngineFlexibleDeploymentEditor);
   }
 
   @Test
   public void testCreateEditor_standard() {
     when(deployable.getEnvironment()).thenReturn(AppEngineEnvironment.APP_ENGINE_STANDARD);
-    AppEngineDeploymentConfigurator configurator = new AppEngineDeploymentConfigurator(myProject);
+    AppEngineDeploymentConfigurator configurator = new AppEngineDeploymentConfigurator(mockProject);
 
-    assertTrue(configurator.createEditor(deployable, server) instanceof AppEngineStandardDeploymentEditor);
+    assertTrue(
+        configurator.createEditor(deployable, server) instanceof AppEngineStandardDeploymentEditor);
   }
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/ServerToIDEFileResolverTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/ServerToIDEFileResolverTest.java
@@ -51,8 +51,8 @@ public class ServerToIDEFileResolverTest extends JavaCodeInsightFixtureTestCase 
     when(psiJavaFile.getPackageName()).thenReturn("com.java.package");
     when(psiJavaFile.getName()).thenReturn("Class.java");
     assertEquals(
-        ServerToIdeFileResolver.getCloudPathFromJavaFile(psiJavaFile),
-        "com/java/package/Class.java");
+        "com/java/package/Class.java",
+        ServerToIdeFileResolver.getCloudPathFromJavaFile(psiJavaFile));
   }
 
   // When searching for full file system path.

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/startup/CloudSdkVersionStartupCheckTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/startup/CloudSdkVersionStartupCheckTest.java
@@ -42,7 +42,7 @@ import java.nio.file.Path;
 public class CloudSdkVersionStartupCheckTest extends BasePluginTestCase {
 
   @Mock
-  Project project;
+  Project myProject;
 
   @Mock
   CloudSdkVersionNotifier cloudSdkVersionNotifier;
@@ -63,7 +63,7 @@ public class CloudSdkVersionStartupCheckTest extends BasePluginTestCase {
     Path mockPath = mock(Path.class);
 
     when(cloudSdkService.getSdkHomePath()).thenReturn(mockPath);
-    cloudSdkVersionStartupCheck.runActivity(project);
+    cloudSdkVersionStartupCheck.runActivity(myProject);
 
     verify(cloudSdkVersionNotifier, times(1)).notifyIfUnsupportedVersion();
   }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/startup/CloudSdkVersionStartupCheckTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/startup/CloudSdkVersionStartupCheckTest.java
@@ -35,21 +35,15 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.nio.file.Path;
 
-/**
- * Unit tests for {@link CloudSdkVersionStartupCheck}
- */
+/** Unit tests for {@link CloudSdkVersionStartupCheck} */
 @RunWith(MockitoJUnitRunner.class)
-public class CloudSdkVersionStartupCheckTest extends BasePluginTestCase {
+public final class CloudSdkVersionStartupCheckTest extends BasePluginTestCase {
 
-  @Mock
-  Project myProject;
+  @Mock private Project mockProject;
+  @Mock private CloudSdkVersionNotifier cloudSdkVersionNotifier;
+  @Mock private CloudSdkService cloudSdkService;
 
-  @Mock
-  CloudSdkVersionNotifier cloudSdkVersionNotifier;
-  @Mock
-  CloudSdkService cloudSdkService;
-
-  CloudSdkVersionStartupCheck cloudSdkVersionStartupCheck;
+  private CloudSdkVersionStartupCheck cloudSdkVersionStartupCheck;
 
   @Before
   public void setUp() {
@@ -63,7 +57,7 @@ public class CloudSdkVersionStartupCheckTest extends BasePluginTestCase {
     Path mockPath = mock(Path.class);
 
     when(cloudSdkService.getSdkHomePath()).thenReturn(mockPath);
-    cloudSdkVersionStartupCheck.runActivity(myProject);
+    cloudSdkVersionStartupCheck.runActivity(mockProject);
 
     verify(cloudSdkVersionNotifier, times(1)).notifyIfUnsupportedVersion();
   }

--- a/google-cloud-tools-plugin/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/server/run/AppEngineServerConfigurationTypeTest.java
+++ b/google-cloud-tools-plugin/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/server/run/AppEngineServerConfigurationTypeTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.intellij.appengine.server.run;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyCollectionOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,13 +25,12 @@ import com.google.cloud.tools.intellij.appengine.project.AppEngineAssetProvider;
 
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.xml.XmlFile;
 import com.intellij.testFramework.PlatformTestCase;
 
 import org.picocontainer.MutablePicoContainer;
-
-import java.util.Collection;
 
 /**
  * Tests for {@link AppEngineServerConfigurationType}.
@@ -54,7 +54,8 @@ public class AppEngineServerConfigurationTypeTest extends PlatformTestCase {
   }
 
   public void testIsApplicable_notAppEngineStandardApp() {
-    when(assetProvider.loadAppEngineStandardWebXml(any(Project.class), any(Collection.class)))
+    when(assetProvider.loadAppEngineStandardWebXml(
+            any(Project.class), anyCollectionOf(Module.class)))
         .thenReturn(null);
     AppEngineServerConfigurationType configurationType
         = AppEngineServerConfigurationType.getInstance();
@@ -64,7 +65,8 @@ public class AppEngineServerConfigurationTypeTest extends PlatformTestCase {
   }
 
   public void testIsApplicable_appEngineStandardApp() {
-    when(assetProvider.loadAppEngineStandardWebXml(any(Project.class), any(Collection.class)))
+    when(assetProvider.loadAppEngineStandardWebXml(
+            any(Project.class), anyCollectionOf(Module.class)))
         .thenReturn(mock(XmlFile.class));
 
     AppEngineServerConfigurationType configurationType


### PR DESCRIPTION
This cleans up the output of Gradle builds so it's not cluttered with ErrorProne errors or compiler warnings. Note that there are still many compiler warnings to take care of (mostly unchecked and deprecated warnings), but they aren't specifically called out in the build output because there are too many of them for the `google-account-plugin` and the `google-cloud-tools-plugin` modules.