### PR TITLE
Fixes lint warnings on CloudToolsRule

### DIFF
--- a/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/CloudToolsRule.java
+++ b/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/CloudToolsRule.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.intellij.testing;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.intellij.facet.FacetManager;
+import com.intellij.facet.FacetType;
 import com.intellij.facet.FacetTypeRegistry;
 import com.intellij.ide.highlighter.ModuleFileType;
 import com.intellij.openapi.application.ApplicationManager;
@@ -162,11 +163,10 @@ public final class CloudToolsRule implements TestRule {
 
             String facetTypeId = field.getAnnotation(TestModule.class).facetTypeId();
             if (!Strings.isNullOrEmpty(facetTypeId)) {
+              FacetType<?, ?> facetType =
+                  FacetTypeRegistry.getInstance().findFacetType(facetTypeId);
               FacetManager.getInstance(module)
-                  .addFacet(
-                      FacetTypeRegistry.getInstance().findFacetType(facetTypeId),
-                      facetTypeId,
-                      /* underlying= */ null);
+                  .addFacet(facetType, facetTypeId, /* underlying= */ null);
             }
           });
     }


### PR DESCRIPTION
Since `FacetTypeRegistry.getInstance().findFacetType(String)` returns a `FacetType` without types, there was an unchecked cast to `FacetType<F, C>`. This small change assigns the result to a `FacetType<?, ?>` which gets rid of these warnings.

This is safe because the returned `Facet` from `.addFacet()` isn't used (so the types don't matter) and `CloudToolsRule` is a test utility, so it _really_ doesn't matter.