### PR TITLE
Get rid of unused method breaking in EAP

### DIFF
--- a/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/BasePluginTestCase.java
+++ b/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/BasePluginTestCase.java
@@ -18,15 +18,10 @@ package com.google.cloud.tools.intellij.testing;
 
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.extensions.DefaultPluginDescriptor;
-import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.extensions.Extensions;
-import com.intellij.openapi.extensions.PluginId;
-import com.intellij.openapi.extensions.impl.ExtensionPointImpl;
 import com.intellij.openapi.extensions.impl.ExtensionsAreaImpl;
 import com.intellij.openapi.project.Project;
 import com.intellij.testFramework.TestRunnerUtil;
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -65,19 +60,6 @@ public class BasePluginTestCase {
    */
   protected <T> void registerService(Class<T> clazz, T instance) {
     applicationContainer.registerComponentInstance(clazz.getName(), instance);
-  }
-
-  /**
-   * Register your extension points for test here.
-   */
-  protected <N, T extends N> ExtensionPointImpl<T> registerExtensionPoint(
-      @NotNull ExtensionPointName<N> name,
-      @NotNull Class<T> type) {
-    extensionsArea.registerExtensionPoint(
-        name.getName(),
-        type.getName(),
-        new DefaultPluginDescriptor(PluginId.getId(type.getName()), type.getClassLoader()));
-    return extensionsArea.getExtensionPoint(name.getName());
   }
 
   @After


### PR DESCRIPTION
Fixes the latest EAP failure: https://sponge.corp.google.com/target?id=b4b9775f-d533-4dcd-bfea-23a043e06916&target=google-cloud-intellij%2Fgcp_ubuntu%2Feap%2Fcontinuous&searchFor=