### PR TITLE
Adds editor listener to update staged artifact name placeholder

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
@@ -126,7 +126,6 @@ public final class AppEngineFlexibleDeploymentEditor
                           AppEngineFlexibleDeploymentEditor.this.deploymentSource)
                       .setFilePath(archiveSelector.getText());
                 }
-                updateStagedArtifactNameEmptyText();
               }
             });
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditor.java
@@ -97,6 +97,8 @@ public final class AppEngineFlexibleDeploymentEditor
     commonConfig.getDeployAllConfigsCheckbox().setSelected(false);
     commonConfig.getDeployAllConfigsCheckbox().setVisible(false);
 
+    addSettingsEditorListener(editor -> updateStagedArtifactNameEmptyText());
+
     archiveSelector.addBrowseFolderListener(
         GctBundle.message("appengine.flex.config.user.specified.artifact.title"),
         null /* description */,
@@ -439,5 +441,10 @@ public final class AppEngineFlexibleDeploymentEditor
   @VisibleForTesting
   void setDeploymentSource(DeploymentSource deploymentSource) {
     this.deploymentSource = deploymentSource;
+  }
+
+  @VisibleForTesting
+  void fireStateChange() {
+    fireEditorStateChanged();
   }
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
@@ -355,6 +355,7 @@ public final class AppEngineFlexibleDeploymentEditorTest {
   public void updateArtifactField_toWar_doesSetStagedArtifactNameEmptyText() {
     editor.setDeploymentSource(userSpecifiedPathDeploymentSource);
     editor.getArchiveSelector().setText(warArtifact.toString());
+    editor.fireStateChange();
 
     assertThat(editor.getStagedArtifactNameTextField().getEmptyText().getText())
         .isEqualTo(warArtifact.getName());
@@ -364,6 +365,7 @@ public final class AppEngineFlexibleDeploymentEditorTest {
   public void updateArtifactField_toJar_doesSetStagedArtifactNameEmptyText() {
     editor.setDeploymentSource(userSpecifiedPathDeploymentSource);
     editor.getArchiveSelector().setText(jarArtifact.toString());
+    editor.fireStateChange();
 
     assertThat(editor.getStagedArtifactNameTextField().getEmptyText().getText())
         .isEqualTo(jarArtifact.getName());
@@ -376,6 +378,7 @@ public final class AppEngineFlexibleDeploymentEditorTest {
 
     editor.setDeploymentSource(userSpecifiedPathDeploymentSource);
     editor.getArchiveSelector().setText(unknownArtifact.toString());
+    editor.fireStateChange();
 
     assertThat(editor.getStagedArtifactNameTextField().getEmptyText().getText()).isEmpty();
   }
@@ -387,6 +390,7 @@ public final class AppEngineFlexibleDeploymentEditorTest {
 
     editor.setDeploymentSource(userSpecifiedPathDeploymentSource);
     editor.getArchiveSelector().setText(null);
+    editor.fireStateChange();
 
     assertThat(editor.getStagedArtifactNameTextField().getEmptyText().getText()).isEmpty();
   }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/flexible/AppEngineFlexibleDeploymentEditorTest.java
@@ -128,6 +128,18 @@ public final class AppEngineFlexibleDeploymentEditorTest {
   }
 
   @Test
+  public void fireStateChange_doesSetStagedArtifactNameEmptyText() {
+    when(deploymentSource.getFile()).thenReturn(warArtifact);
+
+    String beforeText = editor.getStagedArtifactNameTextField().getEmptyText().getText();
+    editor.fireStateChange();
+    String afterText = editor.getStagedArtifactNameTextField().getEmptyText().getText();
+
+    assertThat(beforeText).isEmpty();
+    assertThat(afterText).isEqualTo(warArtifact.getName());
+  }
+
+  @Test
   public void applyEditorTo_withDefaultConfiguration_doesSetDefaults() throws Exception {
     editor.applyEditorTo(configuration);
 


### PR DESCRIPTION
Fixes #1621.

Previously there was just a listener on the artifact path field to update the staged artifact name placeholder text. This would not be triggered if the user selects (or previously had selected) a non-user specified source, like a Maven target. This adds an additional listener to the state of the settings editor itself, which receives updates any time the state has changed (e.g. when a deployment source has been selected).