### PR TITLE
Fix auto value dependency

### DIFF
--- a/common-test-lib/build.gradle
+++ b/common-test-lib/build.gradle
@@ -19,5 +19,4 @@ dependencies {
     compile 'org.mockito:mockito-all:1.9.5'
 
     compileOnly 'com.google.auto.value:auto-value:1.4.1'
-    apt         'com.google.auto.value:auto-value:1.4.1'
 }


### PR DESCRIPTION
@nkibler I think I missed this during review of https://github.com/GoogleCloudPlatform/google-cloud-intellij/pull/1550

But it looks like this apt scope is something copied over from android studio? In any case, its causing test compilation issues and removing it seems to fix things.