### PR TITLE
Resets cloud project name when editing deploy config

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurationPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurationPanel.java
@@ -35,9 +35,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.event.TreeModelEvent;
 
-/**
- * Common App Engine deployment configuration UI shared by flexible and standard deployments.
- */
+/** Common App Engine deployment configuration UI shared by flexible and standard deployments. */
 public final class AppEngineDeploymentConfigurationPanel {
 
   private JPanel commonConfigPanel;
@@ -101,13 +99,14 @@ public final class AppEngineDeploymentConfigurationPanel {
   }
 
   /**
-   * Shared implementation of
-   * {@link com.intellij.openapi.options.SettingsEditor#resetEditorFrom(Object)}. To be invoked
-   * by users of this panel in the overriden method.
+   * Shared implementation of {@link
+   * com.intellij.openapi.options.SettingsEditor#resetEditorFrom(Object)}. To be invoked by users of
+   * this panel in the overriden method.
    */
   public void resetEditorFrom(@NotNull AppEngineDeploymentConfiguration configuration) {
     promoteCheckbox.setSelected(configuration.isPromote());
     versionIdField.setText(configuration.getVersion());
+    projectSelector.setText(configuration.getCloudProjectName());
     stopPreviousVersionCheckbox.setSelected(configuration.isStopPreviousVersion());
     deployAllConfigsCheckbox.setSelected(configuration.isDeployAllConfigs());
 
@@ -119,9 +118,9 @@ public final class AppEngineDeploymentConfigurationPanel {
   }
 
   /**
-   * Shared implementation of
-   * {@link com.intellij.openapi.options.SettingsEditor#applyEditorTo(Object)}. To be invoked
-   * by users of this panel in the overriden method.
+   * Shared implementation of {@link
+   * com.intellij.openapi.options.SettingsEditor#applyEditorTo(Object)}. To be invoked by users of
+   * this panel in the overriden method.
    */
   public void applyEditorTo(@NotNull AppEngineDeploymentConfiguration configuration) {
     configuration.setVersion(versionIdField.getText());
@@ -143,8 +142,9 @@ public final class AppEngineDeploymentConfigurationPanel {
   public void setDeploymentProjectAndVersion(DeploymentSource deploymentSource) {
     if (deploymentSource instanceof AppEngineDeployable) {
       ((AppEngineDeployable) deploymentSource).setProjectName(projectSelector.getText());
-      ((AppEngineDeployable) deploymentSource).setVersion(
-          Strings.isNullOrEmpty(versionIdField.getText()) ? "auto" : versionIdField.getText());
+      ((AppEngineDeployable) deploymentSource)
+          .setVersion(
+              Strings.isNullOrEmpty(versionIdField.getText()) ? "auto" : versionIdField.getText());
     }
   }
 

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.intellij.appengine.cloud.flexible;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.intellij.appengine.cloud.AppEngineApplicationInfoPanel;
@@ -291,5 +292,15 @@ public final class AppEngineFlexibleDeploymentEditorTest {
     editor.getAppYamlCombobox().setSelectedItem(facet);
 
     assertThat(editor.getCommonConfig().getServiceLabel().getText()).isEqualTo("customService");
+  }
+
+  @Test
+  public void resetEditorFrom_withCloudProjectName_doesSetCloudProjectName() {
+    String projectName = "some-project";
+    configuration.setCloudProjectName(projectName);
+
+    editor.resetEditorFrom(configuration);
+
+    verify(projectSelector).setText(projectName);
   }
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/standard/AppEngineStandardDeploymentEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/standard/AppEngineStandardDeploymentEditorTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.intellij.appengine.cloud.standard;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 import com.google.cloud.tools.intellij.appengine.cloud.AppEngineArtifactDeploymentSource;
 import com.google.cloud.tools.intellij.appengine.cloud.AppEngineDeploymentConfiguration;
@@ -175,7 +176,6 @@ public final class AppEngineStandardDeploymentEditorTest {
     assertThat(configuration.isStopPreviousVersion()).isTrue();
   }
 
-
   @Test
   public void applyEditorTo_doesSetDeployAllConfigs() throws Exception {
     editor.getCommonConfig().getDeployAllConfigsCheckbox().setSelected(true);
@@ -267,14 +267,14 @@ public final class AppEngineStandardDeploymentEditorTest {
   }
 
   @Test
-  public void resetEditorFrom_doesNotSetCloudProjectName() {
-    configuration.setCloudProjectName("some-project");
+  public void resetEditorFrom_doesSetCloudProjectName() {
+    String projectName = "some-project";
+    configuration.setCloudProjectName(projectName);
 
     editor.resetEditorFrom(configuration);
 
-    assertThat(editor.getCommonConfig().getProjectSelector().getText()).isNull();
+    verify(projectSelector).setText(projectName);
   }
-
 
   @Test
   public void resetEditorFrom_doesNotSetGoogleUsername() {


### PR DESCRIPTION
Fixes #1577.

Interestingly enough, I purposefully left this out. I think I did this when I noticed only the project text was set but the current user in the `ProjectSelector` was still `null`, resulting in an error state shown. But the reason for this is because I needed to sign-in again; all is well when stored credentials exist for the user.