### PR TITLE
Adds the Cloud library dependency writer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,10 @@ subprojects {
     dependencies {
         compile 'joda-time:joda-time:2.9.2'
 
-        testCompile ('com.google.truth:truth:0.30') {
+        testCompile ('com.google.truth:truth:0.36') {
+            exclude group: 'com.google.guava', module: 'guava'
+        }
+        testCompile ('com.google.truth.extensions:truth-java8-extension:0.36') {
             exclude group: 'com.google.guava', module: 'guava'
         }
         testCompile 'junit:junit:4.+'

--- a/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/apis/TestCloudLibrary.java
+++ b/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/apis/TestCloudLibrary.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.libraries.json.CloudLibraryClientMavenCoordinates;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A JSON object for {@link CloudLibrary} instances that need to be built in unit tests.
@@ -73,6 +74,7 @@ public abstract class TestCloudLibrary extends TestJson {
   public abstract String icon();
 
   /** @see CloudLibrary#clients */
+  @Nullable
   public abstract List<TestCloudLibraryClient> clients();
 
   /** Returns a newly built {@link CloudLibrary} for the parameters in this class. */
@@ -95,7 +97,7 @@ public abstract class TestCloudLibrary extends TestJson {
      * built with empty strings too.
      */
     public static TestCloudLibraryClient createEmpty() {
-      return create("", "", "", "", "", TestCloudLibraryClientMavenCoordinates.createEmpty());
+      return create("", "", "", "", "", "", TestCloudLibraryClientMavenCoordinates.createEmpty());
     }
 
     /**
@@ -104,6 +106,7 @@ public abstract class TestCloudLibrary extends TestJson {
      * @see CloudLibraryClient
      */
     public static TestCloudLibraryClient create(
+        String name,
         String language,
         String apireference,
         String launchStage,
@@ -111,8 +114,11 @@ public abstract class TestCloudLibrary extends TestJson {
         String languageLevel,
         TestCloudLibraryClientMavenCoordinates mavenCoordinates) {
       return new AutoValue_TestCloudLibrary_TestCloudLibraryClient(
-          language, apireference, launchStage, source, languageLevel, mavenCoordinates);
+          name, language, apireference, launchStage, source, languageLevel, mavenCoordinates);
     }
+
+    /** @see CloudLibraryClient#name */
+    public abstract String name();
 
     /** @see CloudLibraryClient#language */
     public abstract String language();
@@ -130,7 +136,13 @@ public abstract class TestCloudLibrary extends TestJson {
     public abstract String languageLevel();
 
     /** @see CloudLibraryClient#mavenCoordinates */
+    @Nullable
     public abstract TestCloudLibraryClientMavenCoordinates mavenCoordinates();
+
+    /** Returns a newly built {@link CloudLibraryClient} for the parameters in this class. */
+    public CloudLibraryClient toCloudLibraryClient() {
+      return new Gson().fromJson(toJson(), CloudLibraryClient.class);
+    }
   }
 
   /**

--- a/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/apis/TestJson.java
+++ b/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/apis/TestJson.java
@@ -55,14 +55,18 @@ abstract class TestJson {
             .flatMap(
                 method -> {
                   try {
+                    Object object = method.invoke(this);
+                    if (object == null) {
+                      return Stream.of();
+                    }
+
                     if (Collection.class.isAssignableFrom(method.getReturnType())) {
-                      Collection<?> objects = (Collection<?>) method.invoke(this);
+                      Collection<?> objects = (Collection<?>) object;
                       String mergedResult =
                           objects.stream().map(Object::toString).collect(Collectors.joining(","));
                       return Stream.of(String.format("%s:[%s]", method.getName(), mergedResult));
                     }
 
-                    Object object = method.invoke(this);
                     String format = (object instanceof String) ? "%s:\"%s\"" : "%s:%s";
                     return Stream.of(String.format(format, method.getName(), object.toString()));
                   } catch (IllegalAccessException | InvocationTargetException e) {

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -208,6 +208,10 @@ appengine.add.framework.support.no.modules.message=All modules already have App 
 appengine.add.framework.support.no.modules.title=Cannot add {0} framework support
 
 cloud.libraries.apireference.link=API Reference
+cloud.libraries.depwriter.maven.added.deps.message=The following libraries were added to your pom.xml:\n{0}
+cloud.libraries.depwriter.maven.added.deps.title=Added Cloud Libraries
+cloud.libraries.depwriter.maven.ignored.deps.message=The following libraries were ignored because they already exist in your pom.xml:\n{0}
+cloud.libraries.depwriter.maven.ignored.deps.title=Ignored Cloud Libraries
 cloud.libraries.dialog.title=Add Cloud Libraries
 cloud.libraries.documentation.link=Documentation
 cloud.libraries.menu.action.text=Add Cloud libraries...

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -208,9 +208,9 @@ appengine.add.framework.support.no.modules.message=All modules already have App 
 appengine.add.framework.support.no.modules.title=Cannot add {0} framework support
 
 cloud.libraries.apireference.link=API Reference
-cloud.libraries.depwriter.maven.added.deps.message=The following libraries were added to your pom.xml:\n{0}
+cloud.libraries.depwriter.maven.added.deps.message=<html><body>The following libraries were added to your pom.xml:<br>{0}</body></html>
 cloud.libraries.depwriter.maven.added.deps.title=Added Cloud Libraries
-cloud.libraries.depwriter.maven.ignored.deps.message=The following libraries were ignored because they already exist in your pom.xml:\n{0}
+cloud.libraries.depwriter.maven.ignored.deps.message=<html><body>The following libraries were ignored because they already exist in your pom.xml:<br>{0}</body></html>
 cloud.libraries.depwriter.maven.ignored.deps.title=Ignored Cloud Libraries
 cloud.libraries.dialog.title=Add Cloud Libraries
 cloud.libraries.documentation.link=Documentation

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/AddCloudLibrariesWizardAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/AddCloudLibrariesWizardAction.java
@@ -58,6 +58,10 @@ public final class AddCloudLibrariesWizardAction extends DumbAwareAction {
     if (e.getProject() != null) {
       AddCloudLibrariesWizard dialog = new AddCloudLibrariesWizard(e.getProject());
       DialogManager.show(dialog);
+      if (dialog.isOK()) {
+        CloudLibraryDependencyWriter.addLibraries(
+            dialog.getSelectedLibraries(), dialog.getSelectedModule());
+      }
     }
   }
 
@@ -77,6 +81,11 @@ public final class AddCloudLibrariesWizardAction extends DumbAwareAction {
       addStep(selectClientLibrariesStep);
       addStep(manageCloudApisStep);
       init();
+    }
+
+    /** Returns the selected {@link Module}. */
+    Module getSelectedModule() {
+      return selectClientLibrariesStep.getSelectedModule();
     }
 
     /** Returns the set of selected {@link CloudLibrary CloudLibraries}. */

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryDependencyWriter.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryDependencyWriter.java
@@ -34,7 +34,7 @@ import org.jetbrains.idea.maven.model.MavenId;
 import org.jetbrains.idea.maven.project.MavenProject;
 import org.jetbrains.idea.maven.project.MavenProjectsManager;
 
-/** A helper class that writes dependencies on Cloud libraries to a given module. */
+/** A helper class that adds dependencies of Cloud libraries to a given module. */
 final class CloudLibraryDependencyWriter {
 
   /** Prevents instantiation. */
@@ -50,7 +50,11 @@ final class CloudLibraryDependencyWriter {
    * @param libraries the set of {@link CloudLibrary CloudLibraries} to add
    * @param module the {@link Module} to add the libraries to
    */
-  static void addLibraries(Set<CloudLibrary> libraries, Module module) {
+  static void addLibraries(@NotNull Set<CloudLibrary> libraries, @NotNull Module module) {
+    if (libraries.isEmpty()) {
+      return;
+    }
+
     Project project = module.getProject();
     MavenProjectsManager projectsManager = MavenProjectsManager.getInstance(module.getProject());
     MavenProject mavenProject = projectsManager.findProject(module);
@@ -74,12 +78,13 @@ final class CloudLibraryDependencyWriter {
         // dependencies, maybe a warning?
         libraries
             .stream()
-            .map(CloudLibraryUtils::getJavaClientMavenCoordinates)
+            .map(CloudLibraryUtils::getFirstJavaClientMavenCoordinates)
             .filter(Optional::isPresent)
             .map(Optional::get)
             .map(CloudLibraryDependencyWriter::toMavenId)
             .filter(mavenId -> isMavenIdNotInDependencyList(mavenId, dependencies))
-            .forEach(mavenId -> MavenDomUtil.createDomDependency(model, null, mavenId));
+            .forEach(
+                mavenId -> MavenDomUtil.createDomDependency(model, /* editor= */ null, mavenId));
       }
     }.execute();
   }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryDependencyWriter.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryDependencyWriter.java
@@ -16,16 +16,25 @@
 
 package com.google.cloud.tools.intellij.apis;
 
+import com.google.cloud.tools.intellij.flags.PropertiesFileFlagReader;
+import com.google.cloud.tools.intellij.ui.GoogleCloudToolsIcons;
+import com.google.cloud.tools.intellij.util.GctBundle;
 import com.google.cloud.tools.libraries.json.CloudLibrary;
 import com.google.cloud.tools.libraries.json.CloudLibraryClientMavenCoordinates;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationDisplayType;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationType;
 import com.intellij.openapi.application.Result;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.xml.DomUtil;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.idea.maven.dom.MavenDomUtil;
 import org.jetbrains.idea.maven.dom.model.MavenDomDependency;
@@ -36,6 +45,14 @@ import org.jetbrains.idea.maven.project.MavenProjectsManager;
 
 /** A helper class that adds dependencies of Cloud libraries to a given module. */
 final class CloudLibraryDependencyWriter {
+
+  private static final NotificationGroup NOTIFICATION_GROUP =
+      new NotificationGroup(
+          new PropertiesFileFlagReader().getFlagString("notifications.plugin.groupdisplayid"),
+          NotificationDisplayType.BALLOON,
+          true,
+          null,
+          GoogleCloudToolsIcons.CLOUD);
 
   /** Prevents instantiation. */
   private CloudLibraryDependencyWriter() {}
@@ -56,41 +73,63 @@ final class CloudLibraryDependencyWriter {
     }
 
     Project project = module.getProject();
-    MavenProjectsManager projectsManager = MavenProjectsManager.getInstance(module.getProject());
-    MavenProject mavenProject = projectsManager.findProject(module);
-    if (mavenProject == null) {
+    if (MavenProjectsManager.getInstance(project).isMavenizedModule(module)) {
+      addLibrariesToMavenModule(libraries, module);
+    } else {
       // TODO(nkibler): Handle non-Maven projects.
-      return;
     }
+  }
 
+  /**
+   * Adds the given set of {@link CloudLibrary CloudLibraries} to the given Maven {@link Module}.
+   *
+   * <p>If the given {@link Module} is not a Maven module, this method may throw an undefined {@link
+   * RuntimeException}.
+   *
+   * @param libraries the set of {@link CloudLibrary CloudLibraries} to add
+   * @param module the Maven {@link Module} to add the libraries to
+   */
+  private static void addLibrariesToMavenModule(
+      @NotNull Set<CloudLibrary> libraries, @NotNull Module module) {
+    Project project = module.getProject();
+    MavenProject mavenProject = MavenProjectsManager.getInstance(project).findProject(module);
     MavenDomProjectModel model =
         MavenDomUtil.getMavenDomProjectModel(project, mavenProject.getFile());
-    if (model == null) {
-      // TODO(nkibler): Handle this error-state, maybe a warning?
-      return;
-    }
 
     new WriteCommandAction(project, DomUtil.getFile(model)) {
       @Override
       protected void run(@NotNull Result result) throws Throwable {
         List<MavenDomDependency> dependencies = model.getDependencies().getDependencies();
-        // TODO(nkibler): Inform the user when libraries were ignored because of existing
-        // dependencies, maybe a warning?
-        libraries
-            .stream()
-            .map(CloudLibraryUtils::getFirstJavaClientMavenCoordinates)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .map(CloudLibraryDependencyWriter::toMavenId)
-            .filter(mavenId -> isMavenIdNotInDependencyList(mavenId, dependencies))
-            .forEach(
-                mavenId -> MavenDomUtil.createDomDependency(model, /* editor= */ null, mavenId));
+        Map<Boolean, List<MavenId>> mavenIdsMap =
+            libraries
+                .stream()
+                .map(CloudLibraryUtils::getFirstJavaClientMavenCoordinates)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(CloudLibraryDependencyWriter::toMavenId)
+                .collect(
+                    Collectors.partitioningBy(
+                        mavenId -> isMavenIdInDependencyList(mavenId, dependencies)));
+
+        // The MavenIds in the "true" list are already in the pom.xml, so we don't duplicate them
+        // and warn the user that they weren't added.
+        List<MavenId> ignoredMavenIds = mavenIdsMap.get(true);
+        notifyIgnoredDependencies(ignoredMavenIds, project);
+
+        // The MavenIds in the "false" list are not in the pom.xml, so we add them and notify the
+        // user when it's complete.
+        List<MavenId> newMavenIds = mavenIdsMap.get(false);
+        if (!newMavenIds.isEmpty()) {
+          newMavenIds.forEach(
+              mavenId -> MavenDomUtil.createDomDependency(model, /* editor= */ null, mavenId));
+          notifyAddedDependencies(newMavenIds, project);
+        }
       }
     }.execute();
   }
 
   /**
-   * Returns {@code true} if the given {@link MavenId} is not in the given list of {@link
+   * Returns {@code true} if the given {@link MavenId} is in the given list of {@link
    * MavenDomDependency dependencies}.
    *
    * <p>Note that equality is tested via matching group IDs and artifact IDs. Equality of versions
@@ -101,11 +140,11 @@ final class CloudLibraryDependencyWriter {
    * @param dependencies the list of {@link MavenDomDependency} objects that currently exist in the
    *     DOM model
    */
-  private static boolean isMavenIdNotInDependencyList(
+  private static boolean isMavenIdInDependencyList(
       MavenId mavenId, List<MavenDomDependency> dependencies) {
     return dependencies
         .stream()
-        .noneMatch(
+        .anyMatch(
             dependency ->
                 mavenId.equals(
                     dependency.getGroupId().getStringValue(),
@@ -124,5 +163,65 @@ final class CloudLibraryDependencyWriter {
         mavenCoordinates.getGroupId(),
         mavenCoordinates.getArtifactId(),
         mavenCoordinates.getVersion());
+  }
+
+  /**
+   * Notifies the user that the given list of {@link MavenId MavenIds} were ignored when attempting
+   * to add them to their pom.xml because they already exist.
+   *
+   * <p>The notification shown has a {@link NotificationType#WARNING} type.
+   *
+   * @param ignoredMavenIds the list of {@link MavenId MavenIds} that were ignored
+   * @param project the {@link Project} that was affected
+   */
+  private static void notifyIgnoredDependencies(List<MavenId> ignoredMavenIds, Project project) {
+    if (ignoredMavenIds.isEmpty()) {
+      return;
+    }
+
+    String title = GctBundle.message("cloud.libraries.depwriter.maven.ignored.deps.title");
+    String mavenIdString = joinMavenIds(ignoredMavenIds);
+    String message =
+        GctBundle.message("cloud.libraries.depwriter.maven.ignored.deps.message", mavenIdString);
+    Notification notification =
+        NOTIFICATION_GROUP.createNotification(
+            title, /* subtitle= */ null, message, NotificationType.WARNING);
+    notification.notify(project);
+  }
+
+  /**
+   * Notifies the user that the given list of {@link MavenId MavenIds} were added to their pom.xml.
+   *
+   * <p>The notification shown has an {@link NotificationType#INFORMATION} type.
+   *
+   * @param addedMavenIds the list of {@link MavenId MavenIds} that were added to the user's pom.xml
+   * @param project the {@link Project} that was affected
+   */
+  private static void notifyAddedDependencies(List<MavenId> addedMavenIds, Project project) {
+    if (addedMavenIds.isEmpty()) {
+      return;
+    }
+
+    String title = GctBundle.message("cloud.libraries.depwriter.maven.added.deps.title");
+    String mavenIdString = joinMavenIds(addedMavenIds);
+    String message =
+        GctBundle.message("cloud.libraries.depwriter.maven.added.deps.message", mavenIdString);
+    Notification notification =
+        NOTIFICATION_GROUP.createNotification(
+            title, /* subtitle= */ null, message, NotificationType.INFORMATION);
+    notification.notify(project);
+  }
+
+  /**
+   * Joins the given list of {@link MavenId MavenIds} into a human-readable string.
+   *
+   * @param mavenIds the list of {@link MavenId MavenIds} to join
+   */
+  private static String joinMavenIds(List<MavenId> mavenIds) {
+    return mavenIds
+        .stream()
+        .map(MavenId::getDisplayString)
+        .map(string -> "- " + string)
+        .collect(Collectors.joining("\n"));
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryDependencyWriter.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryDependencyWriter.java
@@ -222,6 +222,6 @@ final class CloudLibraryDependencyWriter {
         .stream()
         .map(MavenId::getDisplayString)
         .map(string -> "- " + string)
-        .collect(Collectors.joining("\n"));
+        .collect(Collectors.joining("<br>"));
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryDependencyWriter.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryDependencyWriter.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.apis;
+
+import com.google.cloud.tools.libraries.json.CloudLibrary;
+import com.google.cloud.tools.libraries.json.CloudLibraryClientMavenCoordinates;
+import com.intellij.openapi.application.Result;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.xml.DomUtil;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.idea.maven.dom.MavenDomUtil;
+import org.jetbrains.idea.maven.dom.model.MavenDomDependency;
+import org.jetbrains.idea.maven.dom.model.MavenDomProjectModel;
+import org.jetbrains.idea.maven.model.MavenId;
+import org.jetbrains.idea.maven.project.MavenProject;
+import org.jetbrains.idea.maven.project.MavenProjectsManager;
+
+/** A helper class that writes dependencies on Cloud libraries to a given module. */
+final class CloudLibraryDependencyWriter {
+
+  /** Prevents instantiation. */
+  private CloudLibraryDependencyWriter() {}
+
+  /**
+   * Adds the given set of {@link CloudLibrary CloudLibraries} to the given {@link Module}.
+   *
+   * <p>For a module whose project manages its dependencies through Maven, the list of libraries
+   * will be added as dependencies to the {@code pom.xml}. For all other dependency management
+   * systems, the libraries will be downloaded and added directly to the module's classpath.
+   *
+   * @param libraries the set of {@link CloudLibrary CloudLibraries} to add
+   * @param module the {@link Module} to add the libraries to
+   */
+  static void addLibraries(Set<CloudLibrary> libraries, Module module) {
+    Project project = module.getProject();
+    MavenProjectsManager projectsManager = MavenProjectsManager.getInstance(module.getProject());
+    MavenProject mavenProject = projectsManager.findProject(module);
+    if (mavenProject == null) {
+      // TODO(nkibler): Handle non-Maven projects.
+      return;
+    }
+
+    MavenDomProjectModel model =
+        MavenDomUtil.getMavenDomProjectModel(project, mavenProject.getFile());
+    if (model == null) {
+      // TODO(nkibler): Handle this error-state, maybe a warning?
+      return;
+    }
+
+    new WriteCommandAction(project, DomUtil.getFile(model)) {
+      @Override
+      protected void run(@NotNull Result result) throws Throwable {
+        List<MavenDomDependency> dependencies = model.getDependencies().getDependencies();
+        // TODO(nkibler): Inform the user when libraries were ignored because of existing
+        // dependencies, maybe a warning?
+        libraries
+            .stream()
+            .map(CloudLibraryUtils::getJavaClientMavenCoordinates)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(CloudLibraryDependencyWriter::toMavenId)
+            .filter(mavenId -> isMavenIdNotInDependencyList(mavenId, dependencies))
+            .forEach(mavenId -> MavenDomUtil.createDomDependency(model, null, mavenId));
+      }
+    }.execute();
+  }
+
+  /**
+   * Returns {@code true} if the given {@link MavenId} is not in the given list of {@link
+   * MavenDomDependency dependencies}.
+   *
+   * <p>Note that equality is tested via matching group IDs and artifact IDs. Equality of versions
+   * is not required. This prevents adding duplicate dependencies for the same artifact, but with a
+   * different version.
+   *
+   * @param mavenId the {@link MavenId} to check for existence in the given list of dependencies
+   * @param dependencies the list of {@link MavenDomDependency} objects that currently exist in the
+   *     DOM model
+   */
+  private static boolean isMavenIdNotInDependencyList(
+      MavenId mavenId, List<MavenDomDependency> dependencies) {
+    return dependencies
+        .stream()
+        .noneMatch(
+            dependency ->
+                mavenId.equals(
+                    dependency.getGroupId().getStringValue(),
+                    dependency.getArtifactId().getStringValue()));
+  }
+
+  /**
+   * Returns a new {@link MavenId} whose values are based on the given {@link
+   * CloudLibraryClientMavenCoordinates}.
+   *
+   * @param mavenCoordinates the {@link CloudLibraryClientMavenCoordinates} to convert to a {@link
+   *     MavenId}
+   */
+  private static MavenId toMavenId(CloudLibraryClientMavenCoordinates mavenCoordinates) {
+    return new MavenId(
+        mavenCoordinates.getGroupId(),
+        mavenCoordinates.getArtifactId(),
+        mavenCoordinates.getVersion());
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryUtils.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.apis;
+
+import com.google.cloud.tools.libraries.json.CloudLibrary;
+import com.google.cloud.tools.libraries.json.CloudLibraryClient;
+import com.google.cloud.tools.libraries.json.CloudLibraryClientMavenCoordinates;
+import java.util.Optional;
+
+/** Holds utility methods that work with {@link CloudLibrary} classes. */
+final class CloudLibraryUtils {
+
+  private static final String JAVA_CLIENT_LANGUAGE = "java";
+
+  /** Prevents instantiation. */
+  private CloudLibraryUtils() {}
+
+  /**
+   * Returns the first Java {@link CloudLibraryClient} in the given {@link CloudLibrary}, or {@link
+   * Optional#empty()} if none exists.
+   *
+   * @param library the {@link CloudLibrary} to return the first Java client for
+   */
+  static Optional<CloudLibraryClient> getJavaClient(CloudLibrary library) {
+    if (library.getClients() == null) {
+      return Optional.empty();
+    }
+
+    return library
+        .getClients()
+        .stream()
+        .filter(client -> JAVA_CLIENT_LANGUAGE.equals(client.getLanguage()))
+        .findFirst();
+  }
+
+  /**
+   * Returns the {@link CloudLibraryClientMavenCoordinates} for the first Java client in the given
+   * {@link CloudLibrary}, or {@link Optional#empty()} if none exists.
+   *
+   * <p>For details on how the {@link CloudLibraryClient} is found, see {@link
+   * #getJavaClient(CloudLibrary)}.
+   *
+   * @param library the {@link CloudLibrary} to return Maven coordinates for
+   */
+  static Optional<CloudLibraryClientMavenCoordinates> getJavaClientMavenCoordinates(
+      CloudLibrary library) {
+    return getJavaClient(library).map(CloudLibraryClient::getMavenCoordinates);
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryUtils.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryUtils.java
@@ -35,7 +35,7 @@ final class CloudLibraryUtils {
    *
    * @param library the {@link CloudLibrary} to return the first Java client for
    */
-  static Optional<CloudLibraryClient> getJavaClient(CloudLibrary library) {
+  static Optional<CloudLibraryClient> getFirstJavaClient(CloudLibrary library) {
     if (library.getClients() == null) {
       return Optional.empty();
     }
@@ -52,12 +52,12 @@ final class CloudLibraryUtils {
    * {@link CloudLibrary}, or {@link Optional#empty()} if none exists.
    *
    * <p>For details on how the {@link CloudLibraryClient} is found, see {@link
-   * #getJavaClient(CloudLibrary)}.
+   * #getFirstJavaClient(CloudLibrary)}.
    *
    * @param library the {@link CloudLibrary} to return Maven coordinates for
    */
-  static Optional<CloudLibraryClientMavenCoordinates> getJavaClientMavenCoordinates(
+  static Optional<CloudLibraryClientMavenCoordinates> getFirstJavaClientMavenCoordinates(
       CloudLibrary library) {
-    return getJavaClient(library).map(CloudLibraryClient::getMavenCoordinates);
+    return getFirstJavaClient(library).map(CloudLibraryClient::getMavenCoordinates);
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.java
@@ -161,7 +161,7 @@ public final class GoogleCloudApiDetailsPanel {
     descriptionTextPane.setText(currentCloudLibrary.getDescription());
 
     if (currentCloudLibrary.getClients() != null) {
-      CloudLibraryUtils.getJavaClient(currentCloudLibrary)
+      CloudLibraryUtils.getFirstJavaClient(currentCloudLibrary)
           .ifPresent(
               client -> {
                 if (client.getMavenCoordinates() != null) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.java
@@ -45,7 +45,6 @@ import org.jetbrains.annotations.Nullable;
 /** The form-bound class for the Cloud API details panel. */
 public final class GoogleCloudApiDetailsPanel {
 
-  private static final String JAVA_CLIENT_LANGUAGE = "java";
   private static final String LINKS_SEPARATOR = " | ";
 
   private JLabel icon;
@@ -162,11 +161,7 @@ public final class GoogleCloudApiDetailsPanel {
     descriptionTextPane.setText(currentCloudLibrary.getDescription());
 
     if (currentCloudLibrary.getClients() != null) {
-      currentCloudLibrary
-          .getClients()
-          .stream()
-          .filter(client -> JAVA_CLIENT_LANGUAGE.equals(client.getLanguage()))
-          .findFirst()
+      CloudLibraryUtils.getJavaClient(currentCloudLibrary)
           .ifPresent(
               client -> {
                 if (client.getMavenCoordinates() != null) {

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/CloudLibraryUtilsTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/CloudLibraryUtilsTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.apis;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+
+import com.google.cloud.tools.intellij.testing.apis.TestCloudLibrary;
+import com.google.cloud.tools.intellij.testing.apis.TestCloudLibrary.TestCloudLibraryClient;
+import com.google.cloud.tools.intellij.testing.apis.TestCloudLibrary.TestCloudLibraryClientMavenCoordinates;
+import com.google.cloud.tools.libraries.json.CloudLibraryClient;
+import com.google.cloud.tools.libraries.json.CloudLibraryClientMavenCoordinates;
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link CloudLibraryUtils}. */
+@RunWith(JUnit4.class)
+public final class CloudLibraryUtilsTest {
+
+  private static final TestCloudLibraryClientMavenCoordinates JAVA_CLIENT_MAVEN_COORDS =
+      TestCloudLibraryClientMavenCoordinates.create("group", "java-client", "1.0.0");
+  private static final TestCloudLibraryClientMavenCoordinates PYTHON_CLIENT_MAVEN_COORDS =
+      TestCloudLibraryClientMavenCoordinates.create("group", "python-client", "1.0.0");
+  private static final TestCloudLibraryClient JAVA_CLIENT_FULL =
+      TestCloudLibraryClient.create(
+          "Java Client", "java", "", "", "", "", JAVA_CLIENT_MAVEN_COORDS);
+  private static final TestCloudLibraryClient JAVA_CLIENT_NO_MAVEN_COORDS =
+      TestCloudLibraryClient.create("No Maven Coords Client", "java", "", "", "", "", null);
+  private static final TestCloudLibraryClient PYTHON_CLIENT_FULL =
+      TestCloudLibraryClient.create(
+          "Python Client", "python", "", "", "", "", PYTHON_CLIENT_MAVEN_COORDS);
+
+  private static final TestCloudLibrary LIBRARY_FULL =
+      TestCloudLibrary.create(
+          "Full Library",
+          "full",
+          "",
+          "",
+          "",
+          ImmutableList.of(PYTHON_CLIENT_FULL, JAVA_CLIENT_FULL));
+  private static final TestCloudLibrary LIBRARY_NO_CLIENTS =
+      TestCloudLibrary.create("No Clients Library", "no-clients", "", "", "", ImmutableList.of());
+  private static final TestCloudLibrary LIBRARY_NULL_CLIENTS =
+      TestCloudLibrary.create("Null Clients Library", "null-clients", "", "", "", null);
+  private static final TestCloudLibrary LIBRARY_PYTHON_CLIENT_ONLY =
+      TestCloudLibrary.create(
+          "Python Client Library",
+          "python-client",
+          "",
+          "",
+          "",
+          ImmutableList.of(PYTHON_CLIENT_FULL));
+  private static final TestCloudLibrary LIBRARY_NO_MAVEN_COORDS =
+      TestCloudLibrary.create(
+          "No Maven Coords Library",
+          "no-maven-coords",
+          "",
+          "",
+          "",
+          ImmutableList.of(JAVA_CLIENT_NO_MAVEN_COORDS));
+
+  @Test
+  public void getJavaClient_withFullLibrary_returnsClient() {
+    Optional<CloudLibraryClient> client =
+        CloudLibraryUtils.getJavaClient(LIBRARY_FULL.toCloudLibrary());
+
+    // TODO(nkibler): Use .hasValue() once CloudLibrary classes have overridden equality methods.
+    assertThat(client).isPresent();
+    assertThat(client.get().getName()).isEqualTo(JAVA_CLIENT_FULL.name());
+  }
+
+  @Test
+  public void getJavaClient_withNoClientsLibrary_returnsEmptyOptional() {
+    Optional<CloudLibraryClient> client =
+        CloudLibraryUtils.getJavaClient(LIBRARY_NO_CLIENTS.toCloudLibrary());
+
+    assertThat(client).isEmpty();
+  }
+
+  @Test
+  public void getJavaClient_withNullClientsLibrary_returnsEmptyOptional() {
+    Optional<CloudLibraryClient> client =
+        CloudLibraryUtils.getJavaClient(LIBRARY_NULL_CLIENTS.toCloudLibrary());
+
+    assertThat(client).isEmpty();
+  }
+
+  @Test
+  public void getJavaClient_withPythonClientLibrary_returnsEmptyOptional() {
+    Optional<CloudLibraryClient> client =
+        CloudLibraryUtils.getJavaClient(LIBRARY_PYTHON_CLIENT_ONLY.toCloudLibrary());
+
+    assertThat(client).isEmpty();
+  }
+
+  @Test
+  public void getJavaClientMavenCoordinates_withFullLibrary_returnsMavenCoords() {
+    Optional<CloudLibraryClientMavenCoordinates> mavenCoordinates =
+        CloudLibraryUtils.getJavaClientMavenCoordinates(LIBRARY_FULL.toCloudLibrary());
+
+    // TODO(nkibler): Use .hasValue() once CloudLibrary classes have overridden equality methods.
+    assertThat(mavenCoordinates).isPresent();
+    assertThat(mavenCoordinates.get().getArtifactId())
+        .isEqualTo(JAVA_CLIENT_MAVEN_COORDS.artifactId());
+  }
+
+  @Test
+  public void getJavaClientMavenCoordinates_withNoClientsLibrary_returnsEmptyOptional() {
+    Optional<CloudLibraryClientMavenCoordinates> mavenCoordinates =
+        CloudLibraryUtils.getJavaClientMavenCoordinates(LIBRARY_NO_CLIENTS.toCloudLibrary());
+
+    assertThat(mavenCoordinates).isEmpty();
+  }
+
+  @Test
+  public void getJavaClientMavenCoordinates_withNullClientsLibrary_returnsEmptyOptional() {
+    Optional<CloudLibraryClientMavenCoordinates> mavenCoordinates =
+        CloudLibraryUtils.getJavaClientMavenCoordinates(LIBRARY_NULL_CLIENTS.toCloudLibrary());
+
+    assertThat(mavenCoordinates).isEmpty();
+  }
+
+  @Test
+  public void getJavaClientMavenCoordinates_withPythonClientLibrary_returnsEmptyOptional() {
+    Optional<CloudLibraryClientMavenCoordinates> mavenCoordinates =
+        CloudLibraryUtils.getJavaClientMavenCoordinates(
+            LIBRARY_PYTHON_CLIENT_ONLY.toCloudLibrary());
+
+    assertThat(mavenCoordinates).isEmpty();
+  }
+
+  @Test
+  public void getJavaClientMavenCoordinates_withNoMavenCoords_returnsEmptyOptional() {
+    Optional<CloudLibraryClientMavenCoordinates> mavenCoordinates =
+        CloudLibraryUtils.getJavaClientMavenCoordinates(LIBRARY_NO_MAVEN_COORDS.toCloudLibrary());
+
+    assertThat(mavenCoordinates).isEmpty();
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/CloudLibraryUtilsTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/CloudLibraryUtilsTest.java
@@ -79,7 +79,7 @@ public final class CloudLibraryUtilsTest {
   @Test
   public void getJavaClient_withFullLibrary_returnsClient() {
     Optional<CloudLibraryClient> client =
-        CloudLibraryUtils.getJavaClient(LIBRARY_FULL.toCloudLibrary());
+        CloudLibraryUtils.getFirstJavaClient(LIBRARY_FULL.toCloudLibrary());
 
     // TODO(nkibler): Use .hasValue() once CloudLibrary classes have overridden equality methods.
     assertThat(client).isPresent();
@@ -89,7 +89,7 @@ public final class CloudLibraryUtilsTest {
   @Test
   public void getJavaClient_withNoClientsLibrary_returnsEmptyOptional() {
     Optional<CloudLibraryClient> client =
-        CloudLibraryUtils.getJavaClient(LIBRARY_NO_CLIENTS.toCloudLibrary());
+        CloudLibraryUtils.getFirstJavaClient(LIBRARY_NO_CLIENTS.toCloudLibrary());
 
     assertThat(client).isEmpty();
   }
@@ -97,7 +97,7 @@ public final class CloudLibraryUtilsTest {
   @Test
   public void getJavaClient_withNullClientsLibrary_returnsEmptyOptional() {
     Optional<CloudLibraryClient> client =
-        CloudLibraryUtils.getJavaClient(LIBRARY_NULL_CLIENTS.toCloudLibrary());
+        CloudLibraryUtils.getFirstJavaClient(LIBRARY_NULL_CLIENTS.toCloudLibrary());
 
     assertThat(client).isEmpty();
   }
@@ -105,7 +105,7 @@ public final class CloudLibraryUtilsTest {
   @Test
   public void getJavaClient_withPythonClientLibrary_returnsEmptyOptional() {
     Optional<CloudLibraryClient> client =
-        CloudLibraryUtils.getJavaClient(LIBRARY_PYTHON_CLIENT_ONLY.toCloudLibrary());
+        CloudLibraryUtils.getFirstJavaClient(LIBRARY_PYTHON_CLIENT_ONLY.toCloudLibrary());
 
     assertThat(client).isEmpty();
   }
@@ -113,7 +113,7 @@ public final class CloudLibraryUtilsTest {
   @Test
   public void getJavaClientMavenCoordinates_withFullLibrary_returnsMavenCoords() {
     Optional<CloudLibraryClientMavenCoordinates> mavenCoordinates =
-        CloudLibraryUtils.getJavaClientMavenCoordinates(LIBRARY_FULL.toCloudLibrary());
+        CloudLibraryUtils.getFirstJavaClientMavenCoordinates(LIBRARY_FULL.toCloudLibrary());
 
     // TODO(nkibler): Use .hasValue() once CloudLibrary classes have overridden equality methods.
     assertThat(mavenCoordinates).isPresent();
@@ -124,7 +124,7 @@ public final class CloudLibraryUtilsTest {
   @Test
   public void getJavaClientMavenCoordinates_withNoClientsLibrary_returnsEmptyOptional() {
     Optional<CloudLibraryClientMavenCoordinates> mavenCoordinates =
-        CloudLibraryUtils.getJavaClientMavenCoordinates(LIBRARY_NO_CLIENTS.toCloudLibrary());
+        CloudLibraryUtils.getFirstJavaClientMavenCoordinates(LIBRARY_NO_CLIENTS.toCloudLibrary());
 
     assertThat(mavenCoordinates).isEmpty();
   }
@@ -132,7 +132,7 @@ public final class CloudLibraryUtilsTest {
   @Test
   public void getJavaClientMavenCoordinates_withNullClientsLibrary_returnsEmptyOptional() {
     Optional<CloudLibraryClientMavenCoordinates> mavenCoordinates =
-        CloudLibraryUtils.getJavaClientMavenCoordinates(LIBRARY_NULL_CLIENTS.toCloudLibrary());
+        CloudLibraryUtils.getFirstJavaClientMavenCoordinates(LIBRARY_NULL_CLIENTS.toCloudLibrary());
 
     assertThat(mavenCoordinates).isEmpty();
   }
@@ -140,7 +140,7 @@ public final class CloudLibraryUtilsTest {
   @Test
   public void getJavaClientMavenCoordinates_withPythonClientLibrary_returnsEmptyOptional() {
     Optional<CloudLibraryClientMavenCoordinates> mavenCoordinates =
-        CloudLibraryUtils.getJavaClientMavenCoordinates(
+        CloudLibraryUtils.getFirstJavaClientMavenCoordinates(
             LIBRARY_PYTHON_CLIENT_ONLY.toCloudLibrary());
 
     assertThat(mavenCoordinates).isEmpty();
@@ -149,7 +149,8 @@ public final class CloudLibraryUtilsTest {
   @Test
   public void getJavaClientMavenCoordinates_withNoMavenCoords_returnsEmptyOptional() {
     Optional<CloudLibraryClientMavenCoordinates> mavenCoordinates =
-        CloudLibraryUtils.getJavaClientMavenCoordinates(LIBRARY_NO_MAVEN_COORDS.toCloudLibrary());
+        CloudLibraryUtils.getFirstJavaClientMavenCoordinates(
+            LIBRARY_NO_MAVEN_COORDS.toCloudLibrary());
 
     assertThat(mavenCoordinates).isEmpty();
   }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
@@ -52,10 +52,22 @@ public final class GoogleCloudApiSelectorPanelTest {
       TestCloudLibraryClientMavenCoordinates.create("java", "client-2", "2.0.0");
   private static final TestCloudLibraryClient JAVA_CLIENT_1 =
       TestCloudLibraryClient.create(
-          "java", "API Ref 1", "alpha", "Source 1", "Lang Level 1", JAVA_CLIENT_MAVEN_COORDS_1);
+          "Client 1",
+          "java",
+          "API Ref 1",
+          "alpha",
+          "Source 1",
+          "Lang Level 1",
+          JAVA_CLIENT_MAVEN_COORDS_1);
   private static final TestCloudLibraryClient JAVA_CLIENT_2 =
       TestCloudLibraryClient.create(
-          "java", "API Ref 2", "beta", "Source 2", "Lang Level 2", JAVA_CLIENT_MAVEN_COORDS_2);
+          "Client 2",
+          "java",
+          "API Ref 2",
+          "beta",
+          "Source 2",
+          "Lang Level 2",
+          JAVA_CLIENT_MAVEN_COORDS_2);
 
   private static final TestCloudLibrary LIBRARY_1 =
       TestCloudLibrary.create(


### PR DESCRIPTION
This PR includes support for adding dependencies of Cloud libraries to Maven modules via the `pom.xml`. After selecting some libraries and pressing the "Finish" button, the user is notified which libraries were successfully added and which ones were ignored:

![screenshot from 2017-11-30 15-05-02](https://user-images.githubusercontent.com/14352762/33452421-2b9a27f0-d5e0-11e7-9a81-e0ea980eded9.png)

![screenshot from 2017-11-30 15-05-31](https://user-images.githubusercontent.com/14352762/33452431-2e404f0c-d5e0-11e7-807c-d136a7f92ede.png)
