### PR TITLE
 Prevent browsing GCS bucket blobs when logged out

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -349,6 +349,7 @@ gcs.panel.bucket.listing.loading.text=loading ...
 gcs.content.explorer.empty.bucket.text=No files or directories found in this bucket
 gcs.content.explorer.empty.directory.text=No files found in this directory
 gcs.content.explorer.loading.error.text=Error loading bucket contents
+gcs.content.explorer.not.logged.in.text=To view bucket contents log in to your Google Cloud Platform account
 gcs.tools.menu.action.text=Browse Google Cloud Storage buckets
 gcs.tools.menu.action.description=Open the Google Cloud Storage explorer
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.form
@@ -76,7 +76,7 @@
               </component>
             </children>
           </grid>
-          <grid id="f3353" binding="noBlobsPanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="f3353" binding="messagePanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="50" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -87,7 +87,7 @@
             </properties>
             <border type="none"/>
             <children>
-              <component id="4e124" class="javax.swing.JLabel" binding="noBlobsLabel">
+              <component id="4e124" class="javax.swing.JLabel" binding="messageLabel">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -101,7 +101,7 @@ final class GcsBucketContentEditorPanel {
 
   void initTableModel() {
     if (!Services.getLoginService().isLoggedIn()) {
-      showMessage(GctBundle.message("gcs.content.explorer.loading.error.text"));
+      showMessage(GctBundle.message("gcs.content.explorer.not.logged.in.text"));
       return;
     }
 
@@ -123,7 +123,7 @@ final class GcsBucketContentEditorPanel {
 
   void updateTableModel(String prefix) {
     if (!Services.getLoginService().isLoggedIn()) {
-      showMessage(GctBundle.message("gcs.content.explorer.loading.error.text"));
+      showMessage(GctBundle.message("gcs.content.explorer.not.logged.in.text"));
       return;
     }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -20,6 +20,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.StorageException;
+import com.google.cloud.tools.intellij.login.Services;
 import com.google.cloud.tools.intellij.util.GctBundle;
 import com.google.cloud.tools.intellij.util.ThreadUtil;
 import com.google.common.annotations.VisibleForTesting;
@@ -51,8 +52,8 @@ final class GcsBucketContentEditorPanel {
   private JTable bucketContentTable;
   private JButton refreshButton;
   private GcsBreadcrumbsTextPane breadcrumbs;
-  private JLabel noBlobsLabel;
-  private JPanel noBlobsPanel;
+  private JLabel messageLabel;
+  private JPanel messagePanel;
   private JScrollPane bucketContentScrollPane;
   private JPanel loadingPanel;
   private JPanel errorPanel;
@@ -99,10 +100,15 @@ final class GcsBucketContentEditorPanel {
   }
 
   void initTableModel() {
+    if (!Services.getLoginService().isLoggedIn()) {
+      showMessage(GctBundle.message("gcs.content.explorer.loading.error.text"));
+      return;
+    }
+
     Consumer<List<Blob>> afterLoad =
         blobs -> {
           if (blobs.isEmpty()) {
-            showEmptyBlobs(GctBundle.message("gcs.content.explorer.empty.bucket.text"));
+            showMessage(GctBundle.message("gcs.content.explorer.empty.bucket.text"));
           } else {
             showBlobTable();
             tableModel = new GcsBlobTableModel();
@@ -116,6 +122,11 @@ final class GcsBucketContentEditorPanel {
   }
 
   void updateTableModel(String prefix) {
+    if (!Services.getLoginService().isLoggedIn()) {
+      showMessage(GctBundle.message("gcs.content.explorer.loading.error.text"));
+      return;
+    }
+
     if (tableModel == null) {
       initTableModel();
       return;
@@ -130,7 +141,7 @@ final class GcsBucketContentEditorPanel {
                 prefix.isEmpty()
                     ? GctBundle.message("gcs.content.explorer.empty.bucket.text")
                     : GctBundle.message("gcs.content.explorer.empty.directory.text");
-            showEmptyBlobs(message);
+            showMessage(message);
           } else {
             showBlobTable();
 
@@ -143,14 +154,14 @@ final class GcsBucketContentEditorPanel {
     loadBlobsStartingWith(prefix, afterLoad);
   }
 
-  private void showEmptyBlobs(String message) {
+  private void showMessage(String message) {
     bucketContentScrollPane.setVisible(false);
-    noBlobsPanel.setVisible(true);
-    noBlobsLabel.setText(message);
+    messagePanel.setVisible(true);
+    messageLabel.setText(message);
   }
 
   private void showBlobTable() {
-    noBlobsPanel.setVisible(false);
+    messagePanel.setVisible(false);
     bucketContentScrollPane.setVisible(true);
   }
 
@@ -214,7 +225,7 @@ final class GcsBucketContentEditorPanel {
   private void showLoader() {
     loadingPanel.setVisible(true);
     bucketContentScrollPane.setVisible(false);
-    noBlobsPanel.setVisible(false);
+    messagePanel.setVisible(false);
   }
 
   private void hideLoader() {
@@ -244,8 +255,8 @@ final class GcsBucketContentEditorPanel {
   }
 
   @VisibleForTesting
-  JLabel getNoBlobsLabel() {
-    return noBlobsLabel;
+  JLabel getMessageLabel() {
+    return messageLabel;
   }
 
   @VisibleForTesting
@@ -254,8 +265,8 @@ final class GcsBucketContentEditorPanel {
   }
 
   @VisibleForTesting
-  JPanel getNoBlobsPanel() {
-    return noBlobsPanel;
+  JPanel getMessagePanel() {
+    return messagePanel;
   }
 
   @VisibleForTesting

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
@@ -188,8 +188,8 @@ public class GcsBucketContentEditorPanelTest {
     editorPanel.initTableModel();
 
     JScrollPane bucketScrollPane = editorPanel.getBucketContentScrollPane();
-    JPanel noBlobsPanel = editorPanel.getNoBlobsPanel();
-    JLabel noBlobsLabel = editorPanel.getNoBlobsLabel();
+    JPanel noBlobsPanel = editorPanel.getMessagePanel();
+    JLabel noBlobsLabel = editorPanel.getMessageLabel();
 
     assertFalse(bucketScrollPane.isVisible());
     assertTrue(noBlobsPanel.isVisible());
@@ -209,8 +209,8 @@ public class GcsBucketContentEditorPanelTest {
     initEditorWithBlobs(binaryBlob);
 
     JScrollPane bucketScrollPane = editorPanel.getBucketContentScrollPane();
-    JPanel noBlobsPanel = editorPanel.getNoBlobsPanel();
-    JLabel noBlobsLabel = editorPanel.getNoBlobsLabel();
+    JPanel noBlobsPanel = editorPanel.getMessagePanel();
+    JLabel noBlobsLabel = editorPanel.getMessageLabel();
 
     assertTrue(bucketScrollPane.isVisible());
     assertFalse(noBlobsPanel.isVisible());
@@ -231,8 +231,8 @@ public class GcsBucketContentEditorPanelTest {
     editorPanel.updateTableModel(DIR_NAME);
 
     JScrollPane bucketScrollPane = editorPanel.getBucketContentScrollPane();
-    JPanel noBlobsPanel = editorPanel.getNoBlobsPanel();
-    JLabel noBlobsLabel = editorPanel.getNoBlobsLabel();
+    JPanel noBlobsPanel = editorPanel.getMessagePanel();
+    JLabel noBlobsLabel = editorPanel.getMessageLabel();
 
     assertFalse(bucketScrollPane.isVisible());
     assertTrue(noBlobsPanel.isVisible());
@@ -252,8 +252,8 @@ public class GcsBucketContentEditorPanelTest {
     initEditorWithBlobs(directoryBlob, binaryBlobInDirectory);
 
     JScrollPane bucketScrollPane = editorPanel.getBucketContentScrollPane();
-    JPanel noBlobsPanel = editorPanel.getNoBlobsPanel();
-    JLabel noBlobsLabel = editorPanel.getNoBlobsLabel();
+    JPanel noBlobsPanel = editorPanel.getMessagePanel();
+    JLabel noBlobsLabel = editorPanel.getMessageLabel();
 
     assertTrue(bucketScrollPane.isVisible());
     assertFalse(noBlobsPanel.isVisible());
@@ -314,7 +314,7 @@ public class GcsBucketContentEditorPanelTest {
     JTable bucketTable = editorPanel.getBucketContentTable();
     assertThat(bucketTable.getColumnCount()).isEqualTo(0);
     assertThat(bucketTable.getRowCount()).isEqualTo(0);
-    assertFalse(editorPanel.getNoBlobsPanel().isVisible());
+    assertFalse(editorPanel.getMessagePanel().isVisible());
     assertFalse(editorPanel.getLoadingPanel().isVisible());
     assertTrue(editorPanel.getErrorPanel().isVisible());
   }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanelTest.java
@@ -27,8 +27,10 @@ import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.StorageException;
+import com.google.cloud.tools.intellij.login.GoogleLoginService;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.DelayedSubmitExecutorServiceProxy;
+import com.google.cloud.tools.intellij.testing.TestService;
 import com.google.cloud.tools.intellij.testing.TimeZoneRule;
 import com.google.cloud.tools.intellij.util.ThreadUtil;
 import com.google.common.collect.BiMap;
@@ -65,6 +67,7 @@ public class GcsBucketContentEditorPanelTest {
 
   private GcsBucketContentEditorPanel editorPanel;
 
+  @TestService @Mock private GoogleLoginService loginService;
   @Mock private Blob binaryBlob;
   @Mock private Blob directoryBlob;
   @Mock private Blob binaryBlobInDirectory;
@@ -73,6 +76,8 @@ public class GcsBucketContentEditorPanelTest {
   @Before
   public void setUp() {
     GcsTestUtils.setupVirtualFileWithBucketMocks(bucketVirtualFile);
+
+    when(loginService.isLoggedIn()).thenReturn(true);
 
     when(directoryBlob.isDirectory()).thenReturn(true);
     when(directoryBlob.getName()).thenReturn(DIR_NAME);
@@ -94,6 +99,17 @@ public class GcsBucketContentEditorPanelTest {
     JTable bucketTable = editorPanel.getBucketContentTable();
     assertThat(bucketTable.getColumnCount()).isEqualTo(0);
     assertThat(bucketTable.getRowCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void testLoginMessageShown_whenLoggedOut() {
+    when(loginService.isLoggedIn()).thenReturn(false);
+    editorPanel = new GcsBucketContentEditorPanel(bucketVirtualFile.getBucket());
+    editorPanel.initTableModel();
+
+    assertTrue(editorPanel.getMessagePanel().isVisible());
+    assertThat(editorPanel.getMessageLabel().getText())
+        .isEqualTo("To view bucket contents log in to your Google Cloud Platform account");
   }
 
   @Test


### PR DESCRIPTION
Fixes #1692

Attempting any action after logging results in:
![image](https://user-images.githubusercontent.com/1735744/31517135-fde6471e-af68-11e7-9b60-031cfa8b7ea6.png)

Logging back in and then refreshing allows resuming where the user left off.