### PR TITLE
Add GCS blob name and bucket name copy actions

### DIFF
--- a/common-lib/src/main/java/com/google/cloud/tools/intellij/ui/CopyToClipboardActionListener.java
+++ b/common-lib/src/main/java/com/google/cloud/tools/intellij/ui/CopyToClipboardActionListener.java
@@ -23,7 +23,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 /** {@link ActionListener} that copies text to the clipboard on action performed. */
-public class CopyToClipboardActionListener implements ActionListener {
+public final class CopyToClipboardActionListener implements ActionListener {
   private final String text;
 
   public CopyToClipboardActionListener(String text) {

--- a/common-lib/src/main/java/com/google/cloud/tools/intellij/ui/CopyToClipboardActionListener.java
+++ b/common-lib/src/main/java/com/google/cloud/tools/intellij/ui/CopyToClipboardActionListener.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.ui;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/** {@link ActionListener} that copies text to the clipboard on action performed. */
+public class CopyToClipboardActionListener implements ActionListener {
+  private final String text;
+
+  public CopyToClipboardActionListener(String text) {
+    this.text = text;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent event) {
+    Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+    clipboard.setContents(new StringSelection(text), null /*owner*/);
+  }
+}

--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -449,9 +449,9 @@
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">
-    <!--<toolWindow id="Google Cloud Storage" anchor="right"-->
-                <!--factoryClass="com.google.cloud.tools.intellij.gcs.GcsToolWindowFactory"/>-->
-    <!--<fileEditorProvider implementation="com.google.cloud.tools.intellij.gcs.GcsBucketEditorProvider"/>-->
+    <toolWindow id="Google Cloud Storage" anchor="right"
+                factoryClass="com.google.cloud.tools.intellij.gcs.GcsToolWindowFactory"/>
+    <fileEditorProvider implementation="com.google.cloud.tools.intellij.gcs.GcsBucketEditorProvider"/>
   </extensions>
 
   <actions>
@@ -468,8 +468,8 @@
       <action id="GoogleCloudTools.CloudDebugger" class="com.google.cloud.tools.intellij.debugger.CloudDebuggerToolsMenuAction"/>
       <separator/>
       <reference ref="GoogleCloudTools.UploadSourceToGCP"/>
-      <!--<separator/>-->
-      <!--<action id="GoogleCloudTools.CloudStorage" class="com.google.cloud.tools.intellij.gcs.GcsToolWindowAction"/>-->
+      <separator/>
+      <action id="GoogleCloudTools.CloudStorage" class="com.google.cloud.tools.intellij.gcs.GcsToolWindowAction"/>
       <separator/>
       <action id="GoogleCloudTools.Feedback" class="com.google.cloud.tools.intellij.CloudToolsFeedbackAction"/>
 

--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -449,9 +449,9 @@
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">
-    <toolWindow id="Google Cloud Storage" anchor="right"
-                factoryClass="com.google.cloud.tools.intellij.gcs.GcsToolWindowFactory"/>
-    <fileEditorProvider implementation="com.google.cloud.tools.intellij.gcs.GcsBucketEditorProvider"/>
+    <!--<toolWindow id="Google Cloud Storage" anchor="right"-->
+                <!--factoryClass="com.google.cloud.tools.intellij.gcs.GcsToolWindowFactory"/>-->
+    <!--<fileEditorProvider implementation="com.google.cloud.tools.intellij.gcs.GcsBucketEditorProvider"/>-->
   </extensions>
 
   <actions>
@@ -468,8 +468,8 @@
       <action id="GoogleCloudTools.CloudDebugger" class="com.google.cloud.tools.intellij.debugger.CloudDebuggerToolsMenuAction"/>
       <separator/>
       <reference ref="GoogleCloudTools.UploadSourceToGCP"/>
-      <separator/>
-      <action id="GoogleCloudTools.CloudStorage" class="com.google.cloud.tools.intellij.gcs.GcsToolWindowAction"/>
+      <!--<separator/>-->
+      <!--<action id="GoogleCloudTools.CloudStorage" class="com.google.cloud.tools.intellij.gcs.GcsToolWindowAction"/>-->
       <separator/>
       <action id="GoogleCloudTools.Feedback" class="com.google.cloud.tools.intellij.CloudToolsFeedbackAction"/>
 

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -351,6 +351,8 @@ gcs.content.explorer.empty.bucket.text=No files or directories found in this buc
 gcs.content.explorer.empty.directory.text=No files found in this directory
 gcs.content.explorer.loading.error.text=Error loading bucket contents
 gcs.content.explorer.not.logged.in.text=To view bucket contents log in to your Google Cloud Platform account
+gcs.content.explorer.right.click.menu.copy.blob.text=Copy blob name to clipboard
+gcs.content.explorer.right.click.menu.copy.bucket.text=Copy bucket name to clipboard
 gcs.tools.menu.action.text=Browse Google Cloud Storage buckets
 gcs.tools.menu.action.description=Open the Google Cloud Storage explorer
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBlobTableModel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBlobTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Vector;
 import java.util.stream.Collectors;
 import javax.swing.table.DefaultTableModel;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Table model representation of a Google Cloud Storage blob row. Handles display of blob name and
@@ -41,11 +42,16 @@ final class GcsBlobTableModel extends DefaultTableModel {
     return false;
   }
 
+  @Nullable
   Blob getBlobAt(int index) {
     if (blobs == null) {
       throw new IllegalStateException("Data vector with blob values not initialized.");
     }
-    return blobs.get(index);
+    try {
+      return blobs.get(index);
+    } catch (IndexOutOfBoundsException ex) {
+      return null;
+    }
   }
 
   void setDataVector(List<Blob> blobs, String directoryPrefix) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -343,7 +343,7 @@ final class GcsBucketContentEditorPanel {
     }
 
     @Override
-    public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent event) {
       Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
       clipboard.setContents(new StringSelection(text), null /*owner*/);
     }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -28,15 +28,23 @@ import com.google.common.collect.Lists;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import java.awt.Font;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.SwingUtilities;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableCellRenderer;
@@ -73,6 +81,24 @@ final class GcsBucketContentEditorPanel {
               if (selectedBlob.isDirectory()) {
                 updateTableModel(selectedBlob.getName());
               }
+            }
+          }
+        });
+
+    bucketContentTable.addMouseListener(
+        new MouseAdapter() {
+          @Override
+          public void mousePressed(MouseEvent event) {
+            if (SwingUtilities.isRightMouseButton(event)) {
+              JTable source = (JTable) event.getSource();
+              int row = source.rowAtPoint(event.getPoint());
+              int col = source.columnAtPoint(event.getPoint());
+
+              if (!source.isRowSelected(row)) {
+                source.changeSelection(row, col, false, false);
+              }
+
+              showRightClickMenu(event);
             }
           }
         });
