### PR TITLE
Fix various error prone warnings

### DIFF
--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/ServerToIDEFileResolverTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/ServerToIDEFileResolverTest.java
@@ -25,8 +25,6 @@ import com.intellij.psi.PsiJavaFile;
 import com.intellij.testFramework.UsefulTestCase;
 import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase;
 
-import org.junit.Ignore;
-
 /** Unit tests for {@link ServerToIdeFileResolver}. */
 public class ServerToIDEFileResolverTest extends JavaCodeInsightFixtureTestCase {
   private PsiClass class1;
@@ -56,7 +54,6 @@ public class ServerToIDEFileResolverTest extends JavaCodeInsightFixtureTestCase 
   }
 
   // When searching for full file system path.
-  @Ignore
   public void ignore_testGetFileFromPath_fullPath() {
     // TODO(joaomartins): Find out why project.getBaseDir() is returning a different tempDir to
     // myFixture.

--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/server/instance/AppEngineRunConfigurationEditor.java
@@ -67,13 +67,14 @@ public class AppEngineRunConfigurationEditor extends SettingsEditor<CommonModel>
     });
 
     setAnchor(myWebArtifactToDeployLabel);
-    appEngineSettingsPanel.setBorder(PlainSmallWithoutIndent.createTitledBorder(
-        null /* border - ignored */,
-        GctBundle.message("appengine.run.settings.title.label"),
-        0 /* titleJustification - ignored */,
-        0 /* titlePosition - ignored */,
-        null /* titleFont - ignored */,
-        null /* titleColor - ignored */));
+    appEngineSettingsPanel.setBorder(
+        PlainSmallWithoutIndent.createTitledBorder(
+            null /* border */,
+            GctBundle.message("appengine.run.settings.title.label"),
+            0 /* titleJustification */,
+            0 /* titlePosition */,
+            null /* titleFont */,
+            null /* titleColor */));
   }
 
   private void onArtifactChanged() {


### PR DESCRIPTION
- Use of JUnit 4 in JUnit 3 test
- invalid naming of named param comments: http://errorprone.info/bugpattern/NamedParameters (had no idea this check was even a thing)