### PR TITLE
Fix nightly release by setting a timestamp as the version

### DIFF
--- a/kokoro/ubuntu/nightly.sh
+++ b/kokoro/ubuntu/nightly.sh
@@ -42,4 +42,5 @@
 cd github/google-cloud-intellij
 
 echo "Publishing plugin to Jetbrains plugin repository nightly channel"
-./gradlew publishPlugin -PijPluginRepoChannel=nightly --info
+nightly_release_date=`date "+%Y%m%d"`
+./gradlew publishPlugin -PijPluginRepoChannel=nightly -Pversion=${nightly_release_date} -version= --info

--- a/kokoro/ubuntu/nightly.sh
+++ b/kokoro/ubuntu/nightly.sh
@@ -43,4 +43,4 @@ cd github/google-cloud-intellij
 
 echo "Publishing plugin to Jetbrains plugin repository nightly channel"
 nightly_release_date=`date "+%Y%m%d"`
-./gradlew publishPlugin -PijPluginRepoChannel=nightly -Pversion=${nightly_release_date} -version= --info
+./gradlew publishPlugin -PijPluginRepoChannel=nightly -Pversion=${nightly_release_date} --info


### PR DESCRIPTION
The nightly release is currently broken because the artifact in the JB repo will only get updated if the version of the plugin changes.

Previously, each nightly release would attempt to upload a new artifact of the same version (unless we just performed an actual production release) which wouldn't work.

This overrides the version in gradle.properties to a simple date stamp to ensure its unique for each nightly run.