### PR TITLE
Forces the popup panel initialization on show every time

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/ProjectSelector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/ProjectSelector.java
@@ -409,8 +409,8 @@ public class ProjectSelector extends CustomizableComboBox implements Customizabl
     if (popup == null || popup.isDisposed()) {
       if (popupPanel == null) {
         popupPanel = new PopupPanel();
-        popupPanel.initializeContent(getText());
       }
+      popupPanel.initializeContent(getText());
 
       ComponentPopupBuilder popup =
           JBPopupFactory.getInstance()
@@ -556,6 +556,8 @@ public class ProjectSelector extends CustomizableComboBox implements Customizabl
         treeModel.setModelNeedsRefresh(false);
         synchronize(true);
       }
+
+      setFilter(selectedProjectId);
     }
 
     @Override


### PR DESCRIPTION
Fixes #1693.

I spent way too much time trying to find a proper solution, which is to essentially rewrite the `ProjectSelector`. This is a quick fix that forces the panel to be re-initialized every time the pop-up is shown. It also applies the filter every time the pop-up is shown, not just when the text changes.