### PR TITLE
Update Idea version to the latest 2017.2. This fixes missing .SHA1 fi…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 ideaEdition = IU
-ideaVersion = 2017.1
+ideaVersion = 2017.2
 intellijRepoUrl = https://storage.googleapis.com/cloud-tools-for-java-team-kokoro-build-cache/idea-distributions
 javaVersion = 1.8
 ijPluginRepoChannel = alpha


### PR DESCRIPTION
…le for previous version that caused build to fail.