### PR TITLE
Improve app engine flexible detection

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
@@ -41,7 +41,8 @@ public class AppEngineFlexibleFrameworkDetector
         AppEngineFlexibleFacet, AppEngineFlexibleFacetConfiguration> {
 
   // app engine flex file names.
-  static final List<String> APP_ENGINE_FLEX_PROJECT_FILES = Collections.unmodifiableList(Arrays.asList("app.yaml",  "app.yml"));
+  static final List<String> APP_ENGINE_FLEX_PROJECT_FILES =
+          Collections.unmodifiableList(Arrays.asList("app.yaml",  "app.yml"));
   // required string in app engine flex YAML project file.
   static final String APP_ENGINE_REQUIRED_YAML = "runtime:";
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
@@ -78,7 +78,7 @@ public class AppEngineFlexibleFrameworkDetector
    */
   private static final class AppEngineFlexPattern
       extends ObjectPattern<FileContent, AppEngineFlexPattern> {
-    private static final Collection<String> APP_ENGINE_FLEX_CONFIG_FILES =
+    private static final ImmutableList<String> APP_ENGINE_FLEX_CONFIG_FILES =
         ImmutableList.of("app.yaml", "app.yml");
 
     private static final String APP_ENGINE_FLEX_REQUIRED_YAML_CONTENT = "runtime:";

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
@@ -86,7 +86,6 @@ public class AppEngineFlexibleFrameworkDetector
     private AppEngineFlexPattern withAppEngineFlexYamlContent() {
       return with(
           new PatternCondition<FileContent>("with-appengine-java-flexible") {
-            // app engine flex file names.
             private final Collection<String> APP_ENGINE_FLEX_CONFIG_FILES =
                 ImmutableList.of("app.yaml", "app.yml");
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
@@ -78,6 +78,10 @@ public class AppEngineFlexibleFrameworkDetector
    */
   private static final class AppEngineFlexPattern
       extends ObjectPattern<FileContent, AppEngineFlexPattern> {
+    private static final Collection<String> APP_ENGINE_FLEX_CONFIG_FILES =
+        ImmutableList.of("app.yaml", "app.yml");
+
+    private static final String APP_ENGINE_FLEX_REQUIRED_YAML_CONTENT = "runtime:";
 
     private AppEngineFlexPattern() {
       super(FileContent.class);
@@ -86,11 +90,6 @@ public class AppEngineFlexibleFrameworkDetector
     private AppEngineFlexPattern withAppEngineFlexYamlContent() {
       return with(
           new PatternCondition<FileContent>("with-appengine-java-flexible") {
-            private final Collection<String> APP_ENGINE_FLEX_CONFIG_FILES =
-                ImmutableList.of("app.yaml", "app.yml");
-
-            private static final String APP_ENGINE_FLEX_REQUIRED_YAML_CONTENT = "runtime:";
-
             @Override
             public boolean accepts(@NotNull FileContent fileContent, ProcessingContext context) {
               // checks for flex engine file names and then checks for required configuration line

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
@@ -42,7 +42,7 @@ public class AppEngineFlexibleFrameworkDetector
 
   // app engine flex file names.
   static final Collection<String> APP_ENGINE_FLEX_PROJECT_FILES =
-          Collections.unmodifiableList(Arrays.asList("app.yaml",  "app.yml"));
+      Collections.unmodifiableList(Arrays.asList("app.yaml", "app.yml"));
   // required string in app engine flex YAML project file.
   static final String APP_ENGINE_REQUIRED_YAML = "runtime:";
 
@@ -83,30 +83,30 @@ public class AppEngineFlexibleFrameworkDetector
    * IntelliJ API pattern class that checks for App Engine Flex project file presence and checks it
    * has required configuration lines to avoid spurious detection.
    */
-  private static class AppEngineFlexPattern extends ObjectPattern<FileContent, AppEngineFlexPattern> {
+  private static class AppEngineFlexPattern
+      extends ObjectPattern<FileContent, AppEngineFlexPattern> {
 
     private AppEngineFlexPattern() {
       super(FileContent.class);
     }
 
     private AppEngineFlexPattern withAppEngineFlexYAMLContent() {
-      return with(new PatternCondition<FileContent>("with-appengine-java-flexible") {
-        @Override
-        public boolean accepts(@NotNull FileContent fileContent, ProcessingContext context) {
-          // checks for flex engine file names and then checks for required configuration line inside.
-          boolean nameMatch = APP_ENGINE_FLEX_PROJECT_FILES.contains(fileContent.getFileName());
-          if (nameMatch) {
-            Scanner scanner = new Scanner(fileContent.getContentAsText().toString());
-            while (scanner.hasNextLine()) {
-              if (scanner.nextLine().startsWith(APP_ENGINE_REQUIRED_YAML))
-                return true;
+      return with(
+          new PatternCondition<FileContent>("with-appengine-java-flexible") {
+            @Override
+            public boolean accepts(@NotNull FileContent fileContent, ProcessingContext context) {
+              // checks for flex engine file names and then checks for required configuration line
+              // inside.
+              boolean nameMatch = APP_ENGINE_FLEX_PROJECT_FILES.contains(fileContent.getFileName());
+              if (nameMatch) {
+                Scanner scanner = new Scanner(fileContent.getContentAsText().toString());
+                while (scanner.hasNextLine()) {
+                  if (scanner.nextLine().startsWith(APP_ENGINE_REQUIRED_YAML)) return true;
+                }
+              }
+              return false;
             }
-          }
-          return false;
-        }
-      });
+          });
     }
-
   }
-
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
@@ -71,8 +71,8 @@ public class AppEngineFlexibleFrameworkDetector
   }
 
   /**
-   * IntelliJ API pattern class that checks for App Engine Flex project file presence and checks it has
-   * required configuration lines to avoid spurious detection.
+   * IntelliJ API pattern class that checks for App Engine Flex project file presence and checks it
+   * has required configuration lines to avoid spurious detection.
    */
   private static class AppEngineFlexFileCondition extends ObjectPattern<FileContent, FileContentPattern> {
 
@@ -85,7 +85,8 @@ public class AppEngineFlexibleFrameworkDetector
         @Override
         public boolean accepts(@NotNull FileContent fileContent, ProcessingContext context) {
           // checks for flex engine file names and then checks for required configuration line inside.
-          boolean nameMatch = fileContent.getFileName().equals("app.yaml") || fileContent.getFileName().equals("app.yml");
+          boolean nameMatch = fileContent.getFileName().equals("app.yaml") ||
+              fileContent.getFileName().equals("app.yml");
           if (nameMatch) {
             Scanner scanner = new Scanner(fileContent.getContentAsText().toString());
             while (scanner.hasNextLine()) {
@@ -93,7 +94,6 @@ public class AppEngineFlexibleFrameworkDetector
                 return true;
             }
           }
-
           return false;
         }
       });

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
@@ -18,10 +18,8 @@ package com.google.cloud.tools.intellij.appengine.facet.flexible;
 
 import com.google.cloud.tools.intellij.stats.UsageTrackerProvider;
 import com.google.cloud.tools.intellij.util.GctTracking;
-import com.google.common.collect.Lists;
 import com.intellij.facet.FacetType;
 import com.intellij.framework.detection.FacetBasedFrameworkDetector;
-import com.intellij.framework.detection.FileContentPattern;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.patterns.ElementPattern;
@@ -29,11 +27,13 @@ import com.intellij.patterns.ObjectPattern;
 import com.intellij.patterns.PatternCondition;
 import com.intellij.util.ProcessingContext;
 import com.intellij.util.indexing.FileContent;
-
-import java.util.*;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.yaml.YAMLFileType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Collection;
+import java.util.Scanner;
 
 /** Detects App Engine Flexible framework in a project. */
 public class AppEngineFlexibleFrameworkDetector
@@ -41,7 +41,7 @@ public class AppEngineFlexibleFrameworkDetector
         AppEngineFlexibleFacet, AppEngineFlexibleFacetConfiguration> {
 
   // app engine flex file names.
-  static final List<String> APP_ENGINE_FLEX_PROJECT_FILES =
+  static final Collection<String> APP_ENGINE_FLEX_PROJECT_FILES =
           Collections.unmodifiableList(Arrays.asList("app.yaml",  "app.yml"));
   // required string in app engine flex YAML project file.
   static final String APP_ENGINE_REQUIRED_YAML = "runtime:";

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
@@ -89,7 +89,7 @@ public class AppEngineFlexibleFrameworkDetector
       super(FileContent.class);
     }
 
-    AppEngineFlexPattern withAppEngineFlexYAMLContent() {
+    private AppEngineFlexPattern withAppEngineFlexYAMLContent() {
       return with(new PatternCondition<FileContent>("with-appengine-java-flexible") {
         @Override
         public boolean accepts(@NotNull FileContent fileContent, ProcessingContext context) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetector.java
@@ -71,7 +71,7 @@ public class AppEngineFlexibleFrameworkDetector
   }
 
   /**
-   * IDEA API pattern class that checks for App Engine Flex project file presence and checks it has
+   * IntelliJ API pattern class that checks for App Engine Flex project file presence and checks it has
    * required configuration lines to avoid spurious detection.
    */
   private static class AppEngineFlexFileCondition extends ObjectPattern<FileContent, FileContentPattern> {

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
@@ -33,7 +33,8 @@ import static org.mockito.Mockito.when;
 
 public class AppEngineFlexibleFrameworkDetectorTest {
 
-  private final String validAppEngineFlexYamlString = AppEngineFlexibleFrameworkDetector.APP_ENGINE_REQUIRED_YAML + " java";
+  private final String validAppEngineFlexYamlString =
+          AppEngineFlexibleFrameworkDetector.APP_ENGINE_REQUIRED_YAML + " java";
 
   @Before
   public void setUp() {
@@ -55,8 +56,10 @@ public class AppEngineFlexibleFrameworkDetectorTest {
 
     // valid name, does not have required framework contents.
     String notAppEngineFlexYamlString = "spring:\n  application:\n  name: jhipsterSampleApplication";
-    MockVirtualFile invalidYamlFile = new MockVirtualFile(AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES.get(0), notAppEngineFlexYamlString);
-    FileContent invalidYamlFileContent = new FileContentImpl(invalidYamlFile, notAppEngineFlexYamlString, System.currentTimeMillis());
+    String anyValidFileName = AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES.get(0);
+    MockVirtualFile invalidYamlFile = new MockVirtualFile(anyValidFileName, notAppEngineFlexYamlString);
+    FileContent invalidYamlFileContent =
+            new FileContentImpl(invalidYamlFile, notAppEngineFlexYamlString, System.currentTimeMillis());
     Assert.assertFalse(pattern.accepts(invalidYamlFileContent));
   }
 
@@ -67,8 +70,10 @@ public class AppEngineFlexibleFrameworkDetectorTest {
     ElementPattern<FileContent> pattern = detector.createSuitableFilePattern();
 
     // valid name, valid app engine line.
-    MockVirtualFile validAppEngineFlexFile = new MockVirtualFile(AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES.get(0), validAppEngineFlexYamlString);
-    FileContent validAppEngineFlexFileContent = new FileContentImpl(validAppEngineFlexFile, validAppEngineFlexYamlString, System.currentTimeMillis());
+    String anyValidFileName = AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES.get(0);
+    MockVirtualFile validAppEngineFlexFile = new MockVirtualFile(anyValidFileName, validAppEngineFlexYamlString);
+    FileContent validAppEngineFlexFileContent =
+            new FileContentImpl(validAppEngineFlexFile, validAppEngineFlexYamlString, System.currentTimeMillis());
     Assert.assertTrue(pattern.accepts(validAppEngineFlexFileContent));
   }
 

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
@@ -31,6 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/** Tests {@link AppEngineFlexibleFrameworkDetector} for valid/invalid App Engine Flex detection. */
 public class AppEngineFlexibleFrameworkDetectorTest {
 
   private final String validAppEngineFlexYamlString =
@@ -54,7 +55,7 @@ public class AppEngineFlexibleFrameworkDetectorTest {
     FileContent wrongFile = new FileContentImpl(invalidNameFile, validAppEngineFlexYamlString, System.currentTimeMillis());
     Assert.assertFalse(pattern.accepts(wrongFile));
 
-    // valid name, does not have required framework contents.
+    // valid name, does not have required YAML contents.
     String notAppEngineFlexYamlString = "spring:\n  application:\n  name: jhipsterSampleApplication";
     for (String validFileName: AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES) {
       MockVirtualFile invalidYamlFile = new MockVirtualFile(validFileName);

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
@@ -1,0 +1,5 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+class AppEngineFlexibleFrameworkDetectorTest {
+
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
@@ -18,11 +18,13 @@ package com.google.cloud.tools.intellij.appengine.facet.flexible;
 
 import com.intellij.mock.MockVirtualFile;
 import com.intellij.openapi.fileTypes.FileTypeRegistry;
+import com.intellij.openapi.util.Getter;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.patterns.ElementPattern;
 import com.intellij.util.indexing.FileContent;
 import com.intellij.util.indexing.FileContentImpl;
 import org.jetbrains.yaml.YAMLFileType;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,14 +38,22 @@ public class AppEngineFlexibleFrameworkDetectorTest {
 
   private final String validAppEngineFlexYamlString =
       AppEngineFlexibleFrameworkDetector.APP_ENGINE_REQUIRED_YAML + " java";
+  // keeps original getter for file type registry to reset after tests are done.
+  private Getter<FileTypeRegistry> fileTypeRegistryGetterOriginal;
 
   @Before
   public void setUp() {
     FileTypeRegistry mockFileTypeRegistry = mock(FileTypeRegistry.class);
     // mock file type check routine. getInstance() is static, has to replace it with IJ Getter mock.
+    fileTypeRegistryGetterOriginal = FileTypeRegistry.ourInstanceGetter;
     FileTypeRegistry.ourInstanceGetter = () -> mockFileTypeRegistry;
     when(mockFileTypeRegistry.getFileTypeByFile(any(VirtualFile.class)))
         .thenReturn(YAMLFileType.YML);
+  }
+
+  @After
+  public void tearDown() {
+    FileTypeRegistry.ourInstanceGetter = fileTypeRegistryGetterOriginal;
   }
 
   @Test

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
@@ -16,9 +16,15 @@
 
 package com.google.cloud.tools.intellij.appengine.facet.flexible;
 
-import com.intellij.testFramework.PlatformTestCase;
+import junit.framework.TestCase;
+import org.jetbrains.yaml.YAMLFileType;
 
-public class AppEngineFlexibleFrameworkDetectorTest extends PlatformTestCase {
+public class AppEngineFlexibleFrameworkDetectorTest extends TestCase {
+
   public void testIncompleteAppYamlDetection() {
+    AppEngineFlexibleFrameworkDetector detector = new AppEngineFlexibleFrameworkDetector();
+    assertEquals(YAMLFileType.YML, detector.getFileType());
+    detector.createSuitableFilePattern();
   }
+
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
@@ -39,7 +39,7 @@ public class AppEngineFlexibleFrameworkDetectorTest {
   @Before
   public void setUp() {
     FileTypeRegistry mockFileTypeRegistry = mock(FileTypeRegistry.class);
-    // mock file type check routine
+    // mock file type check routine. getInstance() is static, has to replace it with IJ Getter mock.
     FileTypeRegistry.ourInstanceGetter = () -> mockFileTypeRegistry;
     when(mockFileTypeRegistry.getFileTypeByFile(any(VirtualFile.class))).thenReturn(YAMLFileType.YML);
   }
@@ -56,25 +56,28 @@ public class AppEngineFlexibleFrameworkDetectorTest {
 
     // valid name, does not have required framework contents.
     String notAppEngineFlexYamlString = "spring:\n  application:\n  name: jhipsterSampleApplication";
-    String anyValidFileName = AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES.get(0);
-    MockVirtualFile invalidYamlFile = new MockVirtualFile(anyValidFileName, notAppEngineFlexYamlString);
-    FileContent invalidYamlFileContent =
-            new FileContentImpl(invalidYamlFile, notAppEngineFlexYamlString, System.currentTimeMillis());
-    Assert.assertFalse(pattern.accepts(invalidYamlFileContent));
+    for (String validFileName: AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES) {
+      MockVirtualFile invalidYamlFile = new MockVirtualFile(validFileName);
+      FileContent invalidYamlFileContent =
+              new FileContentImpl(invalidYamlFile, notAppEngineFlexYamlString, System.currentTimeMillis());
+      Assert.assertFalse(pattern.accepts(invalidYamlFileContent));
+    }
   }
 
   @Test
   public void testValidAppYamlDetection() {
+    // test we require YAML files for detection.
     AppEngineFlexibleFrameworkDetector detector = new AppEngineFlexibleFrameworkDetector();
     Assert.assertEquals(YAMLFileType.YML, detector.getFileType());
     ElementPattern<FileContent> pattern = detector.createSuitableFilePattern();
 
-    // valid name, valid app engine line.
-    String anyValidFileName = AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES.get(0);
-    MockVirtualFile validAppEngineFlexFile = new MockVirtualFile(anyValidFileName, validAppEngineFlexYamlString);
-    FileContent validAppEngineFlexFileContent =
-            new FileContentImpl(validAppEngineFlexFile, validAppEngineFlexYamlString, System.currentTimeMillis());
-    Assert.assertTrue(pattern.accepts(validAppEngineFlexFileContent));
+    // check all valid names, with valid app engine line.
+    for (String validFileName: AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES) {
+      MockVirtualFile validAppEngineFlexFile = new MockVirtualFile(validFileName);
+      FileContent validAppEngineFlexFileContent =
+              new FileContentImpl(validAppEngineFlexFile, validAppEngineFlexYamlString, System.currentTimeMillis());
+      Assert.assertTrue(pattern.accepts(validAppEngineFlexFileContent));
+    }
   }
 
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
@@ -35,14 +35,15 @@ import static org.mockito.Mockito.when;
 public class AppEngineFlexibleFrameworkDetectorTest {
 
   private final String validAppEngineFlexYamlString =
-          AppEngineFlexibleFrameworkDetector.APP_ENGINE_REQUIRED_YAML + " java";
+      AppEngineFlexibleFrameworkDetector.APP_ENGINE_REQUIRED_YAML + " java";
 
   @Before
   public void setUp() {
     FileTypeRegistry mockFileTypeRegistry = mock(FileTypeRegistry.class);
     // mock file type check routine. getInstance() is static, has to replace it with IJ Getter mock.
     FileTypeRegistry.ourInstanceGetter = () -> mockFileTypeRegistry;
-    when(mockFileTypeRegistry.getFileTypeByFile(any(VirtualFile.class))).thenReturn(YAMLFileType.YML);
+    when(mockFileTypeRegistry.getFileTypeByFile(any(VirtualFile.class)))
+        .thenReturn(YAMLFileType.YML);
   }
 
   @Test
@@ -51,16 +52,21 @@ public class AppEngineFlexibleFrameworkDetectorTest {
     ElementPattern<FileContent> pattern = detector.createSuitableFilePattern();
 
     // unaccepted file name pattern, although correct content.
-    MockVirtualFile invalidNameFile = new MockVirtualFile("myApp.yaml", validAppEngineFlexYamlString);
-    FileContent wrongFile = new FileContentImpl(invalidNameFile, validAppEngineFlexYamlString, System.currentTimeMillis());
+    MockVirtualFile invalidNameFile =
+        new MockVirtualFile("myApp.yaml", validAppEngineFlexYamlString);
+    FileContent wrongFile =
+        new FileContentImpl(
+            invalidNameFile, validAppEngineFlexYamlString, System.currentTimeMillis());
     Assert.assertFalse(pattern.accepts(wrongFile));
 
     // valid name, does not have required YAML contents.
-    String notAppEngineFlexYamlString = "spring:\n  application:\n  name: jhipsterSampleApplication";
-    for (String validFileName: AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES) {
+    String notAppEngineFlexYamlString =
+        "spring:\n  application:\n  name: jhipsterSampleApplication";
+    for (String validFileName : AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES) {
       MockVirtualFile invalidYamlFile = new MockVirtualFile(validFileName);
       FileContent invalidYamlFileContent =
-              new FileContentImpl(invalidYamlFile, notAppEngineFlexYamlString, System.currentTimeMillis());
+          new FileContentImpl(
+              invalidYamlFile, notAppEngineFlexYamlString, System.currentTimeMillis());
       Assert.assertFalse(pattern.accepts(invalidYamlFileContent));
     }
   }
@@ -73,12 +79,12 @@ public class AppEngineFlexibleFrameworkDetectorTest {
     ElementPattern<FileContent> pattern = detector.createSuitableFilePattern();
 
     // check all valid names, with valid app engine line.
-    for (String validFileName: AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES) {
+    for (String validFileName : AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES) {
       MockVirtualFile validAppEngineFlexFile = new MockVirtualFile(validFileName);
       FileContent validAppEngineFlexFileContent =
-              new FileContentImpl(validAppEngineFlexFile, validAppEngineFlexYamlString, System.currentTimeMillis());
+          new FileContentImpl(
+              validAppEngineFlexFile, validAppEngineFlexYamlString, System.currentTimeMillis());
       Assert.assertTrue(pattern.accepts(validAppEngineFlexFileContent));
     }
   }
-
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
@@ -16,15 +16,60 @@
 
 package com.google.cloud.tools.intellij.appengine.facet.flexible;
 
-import junit.framework.TestCase;
+import com.intellij.mock.MockVirtualFile;
+import com.intellij.openapi.fileTypes.FileTypeRegistry;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.patterns.ElementPattern;
+import com.intellij.util.indexing.FileContent;
+import com.intellij.util.indexing.FileContentImpl;
 import org.jetbrains.yaml.YAMLFileType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-public class AppEngineFlexibleFrameworkDetectorTest extends TestCase {
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+public class AppEngineFlexibleFrameworkDetectorTest {
+
+  private final String validAppEngineFlexYamlString = AppEngineFlexibleFrameworkDetector.APP_ENGINE_REQUIRED_YAML + " java";
+
+  @Before
+  public void setUp() {
+    FileTypeRegistry mockFileTypeRegistry = mock(FileTypeRegistry.class);
+    // mock file type check routine
+    FileTypeRegistry.ourInstanceGetter = () -> mockFileTypeRegistry;
+    when(mockFileTypeRegistry.getFileTypeByFile(any(VirtualFile.class))).thenReturn(YAMLFileType.YML);
+  }
+
+  @Test
   public void testIncompleteAppYamlDetection() {
     AppEngineFlexibleFrameworkDetector detector = new AppEngineFlexibleFrameworkDetector();
-    assertEquals(YAMLFileType.YML, detector.getFileType());
-    detector.createSuitableFilePattern();
+    ElementPattern<FileContent> pattern = detector.createSuitableFilePattern();
+
+    // unaccepted file name pattern, although correct content.
+    MockVirtualFile invalidNameFile = new MockVirtualFile("myApp.yaml", validAppEngineFlexYamlString);
+    FileContent wrongFile = new FileContentImpl(invalidNameFile, validAppEngineFlexYamlString, System.currentTimeMillis());
+    Assert.assertFalse(pattern.accepts(wrongFile));
+
+    // valid name, does not have required framework contents.
+    String notAppEngineFlexYamlString = "spring:\n  application:\n  name: jhipsterSampleApplication";
+    MockVirtualFile invalidYamlFile = new MockVirtualFile(AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES.get(0), notAppEngineFlexYamlString);
+    FileContent invalidYamlFileContent = new FileContentImpl(invalidYamlFile, notAppEngineFlexYamlString, System.currentTimeMillis());
+    Assert.assertFalse(pattern.accepts(invalidYamlFileContent));
+  }
+
+  @Test
+  public void testValidAppYamlDetection() {
+    AppEngineFlexibleFrameworkDetector detector = new AppEngineFlexibleFrameworkDetector();
+    Assert.assertEquals(YAMLFileType.YML, detector.getFileType());
+    ElementPattern<FileContent> pattern = detector.createSuitableFilePattern();
+
+    // valid name, valid app engine line.
+    MockVirtualFile validAppEngineFlexFile = new MockVirtualFile(AppEngineFlexibleFrameworkDetector.APP_ENGINE_FLEX_PROJECT_FILES.get(0), validAppEngineFlexYamlString);
+    FileContent validAppEngineFlexFileContent = new FileContentImpl(validAppEngineFlexFile, validAppEngineFlexYamlString, System.currentTimeMillis());
+    Assert.assertTrue(pattern.accepts(validAppEngineFlexFileContent));
   }
 
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleFrameworkDetectorTest.java
@@ -1,5 +1,24 @@
-import static org.junit.jupiter.api.Assertions.*;
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-class AppEngineFlexibleFrameworkDetectorTest {
+package com.google.cloud.tools.intellij.appengine.facet.flexible;
 
+import com.intellij.testFramework.PlatformTestCase;
+
+public class AppEngineFlexibleFrameworkDetectorTest extends PlatformTestCase {
+  public void testIncompleteAppYamlDetection() {
+  }
 }


### PR DESCRIPTION
- Fixes issue #1698
- Replaces checking for simple presence of app engine flexible project file with actual checking for required YAML content ("runtime:")
- Adds unit test to test only valid app.yaml files are accepted when detecting app engine flexible