### PR TITLE
Fixes test coverage on AppEngineDeploymentConfiguration

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
@@ -29,8 +29,6 @@ import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
 import com.intellij.remoteServer.util.CloudDeploymentNameConfiguration;
 import com.intellij.util.xmlb.annotations.Attribute;
 import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
 import org.apache.commons.lang.StringUtils;
@@ -213,26 +211,8 @@ public class AppEngineDeploymentConfiguration
    * @param stringPath the path to check
    */
   private static boolean isJarOrWar(String stringPath) {
-    try {
-      Path path = Paths.get(stringPath);
-      return !Files.isDirectory(path)
-          && (StringUtil.endsWithIgnoreCase(stringPath, ".jar")
-              || StringUtil.endsWithIgnoreCase(stringPath, ".war"));
-    } catch (InvalidPathException ipe) {
-      return false;
-    }
-  }
-
-  /**
-   * Returns true if the given path points to a valid, regular file, otherwise returns false.
-   *
-   * @param path the path to check
-   */
-  private static boolean isRegularFile(Path path) {
-    try {
-      return Files.exists(path) && Files.isRegularFile(path);
-    } catch (SecurityException ex) {
-      return false;
-    }
+    String lowercasePath = stringPath.toLowerCase();
+    return Files.isRegularFile(Paths.get(stringPath))
+        && (lowercasePath.endsWith(".jar") || lowercasePath.endsWith(".war"));
   }
 }


### PR DESCRIPTION
Removes unused method in `AppEngineDeploymentConfiguration`, adds a few missing tests, and removes unnecessary try/catch block to achieve 100% code coverage:

![screenshot from 2017-07-25 15 30 48](https://user-images.githubusercontent.com/14352762/28590053-bd6986f4-714e-11e7-90da-32ddb39d7127.png)