### PR TITLE
Fixes an errorprone warning by making an inner class static

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -56,7 +56,7 @@ final class GcsBucketContentEditorPanel {
     return bucketContentTable;
   }
 
-  private final class GcsBucketTableModel extends DefaultTableModel {
+  private static final class GcsBucketTableModel extends DefaultTableModel {
 
     GcsBucketTableModel(Iterable<Blob> blobs) {
       super();


### PR DESCRIPTION
The error-prone warning shown on builds is:

> google-cloud-intellij/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java:59: warning: [ClassCanBeStatic] Inner class is non-static but does not reference enclosing class
  private final class GcsBucketTableModel extends DefaultTableModel {
                ^
    (see http://errorprone.info/bugpattern/ClassCanBeStatic)
  Did you mean 'private static final class GcsBucketTableModel extends DefaultTableModel {'?