### PR TITLE
Disable ok button in framework support dialog when no modules selected

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -210,7 +210,7 @@ appengine.flexible.facet.name=Google App Engine flexible
 appengine.add.framework.support.tools.menu.description=Adds {0} framework support to a module.
 appengine.add.framework.support.dialog.title=Add {0} Framework Support
 appengine.add.framework.support.choose.module.dialog.title=Choose Module
-appengine.add.framework.support.choose.module.dialog.description={0} framework support will be added to selected module
+appengine.add.framework.support.choose.module.dialog.description={0} framework support will be added to the selected module
 appengine.add.framework.support.no.modules.message=Cannot add {0} framework support. \nAll modules already have App Engine support, or no modules were found.
 appengine.add.framework.support.no.modules.title=No Suitable Modules for {0} Framework Support Found.
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AddAppEngineFrameworkSupportAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AddAppEngineFrameworkSupportAction.java
@@ -32,6 +32,8 @@ import com.intellij.openapi.ui.Messages;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -87,7 +89,20 @@ public abstract class AddAppEngineFrameworkSupportAction extends AnAction {
                 "appengine.add.framework.support.choose.module.dialog.description",
                 FRAMEWORK_NAME));
     chooseModulesDialog.setSingleSelectionMode();
+    chooseModulesDialog.setOKActionEnabled(false);
+
+    if (chooseModulesDialog.getPreferredFocusedComponent() instanceof JTable) {
+      JTable chooseModuleTable = (JTable) chooseModulesDialog.getPreferredFocusedComponent();
+
+      ListSelectionModel selectionModel = chooseModuleTable.getSelectionModel();
+      if (selectionModel != null) {
+        selectionModel.addListSelectionListener(
+            e -> chooseModulesDialog.setOKActionEnabled(chooseModuleTable.getSelectedRow() != -1));
+      }
+    }
+
     chooseModulesDialog.show();
+
     final List<Module> elements = chooseModulesDialog.getChosenElements();
     if (!chooseModulesDialog.isOK() || elements.size() != 1) {
       return;
@@ -104,7 +119,7 @@ public abstract class AddAppEngineFrameworkSupportAction extends AnAction {
   }
 
   @VisibleForTesting
-  public List<Module> getSuitableModules(Project project) {
+  List<Module> getSuitableModules(Project project) {
     List<Module> suitableModules =
         new ArrayList<>(Arrays.asList(ModuleManager.getInstance(project).getModules()));
     DefaultFacetsProvider facetsProvider = new DefaultFacetsProvider();

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AddAppEngineFrameworkSupportAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/AddAppEngineFrameworkSupportAction.java
@@ -68,7 +68,7 @@ public abstract class AddAppEngineFrameworkSupportAction extends AnAction {
       return;
     }
 
-    List<Module> suitableModules = getSuitableModules(project);
+    List<Module> suitableModules = getModulesWithoutAppEngineSupport(project);
 
     String frameworkNameInTitle = getTemplatePresentation().getText();
     if (suitableModules.isEmpty()) {
@@ -119,7 +119,7 @@ public abstract class AddAppEngineFrameworkSupportAction extends AnAction {
   }
 
   @VisibleForTesting
-  List<Module> getSuitableModules(Project project) {
+  List<Module> getModulesWithoutAppEngineSupport(Project project) {
     List<Module> suitableModules =
         new ArrayList<>(Arrays.asList(ModuleManager.getInstance(project).getModules()));
     DefaultFacetsProvider facetsProvider = new DefaultFacetsProvider();

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/AddAppEngineFrameworkSupportActionTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/AddAppEngineFrameworkSupportActionTest.java
@@ -50,7 +50,7 @@ public abstract class AddAppEngineFrameworkSupportActionTest extends PlatformTes
     createModuleAt("module2", project, moduleType, path);
     createModuleAt("module3", project, moduleType, path);
 
-    List<Module> suitableModules = getAction().getSuitableModules(project);
+    List<Module> suitableModules = getAction().getModulesWithoutAppEngineSupport(project);
     assertEquals(3, suitableModules.size());
   }
 
@@ -75,7 +75,7 @@ public abstract class AddAppEngineFrameworkSupportActionTest extends PlatformTes
       }
     }.execute();
 
-    List<Module> suitableModules = getAction().getSuitableModules(project);
+    List<Module> suitableModules = getAction().getModulesWithoutAppEngineSupport(project);
     assertEquals(1, suitableModules.size());
     assertEquals("module1", suitableModules.get(0).getName());
   }


### PR DESCRIPTION
fixes #1725 

Tests need some refactoring to be able to cover this cleanly