@@ -152,6 +178,22 @@ final class GcsBucketContentEditorPanel {
 
     breadcrumbs.render(bucket.getName(), prefix);
     loadBlobsStartingWith(prefix, afterLoad);
+  }
+
+  private void showRightClickMenu(MouseEvent event) {
+    JPopupMenu rightClickMenu = new JPopupMenu();
+    JMenuItem copyBlobNameMenuItem = new JMenuItem("Copy blob name");
+    JMenuItem copyBucketNameMenuItem = new JMenuItem("Copy bucket name");
+    rightClickMenu.add(copyBlobNameMenuItem);
+    rightClickMenu.add(copyBucketNameMenuItem);
+
+    Blob selectedBlob = tableModel.getBlobAt(bucketContentTable.rowAtPoint(event.getPoint()));
+
+    copyBlobNameMenuItem.addActionListener(new CopyToClipboardMouseAdapter(selectedBlob.getName()));
+    copyBucketNameMenuItem.addActionListener(
+        new CopyToClipboardMouseAdapter(selectedBlob.getBucket()));
+
+    rightClickMenu.show(event.getComponent(), event.getX(), event.getY());
   }
 
   private void showMessage(String message) {
@@ -290,5 +332,20 @@ final class GcsBucketContentEditorPanel {
             return super.getCellRenderer(row, column);
           }
         };
