### PR TITLE
Specifically set gradlew.bat to CRLF endings in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,4 +23,4 @@ CONTRIBUTORS text
 *.jpg binary
 *.jar binary
 
-gradlew.bat=crlf
+gradlew.bat eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,5 @@ CONTRIBUTORS text
 *.png binary
 *.jpg binary
 *.jar binary
+
+gradlew.bat=crlf


### PR DESCRIPTION
This should fix it (I think). It undoes my last PR by using CRLF endings in `gradlew.bat` but forces it to stay that way in the `.gitattributes` file.