### PR TITLE
Removes the dead /auth/projecthosting scope

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/OAuthScopeRegistry.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/OAuthScopeRegistry.java
@@ -33,7 +33,6 @@ class OAuthScopeRegistry {
     scopes.add("https://www.googleapis.com/auth/userinfo#email");
     scopes.add("https://www.googleapis.com/auth/appengine.admin");
     scopes.add("https://www.googleapis.com/auth/cloud-platform");
-    scopes.add("https://www.googleapis.com/auth/projecthosting");
     scopes.add("https://www.googleapis.com/auth/cloud_debugger");
     SCOPES = Collections.unmodifiableSortedSet(scopes);
   }


### PR DESCRIPTION
Fixes #1598.

This scope is no longer in-use and has been removed.