+  }
+
+  private static class CopyToClipboardMouseAdapter implements ActionListener {
+
+    private final String text;
+
+    CopyToClipboardMouseAdapter(String text) {
+      this.text = text;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+      Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+      clipboard.setContents(new StringSelection(text), null /*owner*/);
+    }
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -182,8 +182,10 @@ final class GcsBucketContentEditorPanel {
 
   private void showRightClickMenu(MouseEvent event) {
     JPopupMenu rightClickMenu = new JPopupMenu();
-    JMenuItem copyBlobNameMenuItem = new JMenuItem("Copy blob name");
-    JMenuItem copyBucketNameMenuItem = new JMenuItem("Copy bucket name");
+    JMenuItem copyBlobNameMenuItem =
+        new JMenuItem(GctBundle.message("gcs.content.explorer.right.click.menu.copy.blob.text"));
+    JMenuItem copyBucketNameMenuItem =
+        new JMenuItem(GctBundle.message("gcs.content.explorer.right.click.menu.copy.bucket.text"));
     rightClickMenu.add(copyBlobNameMenuItem);
     rightClickMenu.add(copyBucketNameMenuItem);
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -78,7 +78,7 @@ final class GcsBucketContentEditorPanel {
               Blob selectedBlob =
                   tableModel.getBlobAt(bucketContentTable.rowAtPoint(event.getPoint()));
 
-              if (selectedBlob.isDirectory()) {
+              if (selectedBlob != null && selectedBlob.isDirectory()) {
                 updateTableModel(selectedBlob.getName());
               }
             }
@@ -191,11 +191,14 @@ final class GcsBucketContentEditorPanel {
 
     Blob selectedBlob = tableModel.getBlobAt(bucketContentTable.rowAtPoint(event.getPoint()));
 
-    copyBlobNameMenuItem.addActionListener(new CopyToClipboardMouseAdapter(selectedBlob.getName()));
-    copyBucketNameMenuItem.addActionListener(
-        new CopyToClipboardMouseAdapter(selectedBlob.getBucket()));
+    if (selectedBlob != null) {
+      copyBlobNameMenuItem.addActionListener(
+          new CopyToClipboardMouseAdapter(selectedBlob.getName()));
+      copyBucketNameMenuItem.addActionListener(
+          new CopyToClipboardMouseAdapter(selectedBlob.getBucket()));
 
-    rightClickMenu.show(event.getComponent(), event.getX(), event.getY());
+      rightClickMenu.show(event.getComponent(), event.getX(), event.getY());
+    }
   }
 
   private void showMessage(String message) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketContentEditorPanel.java
@@ -21,6 +21,7 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.tools.intellij.login.Services;
+import com.google.cloud.tools.intellij.ui.CopyToClipboardActionListener;
 import com.google.cloud.tools.intellij.util.GctBundle;
 import com.google.cloud.tools.intellij.util.ThreadUtil;
 import com.google.common.annotations.VisibleForTesting;
@@ -28,11 +29,6 @@ import com.google.common.collect.Lists;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import java.awt.Font;
-import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.StringSelection;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.List;
@@ -193,9 +189,9 @@ final class GcsBucketContentEditorPanel {
 
     if (selectedBlob != null) {
       copyBlobNameMenuItem.addActionListener(
-          new CopyToClipboardMouseAdapter(selectedBlob.getName()));
+          new CopyToClipboardActionListener(selectedBlob.getName()));
       copyBucketNameMenuItem.addActionListener(
-          new CopyToClipboardMouseAdapter(selectedBlob.getBucket()));
+          new CopyToClipboardActionListener(selectedBlob.getBucket()));
 
       rightClickMenu.show(event.getComponent(), event.getX(), event.getY());
     }
@@ -337,20 +333,5 @@ final class GcsBucketContentEditorPanel {
             return super.getCellRenderer(row, column);
           }
         };
-  }
-
-  private static class CopyToClipboardMouseAdapter implements ActionListener {
-
-    private final String text;
-
-    CopyToClipboardMouseAdapter(String text) {
-      this.text = text;
-    }
-
-    @Override
-    public void actionPerformed(ActionEvent event) {
-      Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-      clipboard.setContents(new StringSelection(text), null /*owner*/);
-    }
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketPanel.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.intellij.login.CredentialedUser;
 import com.google.cloud.tools.intellij.login.Services;
 import com.google.cloud.tools.intellij.resources.GoogleApiClientFactory;
 import com.google.cloud.tools.intellij.resources.ProjectSelector;
+import com.google.cloud.tools.intellij.ui.CopyToClipboardActionListener;
 import com.google.cloud.tools.intellij.util.GctBundle;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
@@ -41,7 +42,10 @@ import java.util.concurrent.Future;
 import javax.swing.DefaultListModel;
 import javax.swing.JLabel;
 import javax.swing.JList;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -93,6 +97,19 @@ final class GcsBucketPanel {
               if (clickedBucket != null) {
                 loadBucketContents(clickedBucket);
               }
+            }
+          }
+        });
+
+    bucketList.addMouseListener(
+        new MouseAdapter() {
+          @Override
+          public void mousePressed(MouseEvent event) {
+            if (SwingUtilities.isRightMouseButton(event)) {
+              JList source = (JList) event.getSource();
+              source.setSelectedIndex(source.locationToIndex(event.getPoint()));
+
+              showRightClickMenu(event);
             }
           }
         });
