### PR TITLE
Handle empty GCS buckets and empty blob directories

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -346,8 +346,8 @@ gcs.panel.bucket.listing.no.project.selected=To view your buckets select a Cloud
 gcs.panel.bucket.listing.error.loading.buckets=Could not load buckets for selected project.
 gcs.panel.bucket.listing.no.buckets.found=No buckets found for selected project.
 gcs.panel.bucket.listing.loading.text=loading ...
-gcs.content.explorer.no.files.in.bucket=No files found in this bucket
-gcs.content.explorer.no.files.in.directory=No files found in this directory
+gcs.content.explorer.empty.bucket.text=No files or directories found in this bucket
+gcs.content.explorer.empty.directory.text=No files found in this directory
 
 settings.error.closing.file=Error closing settings file {0}.\nError details: {1}
 #{0} and {1} in the below message represent open and closing tags of a hyperlink.

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -346,6 +346,8 @@ gcs.panel.bucket.listing.no.project.selected=To view your buckets select a Cloud
 gcs.panel.bucket.listing.error.loading.buckets=Could not load buckets for selected project.
 gcs.panel.bucket.listing.no.buckets.found=No buckets found for selected project.
 gcs.panel.bucket.listing.loading.text=loading ...
+gcs.content.explorer.no.files.in.bucket=No files found in this bucket
+gcs.content.explorer.no.files.in.directory=No files found in this directory
 
 settings.error.closing.file=Error closing settings file {0}.\nError details: {1}
 #{0} and {1} in the below message represent open and closing tags of a hyperlink.

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.cloud.tools.intellij.gcs.GcsBucketContentEditorPanel">
-  <grid id="27dc6" binding="bucketContentEditorPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="bucketContentEditorPanel" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -33,9 +33,9 @@
           </component>
         </children>
       </grid>
-      <scrollpane id="531fe">
+      <scrollpane id="531fe" binding="bucketContentScrollPane">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -66,6 +66,33 @@
           </component>
         </children>
       </grid>
