### PR TITLE
Allow GCS bucket explorer table to take up full vertical space

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.cloud.tools.intellij.gcs.GcsBucketContentEditorPanel">
-  <grid id="27dc6" binding="bucketContentEditorPanel" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="bucketContentEditorPanel" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -42,7 +42,9 @@
         <children>
           <component id="b5290" class="javax.swing.JTable" binding="bucketContentTable" custom-create="true">
             <constraints/>
-            <properties/>
+            <properties>
+              <fillsViewportHeight value="true"/>
+            </properties>
           </component>
         </children>
       </scrollpane>
@@ -88,11 +90,6 @@
           </component>
         </children>
       </grid>
-      <vspacer id="ecde1">
-        <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </vspacer>
       <grid id="97c04" binding="loadingPanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="50" left="0" bottom="0" right="0"/>
         <constraints>


### PR DESCRIPTION
fixes #1679 

The table will now expand vertically to fill the available space:

Before:
<img width="1209" alt="screen shot 2017-10-05 at 3 16 36 pm" src="https://user-images.githubusercontent.com/1735744/31248138-db76c588-a9e0-11e7-8625-778e4e62a913.png">

Now:
<img width="816" alt="screen shot 2017-10-05 at 3 20 34 pm" src="https://user-images.githubusercontent.com/1735744/31248134-d732d750-a9e0-11e7-82e7-8f68a93ce4e5.png">
