### PR TITLE
Fixes project selector reloading issues with applied filters

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/GoogleUserModelItem.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/GoogleUserModelItem.java
@@ -231,17 +231,31 @@ class GoogleUserModelItem extends DefaultMutableTreeNode {
   }
 
   @Override
+  public void remove(int childIndex) {
+    if (children == null) {
+      // Preserved functionality from default getChildAt() implementation.
+      throw new ArrayIndexOutOfBoundsException("node has no children");
+    }
+
+    // This is different from the default implementation because it uses the raw children vector
+    // instead of relying on the getChildAt() method, which has been modified to only return
+    // filtered children.
+    MutableTreeNode child = (MutableTreeNode) children.elementAt(childIndex);
+    children.removeElementAt(childIndex);
+    child.setParent(null);
+  }
+
+  @Override
   public void removeAllChildren() {
     if (children == null) {
       return;
     }
 
+    // This is different from the default implementation because it uses the raw children vector
+    // instead of relying on the getChildCount() method, which has been modified to only return
+    // the number of filtered children.
     for (int i = children.size() - 1; i >= 0; i--) {
-      // We do this manually because the overridden getChildCount() method will only return the
-      // count of filtered results and not all child nodes.
-      MutableTreeNode child = (MutableTreeNode) children.elementAt(i);
-      children.removeElementAt(i);
-      child.setParent(null);
+      remove(i);
     }
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/GoogleUserModelItem.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/GoogleUserModelItem.java
@@ -206,8 +206,10 @@ class GoogleUserModelItem extends DefaultMutableTreeNode {
               GoogleUserModelItem.this.add(item);
             }
 
-            // Re-applies the filter to the new child nodes.
-            setFilter(filter);
+            if (!Strings.isNullOrEmpty(filter)) {
+              // Re-applies the filter to the new child nodes.
+              setFilter(filter);
+            }
             treeModel.reload(GoogleUserModelItem.this);
           });
     } catch (InterruptedException ex) {


### PR DESCRIPTION
Fixes #1709.

The problem is that the filtering logic overrides the `getChildAt()` and `getChildCount()` methods in the `GoogleUserModelItem`. While it's important to do this for rendering purposes (so it only renders filtered children), when removing children, we never want to restrict the removal to just the filtered children. This PR adds overrides to the `remove()` and `removeAllChildren()` methods to not rely on the `getChildAt()` or `getChildCount()` methods and instead use the raw `children` vector directly.