@@ -224,5 +241,20 @@ final class GcsBucketPanel {
   private void showBucketListPanel() {
     bucketListPanel.setVisible(true);
     notificationPanel.setVisible(false);
+  }
+
+  private void showRightClickMenu(MouseEvent event) {
+    JPopupMenu rightClickMenu = new JPopupMenu();
+    JMenuItem copyBlobNameMenuItem =
+        new JMenuItem(GctBundle.message("gcs.content.explorer.right.click.menu.copy.blob.text"));
+    rightClickMenu.add(copyBlobNameMenuItem);
+
+    int index = bucketList.locationToIndex(event.getPoint());
+    Bucket bucket = bucketListModel.getElementAt(index);
+
+    if (bucket != null) {
+      copyBlobNameMenuItem.addActionListener(new CopyToClipboardActionListener(bucket.getName()));
+      rightClickMenu.show(event.getComponent(), event.getX(), event.getY());
+    }
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketPanel.java
@@ -245,15 +245,15 @@ final class GcsBucketPanel {
 
   private void showRightClickMenu(MouseEvent event) {
     JPopupMenu rightClickMenu = new JPopupMenu();
-    JMenuItem copyBlobNameMenuItem =
-        new JMenuItem(GctBundle.message("gcs.content.explorer.right.click.menu.copy.blob.text"));
-    rightClickMenu.add(copyBlobNameMenuItem);
+    JMenuItem copyBucketNameMenuItem =
+        new JMenuItem(GctBundle.message("gcs.content.explorer.right.click.menu.copy.bucket.text"));
+    rightClickMenu.add(copyBucketNameMenuItem);
 
     int index = bucketList.locationToIndex(event.getPoint());
     Bucket bucket = bucketListModel.getElementAt(index);
 
     if (bucket != null) {
-      copyBlobNameMenuItem.addActionListener(new CopyToClipboardActionListener(bucket.getName()));
+      copyBucketNameMenuItem.addActionListener(new CopyToClipboardActionListener(bucket.getName()));
       rightClickMenu.show(event.getComponent(), event.getX(), event.getY());
     }
   }


### PR DESCRIPTION
fixes #1671 

POC - still needs a little cleanup. 

See the issues for rationale behind this.

![image](https://user-images.githubusercontent.com/1735744/31563468-33209bcc-b02d-11e7-8a22-9e7afedc5182.png)

blob name: an absolute path to the blob; e.g. `folder1/folder2/myblob.zip`

What do you think of this approach? I was also considering having a little bottom notification panel popup on clicking on one of the copy actions to acknowledge that the text was copied (and show its contents).