### PR TITLE
Adds a tool menu action for GCS

### DIFF
--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -468,6 +468,8 @@
       <action id="GoogleCloudTools.CloudDebugger" class="com.google.cloud.tools.intellij.debugger.CloudDebuggerToolsMenuAction"/>
       <separator/>
       <reference ref="GoogleCloudTools.UploadSourceToGCP"/>
+      <!--<separator/>-->
+      <!--<action id="GoogleCloudTools.CloudStorage" class="com.google.cloud.tools.intellij.gcs.GcsToolWindowAction"/>-->
       <separator/>
       <action id="GoogleCloudTools.Feedback" class="com.google.cloud.tools.intellij.CloudToolsFeedbackAction"/>
 

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -349,6 +349,8 @@ gcs.panel.bucket.listing.loading.text=loading ...
 gcs.content.explorer.empty.bucket.text=No files or directories found in this bucket
 gcs.content.explorer.empty.directory.text=No files found in this directory
 gcs.content.explorer.loading.error.text=Error loading bucket contents
+gcs.tools.menu.action.text=Browse Google Cloud Storage buckets
+gcs.tools.menu.action.description=Open the Google Cloud Storage explorer
 
 settings.error.closing.file=Error closing settings file {0}.\nError details: {1}
 #{0} and {1} in the below message represent open and closing tags of a hyperlink.

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsToolWindowAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsToolWindowAction.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.gcs;
+
+import com.google.cloud.tools.intellij.ui.GoogleCloudToolsIcons;
+import com.google.cloud.tools.intellij.util.GctBundle;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+
+/**
+ * Creates a shortcut action to open the Google Cloud storage explorer in the Google Cloud Tools
+ * tool menu group.
+ */
+public final class GcsToolWindowAction extends DumbAwareAction {
+
+  public GcsToolWindowAction() {
+    super(
+        GctBundle.message("gcs.tools.menu.action.text"),
+        GctBundle.message("gcs.tools.menu.action.description"),
+        GoogleCloudToolsIcons.CLOUD_STORAGE);
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent event) {
+    Project project = event.getProject();
+    if (project != null) {
+      ToolWindow window =
+          ToolWindowManager.getInstance(project).getToolWindow("Google Cloud Storage");
+      window.activate(null /*runnable*/);
+    }
+  }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1735744/31401449-e234ebdc-adc0-11e7-890b-a10449aaa136.png)

When clicked, the action will open the GCS tool window panel and focus on the project selector. 

The platform is making it really difficult for me to add a test to cover this, but will look a little bit more.