### PR TITLE
Update generated Dockerfile artifact names

### DIFF
--- a/google-cloud-tools-plugin/resources/fileTemplates/internal/JarDockerfile.gaedocker.ft
+++ b/google-cloud-tools-plugin/resources/fileTemplates/internal/JarDockerfile.gaedocker.ft
@@ -1,4 +1,5 @@
 FROM gcr.io/google_appengine/openjdk
-ADD target.jar /app/
+# Replace occurrences of ${project.build.finalName} with the name of the deployed jar
+ADD ${project.build.finalName}.jar /app/
 ENTRYPOINT ["/docker-entrypoint.bash"]
-CMD ["java","-jar","/app/target.jar"]
+CMD ["java","-jar","/app/${project.build.finalName}.jar"]

--- a/google-cloud-tools-plugin/resources/fileTemplates/internal/JarDockerfile.gaedocker.ft
+++ b/google-cloud-tools-plugin/resources/fileTemplates/internal/JarDockerfile.gaedocker.ft
@@ -1,5 +1,5 @@
 FROM gcr.io/google_appengine/openjdk
-# Replace occurrences of ${project.build.finalName} with the name of the deployed jar
-ADD ${project.build.finalName}.jar /app/
+# Replace occurrences of YOUR_ARTIFACT_NAME_HERE with the name of the deployed jar
+ADD YOUR_ARTIFACT_NAME_HERE.jar /app/
 ENTRYPOINT ["/docker-entrypoint.bash"]
-CMD ["java","-jar","/app/${project.build.finalName}.jar"]
+CMD ["java","-jar","/app/YOUR_ARTIFACT_NAME_HERE.jar"]

--- a/google-cloud-tools-plugin/resources/fileTemplates/internal/WarDockerfile.gaedocker.ft
+++ b/google-cloud-tools-plugin/resources/fileTemplates/internal/WarDockerfile.gaedocker.ft
@@ -1,2 +1,3 @@
 FROM gcr.io/google_appengine/jetty
-ADD target.war $JETTY_BASE/webapps/root.war
+# Replace ${project.build.finalName} with the name of the deployed war
+ADD ${project.build.finalName}.war $JETTY_BASE/webapps/root.war

--- a/google-cloud-tools-plugin/resources/fileTemplates/internal/WarDockerfile.gaedocker.ft
+++ b/google-cloud-tools-plugin/resources/fileTemplates/internal/WarDockerfile.gaedocker.ft
@@ -1,3 +1,3 @@
 FROM gcr.io/google_appengine/jetty
-# Replace ${project.build.finalName} with the name of the deployed war
-ADD ${project.build.finalName}.war $JETTY_BASE/webapps/root.war
+# Replace YOUR_ARTIFACT_NAME_HERE with the name of the deployed war
+ADD YOUR_ARTIFACT_NAME_HERE.war $JETTY_BASE/webapps/root.war


### PR DESCRIPTION
fixes #1648 

I updated the names of the artifact in the Docker templates to `${project.build.finalName}`. I went with this because presumably the user could configure the maven resource filtering to filter in this name into the Dockerfile. I am aware this won't work for native / gradle. But there are comments in the template now instructing the user to replace these.

I need to test that these new variables don't overly obfuscate the gcloud output when deployed as is.

@patflynn @nkibler wdyt?