### PR TITLE
GCS bucket content explorer setup

### DIFF
--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -418,9 +418,9 @@
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">
-    <toolWindow id="Google Cloud Storage" anchor="right"
-                factoryClass="com.google.cloud.tools.intellij.gcs.GcsToolWindowFactory"/>
-    <fileEditorProvider implementation="com.google.cloud.tools.intellij.gcs.GcsBucketEditorProvider"/>
+    <!--<toolWindow id="Google Cloud Storage" anchor="right"-->
+                <!--factoryClass="com.google.cloud.tools.intellij.gcs.GcsToolWindowFactory"/>-->
+    <!--<fileEditorProvider implementation="com.google.cloud.tools.intellij.gcs.GcsBucketEditorProvider"/>-->
   </extensions>
 
   <actions>

--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -418,8 +418,9 @@
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">
-    <!--<toolWindow id="Google Cloud Storage" anchor="right"-->
-                <!--factoryClass="com.google.cloud.tools.intellij.gcs.GcsToolWindowFactory"/>-->
+    <toolWindow id="Google Cloud Storage" anchor="right"
+                factoryClass="com.google.cloud.tools.intellij.gcs.GcsToolWindowFactory"/>
+    <fileEditorProvider implementation="com.google.cloud.tools.intellij.gcs.GcsBucketEditorProvider"/>
   </extensions>
 
   <actions>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditor.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.gcs;
