### PR TITLE
Fix analytics env property injection

### DIFF
--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -87,6 +87,16 @@ configurations {
     tests
 }
 
+processResources {
+    def trackerProperty =  System.getenv("ANALYTICS_ID")
+    if (trackerProperty) {
+        inputs.property("usageTrackerProperty", trackerProperty)
+        filesMatching("**/config.properties") {
+            expand "usageTrackerProperty": trackerProperty
+        }
+    }
+}
+
 artifacts {
     tests testJar
 }

--- a/google-cloud-tools-plugin/google-account/build.gradle
+++ b/google-cloud-tools-plugin/google-account/build.gradle
@@ -45,13 +45,3 @@ configurations {
     compile.exclude group: 'com.google.api-client', module: 'google-api-client'
     compile.exclude group: 'com.google.http-client', module: 'google-http-client'
 }
-
-processResources {
-    def trackerProperty =  System.getenv("ANALYTICS_ID")
-    if (trackerProperty) {
-        inputs.property("usageTrackerProperty", trackerProperty)
-        filesMatching("**/config.properties") {
-            expand "usageTrackerProperty": trackerProperty
-        }
-    }
-}


### PR DESCRIPTION
fixes #1773 

The issue was that after merging the account plugin, the account module became a sibling of the google cloud tools module. The processResource logic which replaces the analytics property with the system env var was then unable to locate the config file (based on the blob matcher).

This fix moves the processResource block into the cloud-tools-plugin gradle config.