### PR TITLE
Fixes the scale of the user icon on HiDPI displays

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/GoogleLoginAction.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/GoogleLoginAction.java
@@ -65,7 +65,7 @@ public class GoogleLoginAction extends AnAction implements DumbAware, RightAlign
       if (image == null) {
         presentation.setIcon(GoogleLoginIcons.DEFAULT_USER_AVATAR);
       } else {
-        int size = (int) JBUI.pixScale(ICON_SIZE);
+        int size = JBUI.scale(ICON_SIZE);
         Image scaledImage = image.getScaledInstance(size, size, Image.SCALE_SMOOTH);
         presentation.setIcon(new ImageIcon(scaledImage));
       }


### PR DESCRIPTION
Fixes #1633.

This was a misunderstanding in the way the utilities in `JBUI` worked. The problem is that `pixScale()` combines the user scale factor with the system scale factor. In JRE-managed HiDPI mode, there are technically two different coordinate spaces (one for the user scale and the second for the system scale). The UI size metrics should be in the user coordinate space; the system scale property will determine the transform between this coordinate space and the system's coordinate space.

Instead of using `pixScale()` to scale the UI, `scale()` will return the correct size within the user coordinate space, leaving the system scaling up to the JRE.