### PR TITLE
Updates the annotation processor plugin to fix AutoValue resolutions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         classpath 'gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.1.10'
         classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
         classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.6"
-        classpath "net.ltgt.gradle:gradle-apt-plugin:0.10"
+        classpath "net.ltgt.gradle:gradle-apt-plugin:0.13"
     }
 }
 
@@ -52,8 +52,7 @@ subprojects {
     }
     assemble.dependsOn jarSources
 
-    apply plugin: "idea"
-    apply plugin: "net.ltgt.apt"
+    apply plugin: "net.ltgt.apt-idea"
     apply plugin: "net.ltgt.errorprone"
 
     apply plugin: 'org.jetbrains.intellij'

--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     compile files('lib/google-api-services-source.jar')
     compile 'org.yaml:snakeyaml:1.18'
 
+    compileOnly 'com.google.auto.value:auto-value:1.4.1'
+    apt         'com.google.auto.value:auto-value:1.4.1'
+
     testCompile(project(':common-test-lib'))
     testRuntime files('google-account/lib/google-gct-login-context-ij-pg.jar')
 }


### PR DESCRIPTION
Without this, I've noticed that the `AutoValue` annotation isn't added to the classpath of the project properly, specifically within the `common-test-lib` module. This updates to the newest version of the annotation processor Gradle plugin and uses the new recommended plugin, which seems to resolve the issue.