### PR TITLE
Upgrades appengine-plugins-core version to 0.3.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ intellijRepoUrl = https://storage.googleapis.com/cloud-tools-for-java-team-kokor
 javaVersion = 1.8
 ijPluginRepoChannel = alpha
 version = 17.9.3-SNAPSHOT
-toolsLibVersion = 0.3.8
+toolsLibVersion = 0.3.9


### PR DESCRIPTION
This new version has the `CloudLibraries` utility that returns the list of libraries from the JSON metadata file.