### PR TITLE
Suppresses warnings for "JdkObsolete" on the Vector class

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBlobTableModel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBlobTableModel.java
@@ -54,6 +54,7 @@ final class GcsBlobTableModel extends DefaultTableModel {
     }
   }
 
+  @SuppressWarnings("JdkObsolete")
   void setDataVector(List<Blob> blobs, String directoryPrefix) {
     this.blobs =
         blobs
@@ -65,6 +66,7 @@ final class GcsBlobTableModel extends DefaultTableModel {
         buildDataVector(this.blobs, directoryPrefix), new Vector<>(TABLE_COL_HEADER));
   }
 
+  @SuppressWarnings("JdkObsolete")
   private static Vector<Vector<String>> buildDataVector(List<Blob> blobs, String directoryPrefix) {
     return blobs
         .stream()


### PR DESCRIPTION
Fixes #1707.

As mentioned in the issue, we have to use `Vector` because the `DefaultTableModel` superclass (a Swing class) asks for a `Vector` in their `.setDataVector()` method signature.