### PR TITLE
Fixes read-only doc error by checking for writable status first

### DIFF
--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineJavaeeSupportContributor.java
@@ -68,7 +68,7 @@ public class AppEngineJavaeeSupportContributor extends JavaeeFrameworkSupportCon
     StartupManager.getInstance(module.getProject()).runWhenProjectIsInitialized(() -> {
       for (WebFacet webFacet : WebFacet.getInstances(module)) {
         final WebApp webApp = webFacet.getRoot();
-        if (webApp == null) {
+        if (webApp == null || !webApp.getXmlTag().isWritable()) {
           continue;
         }
 


### PR DESCRIPTION
Fixes #1557.

**Side-effect:** If the `web.xml` is not writable, the `AppEngineJavaeeSupportContributor` skips past it and does not attempt to write the servlet version into the `web.xml`.