### PR TITLE
Null check for flex environment in deployment source

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
@@ -154,7 +154,7 @@ public class AppEngineDeploymentConfiguration
 
     AppEngineDeployable deployable = (AppEngineDeployable) deploymentSource;
     checkCommonConfig(deployable);
-    if (deployable.getEnvironment().isFlexible()) {
+    if (deployable.getEnvironment() != null && deployable.getEnvironment().isFlexible()) {
       checkFlexConfig(deployable);
     }
   }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurationTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurationTest.java
@@ -236,11 +236,26 @@ public final class AppEngineDeploymentConfigurationTest {
     assertThat(error).hasMessage("Browse to an app.yaml file.");
   }
 
+  @Test
+  public void checkConfiguration_withNullEnvironment_doesNotThrow() throws Exception {
+    setUpConfigurationWithNullEnvironment();
+    configuration.checkConfiguration(mockRemoteServer, mockAppEngineDeployable);
+  }
+
   /** Sets up the {@code configuration} to be valid for a deployment to a flex environment. */
   private void setUpValidFlexConfiguration() {
     when(mockCloudSdkService.validateCloudSdk()).thenReturn(ImmutableSet.of());
     when(mockAppEngineDeployable.isValid()).thenReturn(true);
     when(mockAppEngineDeployable.getEnvironment()).thenReturn(AppEngineEnvironment.APP_ENGINE_FLEX);
+
+    configuration.setCloudProjectName("some-project-name");
+    configuration.setModuleName("some-module-name");
+  }
+
+  private void setUpConfigurationWithNullEnvironment() {
+    when(mockCloudSdkService.validateCloudSdk()).thenReturn(ImmutableSet.of());
+    when(mockAppEngineDeployable.isValid()).thenReturn(true);
+    when(mockAppEngineDeployable.getEnvironment()).thenReturn(null);
 
     configuration.setCloudProjectName("some-project-name");
     configuration.setModuleName("some-module-name");

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurationTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurationTest.java
@@ -238,7 +238,9 @@ public final class AppEngineDeploymentConfigurationTest {
 
   @Test
   public void checkConfiguration_withNullEnvironment_doesNotThrow() throws Exception {
-    setUpConfigurationWithNullEnvironment();
+    setUpValidFlexConfiguration();
+    when(mockAppEngineDeployable.getEnvironment()).thenReturn(null);
+
     configuration.checkConfiguration(mockRemoteServer, mockAppEngineDeployable);
   }
 
@@ -247,15 +249,6 @@ public final class AppEngineDeploymentConfigurationTest {
     when(mockCloudSdkService.validateCloudSdk()).thenReturn(ImmutableSet.of());
     when(mockAppEngineDeployable.isValid()).thenReturn(true);
     when(mockAppEngineDeployable.getEnvironment()).thenReturn(AppEngineEnvironment.APP_ENGINE_FLEX);
-
-    configuration.setCloudProjectName("some-project-name");
-    configuration.setModuleName("some-module-name");
-  }
-
-  private void setUpConfigurationWithNullEnvironment() {
-    when(mockCloudSdkService.validateCloudSdk()).thenReturn(ImmutableSet.of());
-    when(mockAppEngineDeployable.isValid()).thenReturn(true);
-    when(mockAppEngineDeployable.getEnvironment()).thenReturn(null);
 
     configuration.setCloudProjectName("some-project-name");
     configuration.setModuleName("some-module-name");


### PR DESCRIPTION
fixes #1576 

When a maven deployment source is freshly deserialized, it doesn't have an environment - this is to ensure that the environment is fresh. 
We needed a null check here.