### PR TITLE
Adds the ThreadUtil utility class

### DIFF
--- a/common-lib/src/main/java/com/google/cloud/tools/intellij/util/ThreadUtil.java
+++ b/common-lib/src/main/java/com/google/cloud/tools/intellij/util/ThreadUtil.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/** Utilities for working with threads. */
+public final class ThreadUtil {
+
+  private static final ThreadUtil INSTANCE = new ThreadUtil();
+
+  private ExecutorService backgroundExecutorService;
+
+  /** Visibility is restricted internally; use {@link #getInstance()} instead. */
+  private ThreadUtil() {
+    this.backgroundExecutorService = Executors.newCachedThreadPool();
+  }
+
+  /** Returns the static instance of this utility. */
+  public static ThreadUtil getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Executes the given {@link Runnable} on the background {@link ExecutorService} and returns the
+   * {@link Future} result.
+   *
+   * @param runnable the {@link Runnable} to run on the background {@link ExecutorService}
+   */
+  public Future<?> executeInBackground(Runnable runnable) {
+    return backgroundExecutorService.submit(runnable);
+  }
+
+  /**
+   * Sets the {@link ExecutorService} used for executing background tasks.
+   *
+   * <p>This should only be used by unit tests to replace the default {@link ExecutorService} with
+   * an executor of your choice. For example, the following snippet replaces the background executor
+   * service with a direct one, causing all tasks submitted to it to be executed synchronously on
+   * the current thread:
+   *
+   * <pre>{@code
+   * ExecutorService directExecutorService = MoreExecutors.newDirectExecutorService();
+   * ThreadUtil.getInstance().setBackgroundExecutorService(directExecutorService);
+   * }</pre>
+   *
+   * @param backgroundExecutorService the new {@link ExecutorService} to use for background tasks
+   */
+  @VisibleForTesting
+  public void setBackgroundExecutorService(ExecutorService backgroundExecutorService) {
+    this.backgroundExecutorService = backgroundExecutorService;
+  }
+}

--- a/common-test-lib/build.gradle
+++ b/common-test-lib/build.gradle
@@ -17,6 +17,7 @@
 dependencies {
     compile 'junit:junit:4.+'
     compile 'org.mockito:mockito-core:2.+'
+    compile project(":common-lib")
 
     compileOnly 'com.google.auto.value:auto-value:1.4.1'
     apt         'com.google.auto.value:auto-value:1.4.1'

--- a/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/CloudToolsRule.java
+++ b/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/CloudToolsRule.java
@@ -16,8 +16,10 @@
 
 package com.google.cloud.tools.intellij.testing;
 
+import com.google.cloud.tools.intellij.util.ThreadUtil;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.intellij.facet.FacetManager;
 import com.intellij.facet.FacetType;
 import com.intellij.facet.FacetTypeRegistry;
@@ -60,6 +62,9 @@ import org.mockito.MockitoAnnotations;
  *       them to the project
  *   <li>Creates {@link File Files} for any fields annotated with {@link TestFile} and manages the
  *       creation and deletion of them
+ *   <li>Binds the {@link java.util.concurrent.ExecutorService} in {@link ThreadUtil} to a direct
+ *       executor service, which executes every submitted task immediately and on the same thread
+ *       that submitted the task
  * </ul>
  */
 public final class CloudToolsRule implements TestRule {
@@ -103,6 +108,7 @@ public final class CloudToolsRule implements TestRule {
     createTestModules();
     createTestFiles(description.getMethodName());
     createTestDirectories();
+    bindDirectExecutorService();
   }
 
   /** Tears down utilities after the test has finished. */
@@ -218,6 +224,11 @@ public final class CloudToolsRule implements TestRule {
       filesToDelete.add(directory);
       field.set(testInstance, directory);
     }
+  }
+
+  /** Binds the executor service in {@link ThreadUtil} to a direct executor service. */
+  private void bindDirectExecutorService() {
+    ThreadUtil.getInstance().setBackgroundExecutorService(MoreExecutors.newDirectExecutorService());
   }
 
   /**


### PR DESCRIPTION
This utility class replaces usages of calls to `ApplicationManager.getApplication().executeOnPooledThread()`. The problem with the previous approach is that even in unit tests, it will use a background `ExecutorService` that is controlled by the IDEA SDK and is inaccessible from our tests. This makes testing code that submits runnables to this service hard to test because it's unknown when the task will be executed.

This PR adds the `ThreadUtil` class, where invocations to execute tasks in the background look like: `ThreadUtil.getInstance().executeInBackground()`. The `CloudToolsRule` also binds a direct executor to the implementation, causing tasks to be executed synchronously on the current thread for unit tests that use the `CloudToolsRule`.

This is prep work for the project selector search feature.