+      <grid id="f3353" binding="noBlobsPanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="50" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <enabled value="true"/>
+          <visible value="false"/>
+        </properties>
+        <border type="none"/>
+        <children>
+          <component id="4e124" class="javax.swing.JLabel" binding="noBlobsLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+              <visible value="true"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <vspacer id="ecde1">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -98,7 +98,7 @@ final class GcsBucketContentEditorPanel {
   void initTableModel() {
     List<Blob> blobs = getBlobsStartingWith("");
     if (blobs.isEmpty()) {
-      showEmptyBlobs(GctBundle.message("gcs.content.explorer.no.files.in.bucket"));
+      showEmptyBlobs(GctBundle.message("gcs.content.explorer.empty.bucket.text"));
     } else {
       showBlobTable();
       tableModel = new GcsBlobTableModel();
@@ -120,8 +120,8 @@ final class GcsBucketContentEditorPanel {
     if (isEmptyDirectory(prefix, blobs)) {
       String message =
           prefix.isEmpty()
-              ? GctBundle.message("gcs.content.explorer.no.files.in.bucket")
-              : GctBundle.message("gcs.content.explorer.no.files.in.directory");
+              ? GctBundle.message("gcs.content.explorer.empty.bucket.text")
+              : GctBundle.message("gcs.content.explorer.empty.directory.text");
       showEmptyBlobs(message);
     } else {
       showBlobTable();

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -165,7 +165,7 @@ final class GcsBucketContentEditorPanel {
    * Tests if a given directory prefix is empty. A directory is empty if there are no blobs or if
    * the only blob matches the current directory prefix.
    */
-  private boolean isEmptyDirectory(String prefix, List<Blob> blobs) {
+  private static boolean isEmptyDirectory(String prefix, List<Blob> blobs) {
     return blobs.isEmpty() || (blobs.size() == 1 && blobs.get(0).getName().equals(prefix));
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -29,6 +29,7 @@ import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.table.JTableHeader;
@@ -44,6 +45,9 @@ final class GcsBucketContentEditorPanel {
   private JTable bucketContentTable;
   private JButton refreshButton;
   private GcsBreadcrumbsTextPane breadcrumbs;
+  private JLabel noBlobsLabel;
+  private JPanel noBlobsPanel;
+  private JScrollPane bucketContentScrollPane;
   private GcsBlobTableModel tableModel;
 
   private static final Color MEDIUM_GRAY = new Color(96, 96, 96);
@@ -92,7 +96,10 @@ final class GcsBucketContentEditorPanel {
 
   void initTableModel() {
     List<Blob> blobs = getBlobsStartingWith("");
-    if (!blobs.isEmpty()) {
+    if (blobs.isEmpty()) {
+      showEmptyBlobs("No files found in this bucket");
+    } else {
+      showBlobTable();
       tableModel = new GcsBlobTableModel();
       tableModel.setDataVector(blobs, "");
       bucketContentTable.setModel(tableModel);
@@ -101,10 +108,36 @@ final class GcsBucketContentEditorPanel {
   }
 
   void updateTableModel(String prefix) {
+    if (tableModel == null) {
+      initTableModel();
+      return;
+    }
+
     tableModel.setRowCount(0);
-    tableModel.setDataVector(getBlobsStartingWith(prefix), prefix);
-    tableModel.fireTableDataChanged();
+    List<Blob> blobs = getBlobsStartingWith(prefix);
+
+    if (isEmptyDirectory(prefix, blobs)) {
+      String message =
+          prefix.isEmpty() ? "No files found in this bucket" : "No files found in this directory";
+      showEmptyBlobs(message);
+    } else {
+      showBlobTable();
+
+      tableModel.setDataVector(blobs, prefix);
+      tableModel.fireTableDataChanged();
+    }
     breadcrumbs.render(bucket.getName(), prefix);
+  }
+
+  private void showEmptyBlobs(String message) {
+    bucketContentScrollPane.setVisible(false);
+    noBlobsPanel.setVisible(true);
+    noBlobsLabel.setText(message);
+  }
+
+  private void showBlobTable() {
+    noBlobsPanel.setVisible(false);
+    bucketContentScrollPane.setVisible(true);
   }
 
   /**
@@ -125,6 +158,14 @@ final class GcsBucketContentEditorPanel {
         bucket.list(BlobListOption.currentDirectory(), BlobListOption.prefix(prefix)).iterateAll());
   }
 
+  /**
+   * Tests if a given directory prefix is empty. A directory is empty if there are no blobs or if
+   * the only blob matches the current directory prefix.
+   */
+  private boolean isEmptyDirectory(String prefix, List<Blob> blobs) {
+    return blobs.isEmpty() || (blobs.size() == 1 && blobs.get(0).getName().equals(prefix));
+  }
+
   JPanel getComponent() {
     return bucketContentEditorPanel;
   }
@@ -132,6 +173,21 @@ final class GcsBucketContentEditorPanel {
   @VisibleForTesting
   JTable getBucketContentTable() {
     return bucketContentTable;
+  }
+
+  @VisibleForTesting
+  JScrollPane getBucketContentScrollPane() {
+    return bucketContentScrollPane;
+  }
+
+  @VisibleForTesting
+  JLabel getNoBlobsLabel() {
+    return noBlobsLabel;
+  }
+
+  @VisibleForTesting
+  JPanel getNoBlobsPanel() {
+    return noBlobsPanel;
   }
 
   private void createUIComponents() {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.intellij.gcs;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.tools.intellij.util.GctBundle;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import java.awt.Color;
@@ -97,7 +98,7 @@ final class GcsBucketContentEditorPanel {
   void initTableModel() {
     List<Blob> blobs = getBlobsStartingWith("");
     if (blobs.isEmpty()) {
-      showEmptyBlobs("No files found in this bucket");
+      showEmptyBlobs(GctBundle.message("gcs.content.explorer.no.files.in.bucket"));
     } else {
       showBlobTable();
       tableModel = new GcsBlobTableModel();
@@ -118,7 +119,9 @@ final class GcsBucketContentEditorPanel {
 
     if (isEmptyDirectory(prefix, blobs)) {
       String message =
-          prefix.isEmpty() ? "No files found in this bucket" : "No files found in this directory";
+          prefix.isEmpty()
+              ? GctBundle.message("gcs.content.explorer.no.files.in.bucket")
+              : GctBundle.message("gcs.content.explorer.no.files.in.directory");
       showEmptyBlobs(message);
     } else {
       showBlobTable();

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
@@ -162,7 +162,7 @@ public class GcsBucketContentEditorPanelTest {
 
     assertFalse(bucketScrollPane.isVisible());
     assertTrue(noBlobsPanel.isVisible());
-    assertThat(noBlobsLabel.getText()).isEqualTo("No files found in this bucket");
+    assertThat(noBlobsLabel.getText()).isEqualTo("No files or directories found in this bucket");
 
     // add blobs and update bucket
     setBlobs(binaryBlob);
@@ -190,7 +190,7 @@ public class GcsBucketContentEditorPanelTest {
 
     assertFalse(bucketScrollPane.isVisible());
     assertTrue(noBlobsPanel.isVisible());
-    assertThat(noBlobsLabel.getText()).isEqualTo("No files found in this bucket");
+    assertThat(noBlobsLabel.getText()).isEqualTo("No files or directories found in this bucket");
   }
 
   @Test

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
@@ -17,6 +17,8 @@
 package com.google.cloud.tools.intellij.gcs;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.google.api.gax.paging.Page;
@@ -31,6 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.IntStream;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import org.junit.Before;
 import org.junit.Rule;
@@ -42,7 +47,7 @@ public class GcsBucketContentEditorPanelTest {
   @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
   @Rule public final TimeZoneRule timeZoneRule = new TimeZoneRule(TimeZone.getTimeZone("GMT"));
 
-  private static final String DIR_NAME = "my_directory";
+  private static final String DIR_NAME = "dir1/dir2/";
   private static final String BLOB_NAME = "my_blob.zip";
   private static final String BLOB_CONTENT_TYPE = "application/zip";
   private static final String NESTED_BLOB_FULL_NAME = "dir1/dir2/nested_blob.zip";
@@ -55,9 +60,9 @@ public class GcsBucketContentEditorPanelTest {
   private GcsBucketContentEditorPanel editorPanel;
   private GcsBucketVirtualFile bucketVirtualFile;
 
-  @Mock private Blob directoryBlob;
   @Mock private Blob binaryBlob;
-  @Mock private Blob nestedBlob;
+  @Mock private Blob directoryBlob;
+  @Mock private Blob binaryBlobInDirectory;
 
   @Before
   public void setUp() {
@@ -72,7 +77,7 @@ public class GcsBucketContentEditorPanelTest {
     when(binaryBlob.getContentType()).thenReturn(BLOB_CONTENT_TYPE);
     when(binaryBlob.getUpdateTime()).thenReturn(0L);
 
-    when(nestedBlob.getName()).thenReturn(NESTED_BLOB_FULL_NAME);
+    when(binaryBlobInDirectory.getName()).thenReturn(NESTED_BLOB_FULL_NAME);
   }
 
   @Test
@@ -87,7 +92,7 @@ public class GcsBucketContentEditorPanelTest {
 
   @Test
   public void testBucketEditorColumnHeaders() {
-    initBlobEditor(directoryBlob);
+    initEditorWithBlobs(directoryBlob);
 
     JTable bucketTable = editorPanel.getBucketContentTable();
     assertThat(bucketTable.getColumnCount()).isEqualTo(4);
@@ -101,7 +106,7 @@ public class GcsBucketContentEditorPanelTest {
 
   @Test
   public void testBucketContent_singleDirectoryBlob() {
-    initBlobEditor(directoryBlob);
+    initEditorWithBlobs(directoryBlob);
 
     JTable bucketTable = editorPanel.getBucketContentTable();
     assertThat(bucketTable.getRowCount()).isEqualTo(1);
@@ -114,7 +119,7 @@ public class GcsBucketContentEditorPanelTest {
 
   @Test
   public void testBucketContent_singleBinaryBlob() {
-    initBlobEditor(binaryBlob);
+    initEditorWithBlobs(binaryBlob);
 
     JTable bucketTable = editorPanel.getBucketContentTable();
     assertThat(bucketTable.getRowCount()).isEqualTo(1);
@@ -129,7 +134,7 @@ public class GcsBucketContentEditorPanelTest {
 
   @Test
   public void testBuckets_mixedBinaryAndDirectoryBlobs() {
-    initBlobEditor(binaryBlob, directoryBlob);
+    initEditorWithBlobs(binaryBlob, directoryBlob);
 
     JTable bucketTable = editorPanel.getBucketContentTable();
     assertThat(bucketTable.getRowCount()).isEqualTo(2);
@@ -137,7 +142,7 @@ public class GcsBucketContentEditorPanelTest {
 
   @Test
   public void testBucketName_directoryPrefixIsTrimmed() {
-    initBlobEditor(nestedBlob);
+    initEditorWithBlobs(binaryBlobInDirectory);
     editorPanel.updateTableModel("dir1/dir2/");
 
     JTable bucketTable = editorPanel.getBucketContentTable();
@@ -146,9 +151,95 @@ public class GcsBucketContentEditorPanelTest {
   }
 
   @Test
+  public void testUpdateEmptyBucket_toNonEmptyBucket() {
+    // setup empty bucket
+    editorPanel = new GcsBucketContentEditorPanel(bucketVirtualFile.getBucket());
+    editorPanel.initTableModel();
+
+    JScrollPane bucketScrollPane = editorPanel.getBucketContentScrollPane();
+    JPanel noBlobsPanel = editorPanel.getNoBlobsPanel();
+    JLabel noBlobsLabel = editorPanel.getNoBlobsLabel();
+
+    assertFalse(bucketScrollPane.isVisible());
+    assertTrue(noBlobsPanel.isVisible());
+    assertThat(noBlobsLabel.getText()).isEqualTo("No files found in this bucket");
+
+    // add blobs and update bucket
+    setBlobs(binaryBlob);
+    editorPanel.updateTableModel("");
+
+    assertTrue(bucketScrollPane.isVisible());
+    assertFalse(noBlobsPanel.isVisible());
+  }
+
+  @Test
+  public void testUpdateNonEmptyBucket_toEmptyBucket() {
+    // setup bucket with blobs
+    initEditorWithBlobs(binaryBlob);
+
+    JScrollPane bucketScrollPane = editorPanel.getBucketContentScrollPane();
+    JPanel noBlobsPanel = editorPanel.getNoBlobsPanel();
+    JLabel noBlobsLabel = editorPanel.getNoBlobsLabel();
+
+    assertTrue(bucketScrollPane.isVisible());
+    assertFalse(noBlobsPanel.isVisible());
+
+    // remove blobs and update
+    setBlobs();
+    editorPanel.updateTableModel("");
+
+    assertFalse(bucketScrollPane.isVisible());
+    assertTrue(noBlobsPanel.isVisible());
+    assertThat(noBlobsLabel.getText()).isEqualTo("No files found in this bucket");
+  }
+
+  @Test
+  public void testUpdateEmptyDirectory_toNonEmptyDirectory() {
+    // Create an empty directory and move to it
+    initEditorWithBlobs(directoryBlob);
+    editorPanel.updateTableModel(DIR_NAME);
+
+    JScrollPane bucketScrollPane = editorPanel.getBucketContentScrollPane();
+    JPanel noBlobsPanel = editorPanel.getNoBlobsPanel();
+    JLabel noBlobsLabel = editorPanel.getNoBlobsLabel();
+
+    assertFalse(bucketScrollPane.isVisible());
+    assertTrue(noBlobsPanel.isVisible());
+    assertThat(noBlobsLabel.getText()).isEqualTo("No files found in this directory");
+
+    // Add a blob to the directory and update
+    setBlobs(binaryBlobInDirectory);
+    editorPanel.updateTableModel(DIR_NAME);
+
+    assertTrue(bucketScrollPane.isVisible());
+    assertFalse(noBlobsPanel.isVisible());
+  }
+
+  @Test
+  public void testUpdateNonEmptyDirectory_toEmptyDirectory() {
+    // setup bucket directory with blobs
+    initEditorWithBlobs(directoryBlob, binaryBlobInDirectory);
+
+    JScrollPane bucketScrollPane = editorPanel.getBucketContentScrollPane();
+    JPanel noBlobsPanel = editorPanel.getNoBlobsPanel();
+    JLabel noBlobsLabel = editorPanel.getNoBlobsLabel();
+
+    assertTrue(bucketScrollPane.isVisible());
+    assertFalse(noBlobsPanel.isVisible());
+
+    // remove blobs from the directory and update
+    setBlobs(directoryBlob);
+    editorPanel.updateTableModel(DIR_NAME);
+
+    assertFalse(bucketScrollPane.isVisible());
+    assertTrue(noBlobsPanel.isVisible());
+    assertThat(noBlobsLabel.getText()).isEqualTo("No files found in this directory");
+  }
+
+  @Test
   public void testBlobSizeDisplay_Bytes() {
     when(binaryBlob.getSize()).thenReturn(100L);
-    initBlobEditor(binaryBlob);
+    initEditorWithBlobs(binaryBlob);
     JTable bucketTable = editorPanel.getBucketContentTable();
 
     assertThat(bucketTable.getValueAt(0, COL_NAME_TO_INDEX.get("Size"))).isEqualTo("100 B");
@@ -157,7 +248,7 @@ public class GcsBucketContentEditorPanelTest {
   @Test
   public void testBlobSizeDisplay_KB() {
     when(binaryBlob.getSize()).thenReturn(102400L);
-    initBlobEditor(binaryBlob);
+    initEditorWithBlobs(binaryBlob);
     JTable bucketTable = editorPanel.getBucketContentTable();
 
     assertThat(bucketTable.getValueAt(0, COL_NAME_TO_INDEX.get("Size"))).isEqualTo("100.0 KB");
@@ -166,7 +257,7 @@ public class GcsBucketContentEditorPanelTest {
   @Test
   public void testBlobSizeDisplay_MB() {
     when(binaryBlob.getSize()).thenReturn(104857600L);
-    initBlobEditor(binaryBlob);
+    initEditorWithBlobs(binaryBlob);
     JTable bucketTable = editorPanel.getBucketContentTable();
 
     assertThat(bucketTable.getValueAt(0, COL_NAME_TO_INDEX.get("Size"))).isEqualTo("100.0 MB");
@@ -175,18 +266,21 @@ public class GcsBucketContentEditorPanelTest {
   @Test
   public void testBlobSizeDisplay_GB() {
     when(binaryBlob.getSize()).thenReturn(107374182400L);
-    initBlobEditor(binaryBlob);
+    initEditorWithBlobs(binaryBlob);
     JTable bucketTable = editorPanel.getBucketContentTable();
 
     assertThat(bucketTable.getValueAt(0, COL_NAME_TO_INDEX.get("Size"))).isEqualTo("100.0 GB");
   }
 
-  private void initBlobEditor(Blob... blobs) {
+  private void initEditorWithBlobs(Blob... blobs) {
+    setBlobs(blobs);
+    editorPanel = new GcsBucketContentEditorPanel(bucketVirtualFile.getBucket());
+    editorPanel.initTableModel();
+  }
+
+  private void setBlobs(Blob... blobs) {
     List<Blob> blobList = Lists.newArrayList(blobs);
     Page<Blob> blobPage = bucketVirtualFile.getBucket().list();
     when(blobPage.iterateAll()).thenReturn(blobList);
-
-    editorPanel = new GcsBucketContentEditorPanel(bucketVirtualFile.getBucket());
-    editorPanel.initTableModel();
   }
 }


### PR DESCRIPTION
Does 2 main things:

1) Handles initial display of empty GCS buckets and empty directories
2) Handles update of buckets and directories when moving from empty to non-empty and vice versa by refreshing. For example, a bucket is initially empty, the user then updates the contents of the bucket outside of the IDE, then refreshes the bucket in the IDE.