### PR TITLE
Moves the HyperlinkListener addition to after the label is recreated.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineApplicationInfoPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineApplicationInfoPanel.java
@@ -60,10 +60,10 @@ public class AppEngineApplicationInfoPanel extends JPanel {
   }
 
   /**
-   *  Updates the panel as follows:
-   *   if {@code projectId} is valid, it displays the given project's information,
-   *   if {@code projectId} is invalid, it displays an error message,
-   *   if {@code projectId} is empty, no message is displayed.
+   * Updates the panel as follows:
+   * if {@code projectId} is valid, it displays the given project's information,
+   * if {@code projectId} is invalid, it displays an error message,
+   * if {@code projectId} is empty, no message is displayed.
    *
    * @param projectId the ID of the project whose application info to display
    * @param credential the Credential to use to make any required API calls
@@ -132,12 +132,13 @@ public class AppEngineApplicationInfoPanel extends JPanel {
   }
 
   private void setCreateApplicationMessage(String projectId, Credential credential) {
-    messageText.addHyperlinkListener(new CreateApplicationLinkListener(projectId, credential));
-
     String beforeLinkText = GctBundle.getString("appengine.application.not.exist") + " ";
     String linkText = GctBundle.getString("appengine.application.create.linkText");
     String afterLinkText = " " + GctBundle.getString("appengine.application.create.afterLinkText");
-    setMessage(() -> messageText.setHyperlinkText(beforeLinkText, linkText, afterLinkText), true);
+    setMessage(() -> {
+      messageText.addHyperlinkListener(new CreateApplicationLinkListener(projectId, credential));
+      messageText.setHyperlinkText(beforeLinkText, linkText, afterLinkText);
+    }, true);
   }
 
   /**


### PR DESCRIPTION
Fixes #1722.

This was a silly mistake on my part; when I moved the recreation of the `messageText` label to the central `setMessage(Runnable, boolean)` method, I forgot that the hyperlink listener was added outside of the passed in Runnable, so the `messageText` was created again after the listener was attached.