### PR TITLE
Fixes the ProjectSelector issues related to text changed listeners.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineApplicationInfoPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineApplicationInfoPanel.java
@@ -114,31 +114,30 @@ public class AppEngineApplicationInfoPanel extends JPanel {
   }
 
   private void setMessage(Runnable messagePrinter, boolean isError) {
-    ApplicationManager.getApplication().invokeAndWait(() -> {
-      errorIcon.setVisible(isError);
-      messagePrinter.run();
-    }, ModalityState.stateForComponent(this));
-  }
+    ApplicationManager.getApplication()
+        .invokeAndWait(
+            () -> {
+              errorIcon.setVisible(isError);
 
-  /**
-   * Prints a message with a hyperlink.
-   */
-  private void setMessage(String beforeLinkText, String linkText, String afterLinkText) {
-    setMessage(() -> messageText.setHyperlinkText(beforeLinkText, linkText, afterLinkText), true);
+              // TODO(nkibler): Figure out what's causing the HyperlinkLabel to not refresh its view
+              // if we re-use the label here.
+              remove(messageText);
+              messageText = new HyperlinkLabel();
+              messageText.setOpaque(false);
+              add(messageText);
+
+              messagePrinter.run();
+            },
+            ModalityState.stateForComponent(this));
   }
 
   private void setCreateApplicationMessage(String projectId, Credential credential) {
-    // TODO(nkibler): Figure out what's causing the HyperlinkLabel to not refresh its view if we
-    // re-use the label here.
-    remove(messageText);
-    messageText = new HyperlinkLabel();
-    messageText.setOpaque(false);
-    add(messageText);
-
     messageText.addHyperlinkListener(new CreateApplicationLinkListener(projectId, credential));
-    setMessage(GctBundle.getString("appengine.application.not.exist") + " ",
-        GctBundle.getString("appengine.application.create.linkText"),
-        " " + GctBundle.getString("appengine.application.create.afterLinkText"));
+
+    String beforeLinkText = GctBundle.getString("appengine.application.not.exist") + " ";
+    String linkText = GctBundle.getString("appengine.application.create.linkText");
+    String afterLinkText = " " + GctBundle.getString("appengine.application.create.afterLinkText");
+    setMessage(() -> messageText.setHyperlinkText(beforeLinkText, linkText, afterLinkText), true);
   }
 
   /**

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineApplicationInfoPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineApplicationInfoPanel.java
@@ -21,25 +21,20 @@ import com.google.api.services.appengine.v1.model.Application;
 import com.google.cloud.tools.intellij.appengine.application.AppEngineAdminService;
 import com.google.cloud.tools.intellij.appengine.application.AppEngineApplicationCreateDialog;
 import com.google.cloud.tools.intellij.appengine.application.GoogleApiException;
-import com.google.cloud.tools.intellij.resources.ProjectSelector.ProjectSelectionChangedEvent;
 import com.google.cloud.tools.intellij.util.GctBundle;
-
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.ui.HyperlinkLabel;
-
+import git4idea.DialogManager;
 import java.awt.BorderLayout;
 import java.io.IOException;
-
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkEvent.EventType;
 import javax.swing.event.HyperlinkListener;
-
-import git4idea.DialogManager;
 
 /**
  * A {@link JPanel} that displays contextual information about an App Engine Application.
@@ -50,9 +45,7 @@ public class AppEngineApplicationInfoPanel extends JPanel {
   private static final int COMPONENTS_VERTICAL_PADDING = 0;
 
   private final JLabel errorIcon;
-  private final HyperlinkLabel messageText;
-
-  private CreateApplicationLinkListener currentLinkListener;
+  private HyperlinkLabel messageText;
 
   public AppEngineApplicationInfoPanel() {
     super(new BorderLayout(COMPONENTS_HORIZONTAL_PADDING, COMPONENTS_VERTICAL_PADDING));
@@ -64,29 +57,6 @@ public class AppEngineApplicationInfoPanel extends JPanel {
 
     add(errorIcon, BorderLayout.WEST);
     add(messageText);
-  }
-
-  @SuppressWarnings("FutureReturnValueIgnored")
-  /**
-   * Updates the panel as follows:
-   *   if the project textbox specifies a valid project, it displays the project's information,
-   *   if the project textbox specifies an invalid project, it displays an error message,
-   *   if the project textbox is empty, no message is displayed.
-   */
-  public void refresh(final ProjectSelectionChangedEvent event) {
-    if (event == null) {
-      ApplicationManager.getApplication().executeOnPooledThread(() -> clearMessage());
-      return;
-    }
-
-    if (event.getSelectedProject() == null) {
-      ApplicationManager.getApplication().executeOnPooledThread(
-          () -> setMessage(GctBundle.getString("appengine.infopanel.no.region"),
-              true /* isError*/));
-      return;
-    }
-
-    refresh(event.getSelectedProject().getProjectId(), event.getUser().getCredential());
   }
 
   /**
@@ -158,14 +128,14 @@ public class AppEngineApplicationInfoPanel extends JPanel {
   }
 
   private void setCreateApplicationMessage(String projectId, Credential credential) {
-    // dispose the old link listener and replace with a new instance that has the current args
-    if (currentLinkListener != null) {
-      // if the listener is not found, this is a no-op
-      messageText.removeHyperlinkListener(currentLinkListener);
-    }
-    currentLinkListener = new CreateApplicationLinkListener(projectId, credential);
-    messageText.addHyperlinkListener(currentLinkListener);
+    // TODO(nkibler): Figure out what's causing the HyperlinkLabel to not refresh its view if we
+    // re-use the label here.
+    remove(messageText);
+    messageText = new HyperlinkLabel();
+    messageText.setOpaque(false);
+    add(messageText);
 
+    messageText.addHyperlinkListener(new CreateApplicationLinkListener(projectId, credential));
     setMessage(GctBundle.getString("appengine.application.not.exist") + " ",
         GctBundle.getString("appengine.application.create.linkText"),
         " " + GctBundle.getString("appengine.application.create.afterLinkText"));

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurationPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfigurationPanel.java
@@ -22,18 +22,17 @@ import com.google.cloud.tools.intellij.ui.BrowserOpeningHyperLinkListener;
 import com.google.cloud.tools.intellij.util.GctBundle;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-
 import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
+import com.intellij.ui.DocumentAdapter;
 import com.intellij.ui.HyperlinkLabel;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.tree.TreeModelAdapter;
-
-import org.jetbrains.annotations.NotNull;
-
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.event.DocumentEvent;
 import javax.swing.event.TreeModelEvent;
+import org.jetbrains.annotations.NotNull;
 
 /** Common App Engine deployment configuration UI shared by flexible and standard deployments. */
 public final class AppEngineDeploymentConfigurationPanel {
@@ -86,13 +85,18 @@ public final class AppEngineDeploymentConfigurationPanel {
     appEngineCostWarningLabel.addHyperlinkListener(new BrowserOpeningHyperLinkListener());
     appEngineCostWarningLabel.setHyperlinkTarget(CloudSdkAppEngineHelper.APP_ENGINE_BILLING_URL);
 
-    projectSelector.addProjectSelectionListener(applicationInfoPanel::refresh);
-
     projectSelector.addModelListener(
         new TreeModelAdapter() {
           @Override
           public void treeStructureChanged(TreeModelEvent event) {
             // projects have finished loading
+            refreshApplicationInfoPanel();
+          }
+        });
+    projectSelector.addTextChangedListener(
+        new DocumentAdapter() {
+          @Override
+          protected void textChanged(DocumentEvent e) {
             refreshApplicationInfoPanel();
           }
         });

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/ui/ProjectDebuggeeBinding.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/ui/ProjectDebuggeeBinding.java
@@ -27,7 +27,6 @@ import com.google.cloud.tools.intellij.login.CredentialedUser;
 import com.google.cloud.tools.intellij.resources.ProjectSelector;
 import com.google.cloud.tools.intellij.util.GctBundle;
 import com.google.common.base.Strings;
-
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -35,19 +34,15 @@ import com.intellij.openapi.project.Project;
 import com.intellij.ui.DocumentAdapter;
 import com.intellij.util.containers.HashMap;
 import com.intellij.util.ui.tree.TreeModelAdapter;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.io.IOException;
 import java.util.Map;
-
 import javax.swing.Action;
 import javax.swing.JComboBox;
 import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.TreeModelEvent;
-import javax.swing.event.TreeModelListener;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This binding between the project and debuggee is refactored out to make it reusable in the
@@ -76,7 +71,7 @@ class ProjectDebuggeeBinding {
     this.targetSelector = targetSelector;
     this.okAction = okAction;
 
-    this.projectSelector.getDocument().addDocumentListener(new DocumentAdapter() {
+    this.projectSelector.addTextChangedListener(new DocumentAdapter() {
       @Override
       protected void textChanged(DocumentEvent event) {
         refreshDebugTargetList();

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/gcs/GcsBucketPanel.java
@@ -57,6 +57,7 @@ import org.jetbrains.annotations.NotNull;
  * Storage API to load project buckets.
  */
 final class GcsBucketPanel {
+
   private static final Logger log = Logger.getInstance(GcsBucketPanel.class);
 
   private final Project project;
@@ -79,8 +80,7 @@ final class GcsBucketPanel {
     bucketList.setBackground(bucketListPanel.getBackground());
 
     projectSelector
-        .getDocument()
-        .addDocumentListener(
+        .addTextChangedListener(
             new DocumentAdapter() {
               @Override
               protected void textChanged(DocumentEvent event) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/ProjectSelector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/ProjectSelector.java
@@ -74,6 +74,7 @@ import org.jetbrains.annotations.Nullable;
  * IntellijGoogleLoginService} to get the set of credentialed users and then into
  * resource manager to get the set of projects. The result is displayed in a tree view organized by
  * google login. */
+// TODO(nkibler): Re-do this mess so we can remove the plethora of hacky solutions for listeners.
 public class ProjectSelector extends CustomizableComboBox implements CustomizableComboBoxPopup {
 
   // An empty marker is used because the template engine validates even
@@ -92,6 +93,7 @@ public class ProjectSelector extends CustomizableComboBox implements Customizabl
   private JBPopup popup;
   private PopupPanel popupPanel;
   private List<ProjectSelectionListener> projectSelectionListeners;
+  private final List<DocumentAdapter> textChangedListeners = new ArrayList<>();
 
   public ProjectSelector() {
     this(false);
@@ -180,6 +182,7 @@ public class ProjectSelector extends CustomizableComboBox implements Customizabl
                 if (popupPanel != null) {
                   popupPanel.setFilter(getText());
                 }
+                textChangedListeners.forEach(listener -> listener.changedUpdate(e));
               }
             });
 
@@ -206,6 +209,10 @@ public class ProjectSelector extends CustomizableComboBox implements Customizabl
                     .connect()
                     .subscribe(
                         GoogleLoginListener.GOOGLE_LOGIN_LISTENER_TOPIC, () -> synchronize(true)));
+  }
+
+  public void addTextChangedListener(DocumentAdapter listener) {
+    textChangedListeners.add(listener);
   }
 
   public void addModelListener(TreeModelListener listener) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/vcs/CloneCloudRepositoryDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/vcs/CloneCloudRepositoryDialog.java
@@ -211,7 +211,7 @@ public class CloneCloudRepositoryDialog extends DialogWrapper {
   private void createUIComponents() {
     projectSelector = new ProjectSelector();
     projectSelector.setMinimumSize(new Dimension(300, 0));
-    projectSelector.getDocument().addDocumentListener(new DocumentAdapter() {
+    projectSelector.addTextChangedListener(new DocumentAdapter() {
       @Override
       protected void textChanged(DocumentEvent event) {
         if (defaultDirectoryName.equals(directoryName.getText())

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/vcs/SetupCloudRepositoryDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/vcs/SetupCloudRepositoryDialog.java
@@ -106,7 +106,7 @@ public class SetupCloudRepositoryDialog extends DialogWrapper {
 
     remoteNameSelector = new RepositoryRemotePanel(gitRepository);
 
-    projectSelector.getDocument().addDocumentListener(new DocumentAdapter() {
+    projectSelector.addTextChangedListener(new DocumentAdapter() {
       @Override
       protected void textChanged(DocumentEvent event) {
         repositorySelector.setCloudProject(projectSelector.getText());


### PR DESCRIPTION
Fixes #1717 and #1714.

There's several temporary, hacky solutions in this PR that solve a few issues:

1. **Issue:** In the GCR/GCS/deployment config editor windows, backspacing the `ProjectSelector` text so the text becomes a valid project does not properly update other dependent windows/dropdowns/etc. to read from this valid project.
  **Cause:** The listeners were attached directly to the text field document. This is also how the listener to apply the filter to the TreeModel is attached. We are not guaranteed an order here; if the filter listener does not run first, it will not add back the model item to the tree that matches the project so the other listeners will get `null` when trying to pull the selected project from the `ProjectSelector`.
  **Solution:** Add a `.addTextChangedListener()` method to the `ProjectSelector` and manually trigger these listeners, only after the filter listener runs first.
1. **Issue:** Even after the change above, the deployment config editor still does not update the region text if it is supposed to go from "Can't retrieve region for selected project" to the hyperlink text to create an App Engine app.
  **Cause:** Not 100% sure, but it seems like something internal to the `HyperlinkLabel` that we're using (part of the IntelliJ SDK). Somehow related to calling `.setText()`, then `.setHyperlinkText()`.
  **Solution:** Recreate the `HyperlinkLabel` any time we want to set the region text to the hyperlink text to create an App Engine app.
1. **Issue:** Closing the dialog to create an App Engine app causes it to re-open, but only on the first open since the deployment config editor was opened.
  **Cause:** Two listeners were being attached to the `HyperlinkLabel` by accident.
  **Solution:** Same as the solution about (recreating the `HyperlinkLabel` fixes this).