### PR TITLE
Reinitialize project selector bottom panel

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/GoogleLoginEmptyPanel.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/GoogleLoginEmptyPanel.java
@@ -19,14 +19,11 @@ package com.google.cloud.tools.intellij.login.ui;
 import com.google.cloud.tools.intellij.login.CredentialedUser;
 import com.google.cloud.tools.intellij.login.Services;
 import com.google.cloud.tools.intellij.login.util.AccountMessageBundle;
-
 import com.intellij.ui.components.JBScrollPane;
-
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Map;
-
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -52,6 +49,12 @@ public class GoogleLoginEmptyPanel extends JPanel {
     super(new BorderLayout());
 
     contentScrollPane = new JBScrollPane();
+
+    add(contentScrollPane, BorderLayout.CENTER);
+    initializeBottomPane();
+  }
+
+  protected void initializeBottomPane() {
     JButton addAccountButton = new JButton(needsToSignIn() ? SIGN_IN : ADD_ACCOUNT);
     addAccountButton.addActionListener(new ActionListener() {
       @Override
@@ -70,8 +73,6 @@ public class GoogleLoginEmptyPanel extends JPanel {
 
     bottomPane = new JPanel();
     buttonPane.add(bottomPane);
-
-    add(contentScrollPane, BorderLayout.CENTER);
     add(buttonPane, BorderLayout.PAGE_END);
   }
 

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/GoogleLoginEmptyPanel.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/GoogleLoginEmptyPanel.java
@@ -73,6 +73,9 @@ public class GoogleLoginEmptyPanel extends JPanel {
 
     bottomPane = new JPanel();
     buttonPane.add(bottomPane);
+
+    // BorderLayout only allows a single component to be added per region so it is safe to call
+    // this multiple times
     add(buttonPane, BorderLayout.PAGE_END);
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/ProjectSelector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/ProjectSelector.java
@@ -545,6 +545,7 @@ public class ProjectSelector extends CustomizableComboBox implements Customizabl
       this.setPreferredSize(new Dimension(Math.max(BaseGoogleLoginUi.MIN_WIDTH, preferredWidth),
           getPreferredPopupHeight()));
 
+      initializeBottomPane();
       getBottomPane().setLayout(new BorderLayout());
 
       if (!needsToSignIn()) {


### PR DESCRIPTION
fixes #1730 

**What was causing the problem?**
After the changes to make the project selector searchable, the [logic was updated](https://github.com/GoogleCloudPlatform/google-cloud-intellij/blob/master/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/ProjectSelector.java#L417) to not recreate the project selector popup panel each time it was opened. Rather, its contents were just reinitialized.

The problem is that the bottom panel, which is created in `GoogleLoginEmptyPanel` was not also reinitialized. Because of this, the state of this bottom panel was not properly updated on login / logout events.

**Why does this PR fix the problem?**
Alongside reinitializing the popup panel, this PR adds a call to reinitialize the bottom panel as well. This will force the panel to be redrawn correctly according to the current login state when the project selector popup is opened.
