### PR TITLE
Updates look and feel of GCS bucket content browser

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBlobNameCellRenderer.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBlobNameCellRenderer.java
@@ -27,10 +27,6 @@ import javax.swing.table.TableCellRenderer;
 /** Custom {@link TableCellRenderer} for rendering blob name cells. */
 final class GcsBlobNameCellRenderer extends DefaultTableCellRenderer {
 
-  GcsBlobNameCellRenderer() {
-    setOpaque(true);
-  }
-
   @Override
   public Component getTableCellRendererComponent(
       JTable table, Object blobName, boolean isSelected, boolean hasFocus, int row, int column) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBlobNameCellRenderer.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBlobNameCellRenderer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.gcs;
+
+import com.intellij.icons.AllIcons.FileTypes;
+import com.intellij.icons.AllIcons.Nodes;
+import java.awt.Color;
+import java.awt.Component;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
+
+/** Custom {@link TableCellRenderer} for rendering blob name cells. */
+final class GcsBlobNameCellRenderer extends DefaultTableCellRenderer {
+
+  GcsBlobNameCellRenderer() {
+    setOpaque(true);
+  }
+
+  @Override
+  public Component getTableCellRendererComponent(
+      JTable table, Object blobName, boolean isSelected, boolean hasFocus, int row, int column) {
+    Component c =
+        super.getTableCellRendererComponent(table, blobName, isSelected, hasFocus, row, column);
+
+    String name = (String) blobName;
+    setText(name);
+    setForeground(Color.BLACK);
+
+    if (name.endsWith("/")) {
+      setIcon(Nodes.Folder);
+    } else {
+      setIcon(FileTypes.Any_type);
+    }
+
+    return c;
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.form
@@ -38,7 +38,7 @@
         <properties/>
         <border type="none"/>
         <children>
-          <component id="b5290" class="javax.swing.JTable" binding="bucketContentTable">
+          <component id="b5290" class="javax.swing.JTable" binding="bucketContentTable" custom-create="true">
             <constraints/>
             <properties/>
           </component>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -21,11 +21,16 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
+import java.awt.Color;
+import java.awt.Font;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.List;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTable;
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellRenderer;
 import org.jetbrains.annotations.NotNull;
 
 /** Defines the Google Cloud Storage bucket content browsing UI panel. */
@@ -40,7 +45,9 @@ final class GcsBucketContentEditorPanel {
   private JTable bucketContentTable;
   private GcsBlobTableModel tableModel;
 
-  GcsBucketContentEditorPanel(@NotNull Bucket bucket) {
+  private static final Color MEDIUM_GRAY = new Color(96, 96, 96);
+
+      GcsBucketContentEditorPanel(@NotNull Bucket bucket) {
     this.bucket = bucket;
 
     bucketContentTable.addMouseListener(
@@ -57,6 +64,15 @@ final class GcsBucketContentEditorPanel {
             }
           }
         });
+    bucketContentTable.setRowHeight(23);
+    bucketContentTable.setForeground(MEDIUM_GRAY);
+
+    JTableHeader tableHeader = bucketContentTable.getTableHeader();
+    Font tableHeaderFont = tableHeader.getFont();
+    tableHeader.setFont(
+        new Font(tableHeaderFont.getFontName(), Font.BOLD, tableHeaderFont.getSize()));
+    tableHeader.setForeground(MEDIUM_GRAY);
+    tableHeader.setAlignmentX(JLabel.LEFT);
   }
 
   void initTableModel() {
@@ -99,5 +115,18 @@ final class GcsBucketContentEditorPanel {
   @VisibleForTesting
   JTable getBucketContentTable() {
     return bucketContentTable;
+  }
+
+  private void createUIComponents() {
+    bucketContentTable =
+        new JTable() {
+          @Override
+          public TableCellRenderer getCellRenderer(int row, int column) {
+            if (column == 0) {
+              return new GcsBlobNameCellRenderer();
+            }
+            return super.getCellRenderer(row, column);
+          }
+        };
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -47,7 +47,7 @@ final class GcsBucketContentEditorPanel {
 
   private static final Color MEDIUM_GRAY = new Color(96, 96, 96);
 
-      GcsBucketContentEditorPanel(@NotNull Bucket bucket) {
+  GcsBucketContentEditorPanel(@NotNull Bucket bucket) {
     this.bucket = bucket;
 
     bucketContentTable.addMouseListener(


### PR DESCRIPTION
Updates the table look and feel containing the GCS bucket contents.

Before:

![image](https://user-images.githubusercontent.com/1735744/30665546-54ff0b68-9e1f-11e7-9b9e-dcebb41fb0c1.png)

After:

![image](https://user-images.githubusercontent.com/1735744/30665498-2b5bb93c-9e1f-11e7-9551-5d1a60eab9a6.png)

![image](https://user-images.githubusercontent.com/1735744/30665514-352421de-9e1f-11e7-9687-b18578a4a74e.png)