### PR TITLE
Fixes EAP test failure

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/CloudToolsFeedbackAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/CloudToolsFeedbackAction.java
@@ -23,7 +23,7 @@ import com.google.cloud.tools.intellij.flags.PropertiesFileFlagReader;
 import com.google.cloud.tools.intellij.ui.GoogleCloudToolsIcons;
 import com.google.cloud.tools.intellij.util.GctBundle;
 import com.google.common.net.UrlEscapers;
-import com.intellij.ide.BrowserUtil;
+import com.intellij.ide.browsers.BrowserLauncher;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.DumbAwareAction;
@@ -60,7 +60,7 @@ public class CloudToolsFeedbackAction extends DumbAwareAction {
 
   @Override
   public void actionPerformed(AnActionEvent event) {
-    BrowserUtil.browse(formatUrl());
+    BrowserLauncher.getInstance().browse(formatUrl(), /* browser= */ null, /* project= */ null);
   }
 
   private static String formatUrl() {

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/CloudToolsFeedbackActionTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/CloudToolsFeedbackActionTest.java
@@ -16,8 +16,11 @@
 
 package com.google.cloud.tools.intellij;
 
-import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,15 +30,21 @@ import com.google.cloud.tools.intellij.testing.TestFile;
 import com.google.cloud.tools.intellij.testing.TestService;
 import com.google.common.net.UrlEscapers;
 import com.intellij.ide.browsers.BrowserLauncher;
+import com.intellij.ide.browsers.WebBrowser;
+import com.intellij.openapi.project.Project;
 import java.io.File;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
 /** Tests for {@link CloudToolsFeedbackAction}. */
-public class CloudToolsFeedbackActionTest {
+@RunWith(JUnit4.class)
+public final class CloudToolsFeedbackActionTest {
 
   @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
 
@@ -47,11 +56,10 @@ public class CloudToolsFeedbackActionTest {
 
   private CloudToolsFeedbackAction feedbackAction;
 
-  private static ArgumentCaptor<String> urlArg = ArgumentCaptor.forClass(String.class);
-
   @Before
-  public void setUp() {
+  public void setUp() throws Exception {
     feedbackAction = new CloudToolsFeedbackAction();
+    maybeStubBrowserLauncher();
   }
 
   @Test
@@ -59,23 +67,54 @@ public class CloudToolsFeedbackActionTest {
     when(sdkService.getSdkHomePath()).thenReturn(missingCloudSdk.toPath());
 
     feedbackAction.actionPerformed(null /*event*/);
-    verify(browserLauncher).browse(urlArg.capture(), eq(null));
 
-    String expectedEmptySdkVersionMessage = "- Google Cloud SDK version: \n";
-    assertTrue(urlContainsMessage(expectedEmptySdkVersionMessage));
+    String expected = "- Google Cloud SDK version: \n";
+    verify(browserLauncher).browse(urlContains(expected), eq(null), eq(null));
   }
 
   @Test
   public void testDisplayableOs() {
     feedbackAction.actionPerformed(null /*event*/);
-    verify(browserLauncher).browse(urlArg.capture(), eq(null));
 
-    String expectedOsMessage =
-        "OS: " + System.getProperty("os.name") + " " + System.getProperty("os.version") + "\n";
-    assertTrue(urlContainsMessage(expectedOsMessage));
+    String expected =
+        String.format(
+            "OS: %s %s\n", System.getProperty("os.name"), System.getProperty("os.version"));
+    verify(browserLauncher).browse(urlContains(expected), eq(null), eq(null));
   }
 
-  private static boolean urlContainsMessage(String message) {
-    return urlArg.getValue().contains(UrlEscapers.urlFormParameterEscaper().escape(message));
+  /**
+   * Stubs the {@link BrowserLauncher#browse(String, WebBrowser)} to call the {@link
+   * BrowserLauncher#browse(String, WebBrowser, Project)} method with a {@code null} {@link Project}
+   * if the method is non-final.
+   *
+   * <p>This required for compatibility reasons between the previous non-Kotlin source for {@link
+   * BrowserLauncher} and the new Kotlin source.
+   *
+   * <p><b>Explanation:</b> The non-Kotlin source declares {@link BrowserLauncher#browse(String,
+   * WebBrowser)} as abstract; the Kotlin source declares this method as final, whose implementation
+   * calls into the {@link BrowserLauncher#browse(String, WebBrowser, Project)} method. Since
+   * Mockito cannot stub final methods, the real implementation will be invoked if the underlying
+   * source is the Kotlin version.
+   *
+   * <p>To support verifying the {@link BrowserLauncher#browse} method was called by the class under
+   * test, the tests verify the 3-parameter method was called and this method will forward
+   * invocations of the 2-parameter method if needed.
+   */
+  private void maybeStubBrowserLauncher() throws NoSuchMethodException {
+    Method browseMethod = BrowserLauncher.class.getMethod("browse", String.class, WebBrowser.class);
+    if (!Modifier.isFinal(browseMethod.getModifiers())) {
+      doAnswer(
+              invocation -> {
+                String url = (String) invocation.getArguments()[0];
+                browserLauncher.browse(url, null, null);
+                return null;
+              })
+          .when(browserLauncher)
+          .browse(anyString(), any());
+    }
+  }
+
+  private static String urlContains(String unescapedMessage) {
+    return contains(UrlEscapers.urlFormParameterEscaper().escape(unescapedMessage));
   }
 }


### PR DESCRIPTION
Fixes #1584.

The crux of the issue is that the EAP switched the `BrowserLauncher` abstract class to a Kotlin source. The first parameter in `BrowserLauncher.browse(String, WebBrowser)` is marked as non-null, which in Kotlin, generates a runtime check that throws an NPE if the passed value is `null` ([see here](https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#null-safety)). Most Mockito `ArgumentMatchers` return `null` when stubbing/verifying; it's an easy way for them to return a value that ultimately doesn't matter and is class-agnostic.

Couple that with the fact that they changed `BrowserLauncher.browse(String, WebBrowser)` from an abstract method to a concrete one that delegates to the 3-parameter method: `BrowserLauncher.browse(String, WebBrowser, Project)`. This method is declared final (the default for Kotlin functions) so Mockito can't stub it and the real implementation will run (with the runtime null-check).

The simple solution in this PR is to use the `BrowserLauncher` directly (instead of indirectly through the `BrowserUtil` class) and directly invoke the 3-parameter `browse(String, WebBrowser, Project)` method, which is still abstract in the Kotlin source. This way Mockito can still stub/verify the method without a hacky workaround that would be required if `BrowserUtil` was still used.