+
+import com.intellij.codeHighlighting.BackgroundEditorHighlighter;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorLocation;
+import com.intellij.openapi.fileEditor.FileEditorState;
+import com.intellij.openapi.util.Key;
+import java.beans.PropertyChangeListener;
+import javax.swing.JComponent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Google Cloud Storage {@link FileEditor} implementation. Instantiates the UI panel that allows
+ * browsing of GCS bucket contents.
+ */
+final class GcsBucketContentEditor implements FileEditor {
+
+  private final GcsBucketContentEditorPanel bucketContentPanel;
+  private final GcsBucketVirtualFile bucketVirtualFile;
+
+  GcsBucketContentEditor(@NotNull GcsBucketVirtualFile bucketVirtualFile) {
+    this.bucketVirtualFile = bucketVirtualFile;
+    bucketContentPanel = new GcsBucketContentEditorPanel(bucketVirtualFile);
+  }
+
+  @NotNull
+  @Override
+  public JComponent getComponent() {
+    return bucketContentPanel.getComponent();
+  }
+
+  @Nullable
+  @Override
+  public JComponent getPreferredFocusedComponent() {
+    return bucketContentPanel.getComponent();
+  }
+
+  @NotNull
+  @Override
+  public String getName() {
+    return "gcs-bucket-content";
+  }
+
+  @Override
+  public void setState(@NotNull FileEditorState state) {}
+
+  @Override
+  public boolean isModified() {
+    return false;
+  }
+
+  @Override
+  public boolean isValid() {
+    return bucketVirtualFile.isValid();
+  }
+
+  @Override
+  public void selectNotify() {}
+
+  @Override
+  public void deselectNotify() {}
+
+  @Override
+  public void addPropertyChangeListener(@NotNull PropertyChangeListener listener) {}
+
+  @Override
+  public void removePropertyChangeListener(@NotNull PropertyChangeListener listener) {}
+
+  @Nullable
+  @Override
+  public BackgroundEditorHighlighter getBackgroundHighlighter() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public FileEditorLocation getCurrentLocation() {
+    return null;
+  }
+
+  @Override
+  public void dispose() {}
+
+  @Nullable
+  @Override
+  public <T> T getUserData(@NotNull Key<T> key) {
+    return null;
+  }
+
+  @Override
+  public <T> void putUserData(@NotNull Key<T> key, @Nullable T value) {}
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditor.java
@@ -49,7 +49,7 @@ final class GcsBucketContentEditor implements FileEditor {
   @Nullable
   @Override
   public JComponent getPreferredFocusedComponent() {
-    return bucketContentPanel.getComponent();
+    return getComponent();
   }
 
   @NotNull

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditor.java
@@ -39,7 +39,8 @@ final class GcsBucketContentEditor implements FileEditor {
 
   GcsBucketContentEditor(@NotNull GcsBucketVirtualFile bucketVirtualFile) {
     this.bucketVirtualFile = bucketVirtualFile;
-    bucketContentPanel = new GcsBucketContentEditorPanel(bucketVirtualFile);
+    bucketContentPanel = new GcsBucketContentEditorPanel();
+    bucketContentPanel.setTableModel(bucketVirtualFile);
   }
 
   @NotNull

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditor.java
@@ -32,6 +32,8 @@ import org.jetbrains.annotations.Nullable;
  */
 final class GcsBucketContentEditor implements FileEditor {
 
+  private static final String GCS_FILE_EDITOR_NAME = "gcs-bucket-content";
+
   private final GcsBucketContentEditorPanel bucketContentPanel;
   private final GcsBucketVirtualFile bucketVirtualFile;
 
@@ -55,7 +57,7 @@ final class GcsBucketContentEditor implements FileEditor {
   @NotNull
   @Override
   public String getName() {
-    return "gcs-bucket-content";
+    return GCS_FILE_EDITOR_NAME;
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditor.java
@@ -40,7 +40,7 @@ final class GcsBucketContentEditor implements FileEditor {
   GcsBucketContentEditor(@NotNull GcsBucketVirtualFile bucketVirtualFile) {
     this.bucketVirtualFile = bucketVirtualFile;
     bucketContentPanel = new GcsBucketContentEditorPanel();
-    bucketContentPanel.setTableModel(bucketVirtualFile);
+    bucketContentPanel.setTableModel(bucketVirtualFile.getBucket().list().iterateAll());
   }
 
   @NotNull

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.form
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.cloud.tools.intellij.gcs.GcsBucketContentEditorPanel">
+  <grid id="27dc6" binding="bucketContentEditorPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <grid id="f043e" binding="bucketContentToolbarPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="a53e9" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="toolbar"/>
+            </properties>
+          </component>
+          <hspacer id="da6eb">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+        </children>
+      </grid>
+      <scrollpane id="531fe">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="b5290" class="javax.swing.JTable" binding="bucketContentTable">
+            <constraints/>
+            <properties/>
+          </component>
+        </children>
+      </scrollpane>
+      <grid id="134f9" binding="breadCrumbsPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="b2df9" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="breadcrumbs"/>
+            </properties>
+          </component>
+          <hspacer id="a1868">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+        </children>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.gcs;
+
+import com.google.cloud.storage.Blob;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterators;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+import org.jetbrains.annotations.NotNull;
+
+/** Defines the Google Cloud Storage bucket content browsing UI panel. */
+// TODO(eshaul) work in progress
+final class GcsBucketContentEditorPanel {
+
+  private JPanel bucketContentEditorPanel;
+  private JPanel bucketContentToolbarPanel;
+  private JPanel breadCrumbsPanel;
+  private JTable bucketContentTable;
+
+  private static final List<String> TABLE_COL_HEADER =
+      Arrays.asList("Name", "Size", "Type", "Last Modified");
+
+  GcsBucketContentEditorPanel(@NotNull GcsBucketVirtualFile bucketVirtualFile) {
+    Iterable<Blob> blobs = bucketVirtualFile.getBucket().list().iterateAll();
+
+    if (Iterators.size(blobs.iterator()) != 0) {
+      bucketContentTable.setModel(new GcsBucketTableModel(blobs));
+    }
+  }
+
+  JPanel getComponent() {
+    return bucketContentEditorPanel;
+  }
+
+  @VisibleForTesting
+  JTable getBucketContentTable() {
+    return bucketContentTable;
+  }
+
+  private final class GcsBucketTableModel extends DefaultTableModel {
+
+    GcsBucketTableModel(Iterable<Blob> blobs) {
+      super();
+      setDataVector(buildDataVector(blobs), new Vector<>(TABLE_COL_HEADER));
+    }
+
+    @Override
+    public boolean isCellEditable(int row, int column) {
+      return false;
+    }
+
+    // TODO(eshaul) this is a placeholder implementation; need to complete.
+    private Vector<Vector<String>> buildDataVector(Iterable<Blob> blobs) {
+      return StreamSupport.stream(blobs.spliterator(), false)
+          .map(
+              blob -> {
+                Vector<String> rowData = new Vector<>();
+                rowData.add(blob.getName());
+                rowData.add("--");
+                rowData.add("--");
+                rowData.add("--");
+                return rowData;
+              })
+          .collect(Collectors.toCollection(Vector::new));
+    }
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -41,9 +41,7 @@ final class GcsBucketContentEditorPanel {
   private static final List<String> TABLE_COL_HEADER =
       Arrays.asList("Name", "Size", "Type", "Last Modified");
 
-  void setTableModel(@NotNull GcsBucketVirtualFile bucketVirtualFile) {
-    Iterable<Blob> blobs = bucketVirtualFile.getBucket().list().iterateAll();
-
+  void setTableModel(@NotNull Iterable<Blob> blobs) {
     if (Iterators.size(blobs.iterator()) != 0) {
       bucketContentTable.setModel(new GcsBucketTableModel(blobs));
     }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -41,7 +41,7 @@ final class GcsBucketContentEditorPanel {
   private static final List<String> TABLE_COL_HEADER =
       Arrays.asList("Name", "Size", "Type", "Last Modified");
 
-  GcsBucketContentEditorPanel(@NotNull GcsBucketVirtualFile bucketVirtualFile) {
+  void setTableModel(@NotNull GcsBucketVirtualFile bucketVirtualFile) {
     Iterable<Blob> blobs = bucketVirtualFile.getBucket().list().iterateAll();
 
     if (Iterators.size(blobs.iterator()) != 0) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketEditorProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketEditorProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.gcs;
+
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorPolicy;
+import com.intellij.openapi.fileEditor.FileEditorProvider;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Provider of {@link GcsBucketContentEditor}'s for browsing Google Cloud Storage bucket contents.
+ */
+public final class GcsBucketEditorProvider implements FileEditorProvider {
+
+  @Override
+  public boolean accept(@NotNull Project project, @NotNull VirtualFile file) {
+    return file instanceof GcsBucketVirtualFile;
+  }
+
+  @NotNull
+  @Override
+  public FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile file) {
+    return new GcsBucketContentEditor((GcsBucketVirtualFile) file);
+  }
+
+  @NotNull
+  @Override
+  public String getEditorTypeId() {
+    return "gcs-bucket-content-editor";
+  }
+
+  @NotNull
+  @Override
+  public FileEditorPolicy getPolicy() {
+    return FileEditorPolicy.HIDE_DEFAULT_EDITOR;
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketEditorProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketEditorProvider.java
@@ -28,6 +28,8 @@ import org.jetbrains.annotations.NotNull;
  */
 public final class GcsBucketEditorProvider implements FileEditorProvider {
 
+  private static final String GCS_EDITOR_TYPE_ID = "gcs-bucket-content-editor";
+
   @Override
   public boolean accept(@NotNull Project project, @NotNull VirtualFile file) {
     return file instanceof GcsBucketVirtualFile;
@@ -42,7 +44,7 @@ public final class GcsBucketEditorProvider implements FileEditorProvider {
   @NotNull
   @Override
   public String getEditorTypeId() {
-    return "gcs-bucket-content-editor";
+    return GCS_EDITOR_TYPE_ID;
   }
 
   @NotNull

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketPanel.java
@@ -51,7 +51,7 @@ import org.jetbrains.annotations.NotNull;
  */
 final class GcsBucketPanel {
 
-  private Project project;
+  final private Project project;
 
   private JPanel gcsBucketPanel;
   private ProjectSelector projectSelector;

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketVirtualFile.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketVirtualFile.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.gcs;
+
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.tools.intellij.ui.GoogleCloudToolsIcons;
+import com.intellij.openapi.fileEditor.FileEditorProvider;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileSystem;
+import com.intellij.openapi.vfs.ex.dummy.DummyFileSystem;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.swing.Icon;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A {@link VirtualFile} representation of a Google Cloud Storage bucket.
+ *
+ * <p>This is essentially just a wrapper for a {@link Bucket} needed in order to create a custom
+ * editor window for exploring GCS bucket contents. Custom editors are created by providing {@link
+ * FileEditorProvider} implementations which are backed by VirtualFiles.
+ */
+class GcsBucketVirtualFile extends VirtualFile {
+
+  private final Bucket bucket;
+
+  GcsBucketVirtualFile(@NotNull Bucket bucket) {
+    this.bucket = bucket;
+  }
+
+  Bucket getBucket() {
+    return bucket;
+  }
+
+  @NotNull
+  @Override
+  public String getName() {
+    return bucket.getName();
+  }
+
+  @NotNull
+  @Override
+  public VirtualFileSystem getFileSystem() {
+    return new DummyFileSystem();
+  }
+
+  @NotNull
+  @Override
+  public String getPath() {
+    return "/" + bucket.getName();
+  }
+
+  @NotNull
+  @Override
+  public FileType getFileType() {
+    return new GcsBucketFileType();
+  }
+
+  @Override
+  public boolean isWritable() {
+    return true;
+  }
+
+  @Override
+  public boolean isDirectory() {
+    return false;
+  }
+
+  @Override
+  public boolean isValid() {
+    return true;
+  }
+
+  @Override
+  public VirtualFile getParent() {
+    return null;
+  }
+
+  @Override
+  public VirtualFile[] getChildren() {
+    return new VirtualFile[0];
+  }
+
+  @NotNull
+  @Override
+  public OutputStream getOutputStream(
+      Object requestor, long newModificationStamp, long newTimeStamp) throws IOException {
+    return new ByteArrayOutputStream();
+  }
+
+  @NotNull
+  @Override
+  public byte[] contentsToByteArray() throws IOException {
+    return new byte[0];
+  }
+
+  @Override
+  public long getTimeStamp() {
+    return 0;
+  }
+
+  @Override
+  public long getLength() {
+    return 0;
+  }
+
+  @Override
+  public void refresh(boolean asynchronous, boolean recursive, @Nullable Runnable postRunnable) {}
+
+  @Override
+  public InputStream getInputStream() throws IOException {
+    return null;
+  }
+
+  @Override
+  public long getModificationStamp() {
+    return 0L;
+  }
+
+  private static final class GcsBucketFileType implements FileType {
+
+    @NotNull
+    @Override
+    public String getName() {
+      return "gcs-bucket-file";
+    }
+
+    @NotNull
+    @Override
+    public String getDescription() {
+      return "GCS Bucket Content File Type";
+    }
+
+    @NotNull
+    @Override
+    public String getDefaultExtension() {
+      return "";
+    }
+
+    @Nullable
+    @Override
+    public Icon getIcon() {
+      return GoogleCloudToolsIcons.CLOUD;
+    }
+
+    @Override
+    public boolean isBinary() {
+      return false;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return false;
+    }
+
+    @Nullable
+    @Override
+    public String getCharset(@NotNull VirtualFile file, @NotNull byte[] content) {
+      return null;
+    }
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
@@ -48,7 +48,8 @@ public class GcsBucketContentEditorPanelTest {
 
   @Test
   public void testEmptyBucket_noBucketContentTable() {
-    editorPanel = new GcsBucketContentEditorPanel(bucketVirtualFile);
+    editorPanel = new GcsBucketContentEditorPanel();
+    editorPanel.setTableModel(bucketVirtualFile);
 
     JTable bucketTable = editorPanel.getBucketContentTable();
     assertThat(bucketTable.getColumnCount()).isEqualTo(0);
@@ -62,7 +63,8 @@ public class GcsBucketContentEditorPanelTest {
     when(blobPage.iterateAll()).thenReturn(blobs);
     when(blob.getName()).thenReturn("blobName");
 
-    editorPanel = new GcsBucketContentEditorPanel(bucketVirtualFile);
+    editorPanel = new GcsBucketContentEditorPanel();
+    editorPanel.setTableModel(bucketVirtualFile);
 
     JTable bucketTable = editorPanel.getBucketContentTable();
     assertThat(bucketTable.getColumnCount()).isEqualTo(4);

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.gcs;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.tools.intellij.testing.CloudToolsRule;
+import com.google.common.collect.Lists;
+import java.util.Iterator;
+import java.util.List;
+import javax.swing.JTable;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+
+/** Tests for {@link GcsBucketContentEditorPanel}. */
+public class GcsBucketContentEditorPanelTest {
+  @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
+
+  private GcsBucketContentEditorPanel editorPanel;
+  @Mock private GcsBucketVirtualFile bucketVirtualFile;
+  @Mock private Bucket bucket;
+  @Mock private Page<Blob> blobPage;
+  @Mock private Iterable<Blob> blobIterable;
+  @Mock private Iterator<Blob> blobIterator;
+  @Mock private Blob blob;
+
+  @Before
+  public void setUp() {
+    when(bucketVirtualFile.getBucket()).thenReturn(bucket);
+    when(bucket.list()).thenReturn(blobPage);
+    when(blobPage.iterateAll()).thenReturn(blobIterable);
+    when(blobIterable.iterator()).thenReturn(blobIterator);
+  }
+
+  @Test
+  public void testEmptyBucket_noBucketContentTable() {
+    editorPanel = new GcsBucketContentEditorPanel(bucketVirtualFile);
+
+    JTable bucketTable = editorPanel.getBucketContentTable();
+    assertThat(bucketTable.getColumnCount()).isEqualTo(0);
+    assertThat(bucketTable.getRowCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void testBucketContentTableInitialization() {
+    List<Blob> blobs = Lists.newArrayList(blob);
+    when(blobPage.iterateAll()).thenReturn(blobs);
+    when(blob.getName()).thenReturn("blobName");
+
+    editorPanel = new GcsBucketContentEditorPanel(bucketVirtualFile);
+
+    JTable bucketTable = editorPanel.getBucketContentTable();
+    assertThat(bucketTable.getColumnCount()).isEqualTo(4);
+    assertThat(bucketTable.getRowCount()).isEqualTo(1);
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
@@ -71,6 +71,14 @@ public class GcsBucketContentEditorPanelTest {
     Map<Integer, String> indexToColName =
         ImmutableMap.of(0, "Name", 1, "Size", 2, "Type", 3, "Last Modified");
     IntStream.range(0, bucketTable.getColumnCount())
-        .forEach(i -> assertThat(indexToColName.get(i)).isEqualTo(bucketTable.getColumnName(i)));
+        .forEach(
+            colIdx ->
+                assertThat(indexToColName.get(colIdx))
+                    .isEqualTo(bucketTable.getColumnName(colIdx)));
+
+    assertThat(bucketTable.getValueAt(0, 0)).isEqualTo("blobName");
+    // TODO update this once the rest of the columns are populated appropriately
+    IntStream.range(1, bucketTable.getColumnCount())
+        .forEach(colIdx -> assertThat(bucketTable.getValueAt(0, colIdx)).isEqualTo("--"));
   }
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
@@ -49,7 +49,7 @@ public class GcsBucketContentEditorPanelTest {
   @Test
   public void testEmptyBucket_noBucketContentTable() {
     editorPanel = new GcsBucketContentEditorPanel();
-    editorPanel.setTableModel(bucketVirtualFile);
+    editorPanel.setTableModel(bucketVirtualFile.getBucket().list().iterateAll());
 
     JTable bucketTable = editorPanel.getBucketContentTable();
     assertThat(bucketTable.getColumnCount()).isEqualTo(0);
@@ -64,7 +64,7 @@ public class GcsBucketContentEditorPanelTest {
     when(blob.getName()).thenReturn("blobName");
 
     editorPanel = new GcsBucketContentEditorPanel();
-    editorPanel.setTableModel(bucketVirtualFile);
+    editorPanel.setTableModel(blobs);
 
     JTable bucketTable = editorPanel.getBucketContentTable();
     assertThat(bucketTable.getColumnCount()).isEqualTo(4);

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketEditorProviderTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketEditorProviderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.gcs;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.tools.intellij.testing.CloudToolsRule;
+import com.google.cloud.tools.intellij.testing.TestFixture;
+import com.intellij.openapi.vfs.newvfs.impl.StubVirtualFile;
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+
+/** Tests for {@link GcsBucketEditorProvider}. */
+public class GcsBucketEditorProviderTest {
+  @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
+  @TestFixture private IdeaProjectTestFixture testFixture;
+
+  private GcsBucketEditorProvider bucketEditorProvider;
+  @Mock private Bucket bucket;
+
+  @Before
+  public void setUp() {
+    bucketEditorProvider = new GcsBucketEditorProvider();
+  }
+
+  @Test
+  public void testAcceptsCorrectFileType() {
+    assertFalse(bucketEditorProvider.accept(testFixture.getProject(), new StubVirtualFile()));
+    assertTrue(
+        bucketEditorProvider.accept(testFixture.getProject(), new GcsBucketVirtualFile(bucket)));
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketEditorProviderTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketEditorProviderTest.java
@@ -16,13 +16,15 @@
 
 package com.google.cloud.tools.intellij.gcs;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.cloud.storage.Bucket;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.TestFixture;
-import com.intellij.openapi.vfs.newvfs.impl.StubVirtualFile;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,17 +37,27 @@ public class GcsBucketEditorProviderTest {
   @TestFixture private IdeaProjectTestFixture testFixture;
 
   private GcsBucketEditorProvider bucketEditorProvider;
-  @Mock private Bucket bucket;
+  @Mock private VirtualFile virtualFile;
+  private GcsBucketVirtualFile gcsBucketVirtualFile;
 
   @Before
   public void setUp() {
     bucketEditorProvider = new GcsBucketEditorProvider();
+    gcsBucketVirtualFile = GcsTestUtils.createVirtualFileWithBucketMocks();
   }
 
   @Test
   public void testAcceptsCorrectFileType() {
-    assertFalse(bucketEditorProvider.accept(testFixture.getProject(), new StubVirtualFile()));
-    assertTrue(
-        bucketEditorProvider.accept(testFixture.getProject(), new GcsBucketVirtualFile(bucket)));
+    assertFalse(bucketEditorProvider.accept(testFixture.getProject(), virtualFile));
+    assertTrue(bucketEditorProvider.accept(testFixture.getProject(), gcsBucketVirtualFile));
+  }
+
+  @Test
+  public void testCreateEditor() {
+    FileEditor editor =
+        bucketEditorProvider.createEditor(testFixture.getProject(), gcsBucketVirtualFile);
+
+    assertNotNull(editor);
+    assertThat(editor).isInstanceOf(GcsBucketContentEditor.class);
   }
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketPanelTest.java
@@ -19,24 +19,33 @@ package com.google.cloud.tools.intellij.gcs;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.tools.intellij.resources.GoogleApiClientFactory;
+import com.google.cloud.tools.intellij.resources.ProjectSelector;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.TestFixture;
+import com.google.cloud.tools.intellij.testing.TestService;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
 
 /** Tests for {@link GcsBucketPanel}. */
 public class GcsBucketPanelTest {
   @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
   @TestFixture private IdeaProjectTestFixture testFixture;
 
+  @Mock @TestService private GoogleApiClientFactory apiFactory;
+  @Mock private ProjectSelector projectSelector;
+
   private GcsBucketPanel bucketPanel;
 
   @Before
   public void setUp() {
     bucketPanel = new GcsBucketPanel(testFixture.getProject());
+    bucketPanel.setProjectSelector(projectSelector);
   }
 
   @Test
@@ -51,8 +60,9 @@ public class GcsBucketPanelTest {
 
   @Test
   public void testNotificationLabel_emptyProjectSelection() {
-    bucketPanel.getProjectSelector().setText("some-project");
-    bucketPanel.getProjectSelector().setText("");
+    when(projectSelector.getText()).thenReturn("");
+
+    bucketPanel.refresh();
 
     assertTrue(bucketPanel.getNotificationPanel().isVisible());
     assertFalse(bucketPanel.getBucketListPanel().isVisible());
@@ -63,7 +73,10 @@ public class GcsBucketPanelTest {
 
   @Test
   public void testNotificationLabel_nonExistentProject() {
-    bucketPanel.getProjectSelector().setText("some-project");
+    when(projectSelector.getText()).thenReturn("non-existent-project");
+    when(projectSelector.getSelectedUser()).thenReturn(null);
+
+    bucketPanel.refresh();
 
     assertTrue(bucketPanel.getNotificationPanel().isVisible());
     assertFalse(bucketPanel.getBucketListPanel().isVisible());

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsTestUtils.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsTestUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.gcs;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import java.util.Iterator;
+
+/** Test utilities for GCS related tests. */
+class GcsTestUtils {
+
+  static GcsBucketVirtualFile createVirtualFileWithBucketMocks() {
+    GcsBucketVirtualFile gcsBucketVirtualFile = mock(GcsBucketVirtualFile.class);
+    Bucket bucket = mock(Bucket.class);
+    Page<Blob> page = mock(Page.class);
+    Iterable<Blob> blobIterable = mock(Iterable.class);
+    Iterator<Blob> blobIterator = mock(Iterator.class);
+
+    when(gcsBucketVirtualFile.getBucket()).thenReturn(bucket);
+    when(bucket.list()).thenReturn(page);
+    when(page.iterateAll()).thenReturn(blobIterable);
+    when(blobIterable.iterator()).thenReturn(blobIterator);
+
+    return gcsBucketVirtualFile;
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsTestUtils.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsTestUtils.java
@@ -25,7 +25,7 @@ import com.google.cloud.storage.Bucket;
 import java.util.Iterator;
 
 /** Utilities for GCS related tests. */
-class GcsTestUtils {
+final class GcsTestUtils {
 
   static GcsBucketVirtualFile createVirtualFileWithBucketMocks() {
     GcsBucketVirtualFile gcsBucketVirtualFile = mock(GcsBucketVirtualFile.class);

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsTestUtils.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsTestUtils.java
@@ -24,7 +24,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
 import java.util.Iterator;
 
-/** Test utilities for GCS related tests. */
+/** Utilities for GCS related tests. */
 class GcsTestUtils {
 
   static GcsBucketVirtualFile createVirtualFileWithBucketMocks() {


### PR DESCRIPTION
This is a partial functionality PR to keep things small(ish). It sets up the GCS bucket content explorer editor. 

The editor itself is unfinished. It just lists all the bucket contents in a flattened view (and just the blob name). **Everything else in this editor is unfinished (all UI polish, icons, toolbars, breadcrumbs, directory structure etc.).**

### Some info on creating custom editor windows:
Custom editors, created by using the `FileEditorProvider` extension point, are backed by `VirtualFile`s. This makes sense since most editor use-cases involve opening up some sort of real file. In our case, we want to open up an editor, but there is no "file" - instead we have a `Bucket` datastructure (from the GCS API). To achieve this, I created a GCS VirtualFile implementation which basically wraps a GCS bucket. In order to get the full functionality of the editor UI, I created several of these file related components: `GcsBucketVirtualFile`, `GcsBucketFileType` etc.

Bucket explorer editor window after opening a bucket in the left panel:
<img width="1404" alt="screen shot 2017-08-24 at 9 15 16 pm" src="https://user-images.githubusercontent.com/1735744/29695508-6274f26c-8911-11e7-85b4-db09a713c32e.png">
