### PR TITLE
Sets the default of the asset update checkbox to true

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
@@ -35,6 +35,7 @@ import com.intellij.remoteServer.util.CloudDeploymentNameConfiguration;
 import com.intellij.util.xmlb.annotations.Attribute;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang.StringUtils;
@@ -176,6 +177,48 @@ public class AppEngineDeploymentConfiguration
     if (deployable.getEnvironment() != null && deployable.getEnvironment().isFlexible()) {
       checkFlexConfig(deployable, project);
     }
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+
+    if (!(other instanceof AppEngineDeploymentConfiguration)) {
+      return false;
+    }
+
+    AppEngineDeploymentConfiguration otherConfig = (AppEngineDeploymentConfiguration) other;
+    return Objects.equals(cloudProjectName, otherConfig.cloudProjectName)
+        && Objects.equals(googleUsername, otherConfig.googleUsername)
+        && Objects.equals(environment, otherConfig.environment)
+        && Objects.equals(userSpecifiedArtifactPath, otherConfig.userSpecifiedArtifactPath)
+        && Objects.equals(promote, otherConfig.promote)
+        && Objects.equals(stopPreviousVersion, otherConfig.stopPreviousVersion)
+        && Objects.equals(version, otherConfig.version)
+        && Objects.equals(deployAllConfigs, otherConfig.deployAllConfigs)
+        && Objects.equals(moduleName, otherConfig.moduleName)
+        && Objects.equals(stagedArtifactName, otherConfig.stagedArtifactName)
+        && Objects.equals(isDefaultDeploymentName(), otherConfig.isDefaultDeploymentName())
+        && Objects.equals(getDeploymentName(), otherConfig.getDeploymentName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        cloudProjectName,
+        googleUsername,
+        environment,
+        userSpecifiedArtifactPath,
+        promote,
+        stopPreviousVersion,
+        version,
+        deployAllConfigs,
+        moduleName,
+        stagedArtifactName,
+        isDefaultDeploymentName(),
+        getDeploymentName());
   }
 
   private void checkCommonConfig(AppEngineDeployable deployable) throws RuntimeConfigurationError {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurator.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurator.java
@@ -33,11 +33,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Sets up the configuration elements for an AppEngine Cloud deployment.
- */
-public class AppEngineDeploymentConfigurator extends
-    DeploymentConfigurator<AppEngineDeploymentConfiguration, AppEngineServerConfiguration> {
+/** Sets up the configuration elements for an AppEngine Cloud deployment. */
+public class AppEngineDeploymentConfigurator
+    extends DeploymentConfigurator<AppEngineDeploymentConfiguration, AppEngineServerConfiguration> {
 
   private static final Logger logger = Logger.getInstance(AppEngineDeploymentConfigurator.class);
 
@@ -62,7 +60,15 @@ public class AppEngineDeploymentConfigurator extends
   @Override
   public AppEngineDeploymentConfiguration createDefaultConfiguration(
       @NotNull DeploymentSource source) {
-    return new AppEngineDeploymentConfiguration();
+    AppEngineDeploymentConfiguration configuration = new AppEngineDeploymentConfiguration();
+    if (source instanceof AppEngineDeployable) {
+      AppEngineEnvironment environment = ((AppEngineDeployable) source).getEnvironment();
+      if (environment != null && environment.isStandard()) {
+        configuration.setDeployAllConfigs(true);
+      }
+    }
+
+    return configuration;
   }
 
   @Nullable
@@ -72,7 +78,8 @@ public class AppEngineDeploymentConfigurator extends
       @NotNull RemoteServer<AppEngineServerConfiguration> server) {
     if (!(source instanceof AppEngineDeployable)) {
       logger.error(
-          String.format("Deployment source with name %s is not deployable to App Engine.",
+          String.format(
+              "Deployment source with name %s is not deployable to App Engine.",
               source.getPresentableName()));
       return null;
     }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurationTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurationTest.java
@@ -44,6 +44,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.remoteServer.configuration.RemoteServer;
 import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
+import com.intellij.remoteServer.util.CloudDeploymentNameConfiguration;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
 import java.io.File;
 import java.util.Optional;
@@ -423,6 +424,62 @@ public final class AppEngineDeploymentConfigurationTest {
     configuration.checkConfiguration(mockRemoteServer, mockAppEngineDeployable, project);
   }
 
+  @Test
+  public void equals_withEqualConfigs_doesReturnTrue() {
+    AppEngineDeploymentConfiguration configA = createPopulatedConfig();
+    AppEngineDeploymentConfiguration configB = createPopulatedConfig();
+
+    assertThat(configA.equals(configB)).isTrue();
+  }
+
+  @Test
+  public void equals_withNewConfigs_doesReturnTrue() {
+    AppEngineDeploymentConfiguration configA = new AppEngineDeploymentConfiguration();
+    AppEngineDeploymentConfiguration configB = new AppEngineDeploymentConfiguration();
+
+    assertThat(configA.equals(configB)).isTrue();
+  }
+
+  @Test
+  public void equals_withSameConfig_doesReturnTrue() {
+    AppEngineDeploymentConfiguration configA = createPopulatedConfig();
+    AppEngineDeploymentConfiguration configB = configA;
+
+    assertThat(configA.equals(configB)).isTrue();
+  }
+
+  @Test
+  public void equals_withOtherObject_doesReturnFalse() {
+    AppEngineDeploymentConfiguration configA = new AppEngineDeploymentConfiguration();
+    CloudDeploymentNameConfiguration configB = new CloudDeploymentNameConfiguration();
+
+    assertThat(configA.equals(configB)).isFalse();
+  }
+
+  @Test
+  public void equals_withDifferentConfigs_doesReturnFalse() {
+    AppEngineDeploymentConfiguration configA = createPopulatedConfig();
+    AppEngineDeploymentConfiguration configB = new AppEngineDeploymentConfiguration();
+
+    assertThat(configA.equals(configB)).isFalse();
+  }
+
+  @Test
+  public void hashCode_withEqualConfigs_doesReturnSameHashCode() {
+    int hashCodeA = createPopulatedConfig().hashCode();
+    int hashCodeB = createPopulatedConfig().hashCode();
+
+    assertThat(hashCodeA).isEqualTo(hashCodeB);
+  }
+
+  @Test
+  public void hashCode_withDifferentConfigs_doesReturnDifferentHashCodes() {
+    int hashCodeA = createPopulatedConfig().hashCode();
+    int hashCodeB = new AppEngineDeploymentConfiguration().hashCode();
+
+    assertThat(hashCodeA).isNotEqualTo(hashCodeB);
+  }
+
   /** Sets up the {@code configuration} to be valid for a deployment to a flex environment. */
   private void setUpValidFlexConfiguration() {
     when(mockCloudSdkService.validateCloudSdk()).thenReturn(ImmutableSet.of());
@@ -494,5 +551,26 @@ public final class AppEngineDeploymentConfigurationTest {
     when(mockAppEngineDeployable.getEnvironment())
         .thenReturn(AppEngineEnvironment.APP_ENGINE_STANDARD);
     configuration.setCloudProjectName("some-project-name");
+  }
+
+  /**
+   * Returns a fully populated {@link AppEngineDeploymentConfiguration} with non-default values for
+   * every field.
+   */
+  private static AppEngineDeploymentConfiguration createPopulatedConfig() {
+    AppEngineDeploymentConfiguration configuration = new AppEngineDeploymentConfiguration();
+    configuration.setCloudProjectName("cloud-project-name");
+    configuration.setGoogleUsername("google-username");
+    configuration.setEnvironment(AppEngineEnvironment.APP_ENGINE_FLEX);
+    configuration.setUserSpecifiedArtifactPath("user-specified-artifact-path");
+    configuration.setPromote(true);
+    configuration.setStopPreviousVersion(true);
+    configuration.setVersion("version");
+    configuration.setDeployAllConfigs(true);
+    configuration.setModuleName("module-name");
+    configuration.setStagedArtifactName("staged-artifact-name");
+    configuration.setDefaultDeploymentName(true);
+    configuration.setDeploymentName("deployment-name");
+    return configuration;
   }
 }


### PR DESCRIPTION
Fixes #1613.

Note that this also includes an implementation for `equals()` and `hashCode()` for the `AppEngineDeploymentConfiguration`, which is somewhat unrelated. We should have implemented these awhile ago and they're useful to compare the configs in the tests for the configurator. The actual fix is in `AppEngineDeploymentConfigurator`.