### PR TITLE
Project selection dialog

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -395,9 +395,10 @@ account.plugin.removal.requires.restart.text=The Google Account plugin is no lon
   has been uninstalled.  Please restart your IDE for it to take effect.  If you cancel you will \
   experience problems using the Google Cloud Tools plugin. \n\nOK to restart?
 
-project.selector.no.selected.project=Select a Google Cloud project
-project.selector.dialog.title=Select Google Cloud Project
-project.selector.project.list.project.name.column=Project Name
-project.selector.project.list.project.id.column=Project ID
+cloud.project.selector.signin.message=Sign in with your Google account to list your Google Developers Console projects.
+cloud.project.selector.no.selected.project=Select a Google Cloud project
+cloud.project.selector.dialog.title=Select Google Cloud Project
+cloud.project.selector.project.list.project.name.column=Project Name
+cloud.project.selector.project.list.project.id.column=Project ID
 project.selector.loader.couldnotconnect=Could not connect to Google. Please make sure you have a working internet connection.
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/CloudProject.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/CloudProject.java
@@ -21,11 +21,13 @@ import com.google.auto.value.AutoValue;
 /** GCP project and account. */
 @AutoValue
 public abstract class CloudProject {
-  public static CloudProject create(String projectName, String googleUsername) {
-    return new AutoValue_CloudProject(projectName, googleUsername);
+  public static CloudProject create(String projectName, String projectId, String googleUsername) {
+    return new AutoValue_CloudProject(projectName, projectId, googleUsername);
   }
 
   public abstract String projectName();
+
+  public abstract String projectId();
 
   public abstract String googleUsername();
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/FilteredTextTableCellRenderer.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/FilteredTextTableCellRenderer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.project;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import java.awt.Component;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableCellRenderer;
+
+/** Renders text in table cells marking filter text as bold. */
+public class FilteredTextTableCellRenderer extends DefaultTableCellRenderer {
+  private String filterText;
+
+  void setFilterText(String filterText) {
+    this.filterText = filterText;
+  }
+
+  @Override
+  public Component getTableCellRendererComponent(
+      JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+    JLabel label =
+        (JLabel)
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+    label.setText(highlightFilterText(filterText, label.getText()));
+    return label;
+  }
+
+  @VisibleForTesting
+  String highlightFilterText(String filterText, String text) {
+    if (!Strings.isNullOrEmpty(filterText) && !Strings.isNullOrEmpty(text)) {
+      return "<html>" + text.replace(filterText, "<b>" + filterText + "</b>");
+    }
+    return text;
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectListTableModel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectListTableModel.java
@@ -46,21 +46,21 @@ class ProjectListTableModel extends AbstractTableModel {
         return projectList.get(row).getName();
       case PROJECT_ID_COLUMN:
         return projectList.get(row).getProjectId();
+      default:
+        return "";
     }
-
-    return "";
   }
 
   @Override
   public String getColumnName(int column) {
     switch (column) {
       case PROJECT_NAME_COLUMN:
-        return GctBundle.getString("project.selector.project.list.project.name.column");
+        return GctBundle.getString("cloud.project.selector.project.list.project.name.column");
       case PROJECT_ID_COLUMN:
-        return GctBundle.getString("project.selector.project.list.project.id.column");
+        return GctBundle.getString("cloud.project.selector.project.list.project.id.column");
+      default:
+        return "";
     }
-
-    return "";
   }
 
   String getProjectNameAtRow(int row) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectListTableModel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectListTableModel.java
@@ -67,6 +67,10 @@ class ProjectListTableModel extends AbstractTableModel {
     return getValueAt(row, ProjectListTableModel.PROJECT_NAME_COLUMN).toString();
   }
 
+  String getProjectIdAtRow(int row) {
+    return getValueAt(row, ProjectListTableModel.PROJECT_ID_COLUMN).toString();
+  }
+
   void setProjectList(List<Project> updatedList) {
     projectList.clear();
     projectList.addAll(updatedList);

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectListTableModel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectListTableModel.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.project;
+
+import com.google.api.services.cloudresourcemanager.model.Project;
+import com.google.cloud.tools.intellij.util.GctBundle;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+
+/** Model for project list table in {@link ProjectSelectionDialog}. */
+class ProjectListTableModel extends AbstractTableModel {
+  private static final int PROJECT_NAME_COLUMN = 0;
+  private static final int PROJECT_ID_COLUMN = 1;
+
+  private final List<Project> projectList = new ArrayList<>();
+
+  @Override
+  public int getRowCount() {
+    return projectList.size();
+  }
+
+  @Override
+  public int getColumnCount() {
+    return 2;
+  }
+
+  @Override
+  public Object getValueAt(int row, int column) {
+    switch (column) {
+      case PROJECT_NAME_COLUMN:
+        return projectList.get(row).getName();
+      case PROJECT_ID_COLUMN:
+        return projectList.get(row).getProjectId();
+    }
+
+    return "";
+  }
+
+  @Override
+  public String getColumnName(int column) {
+    switch (column) {
+      case PROJECT_NAME_COLUMN:
+        return GctBundle.getString("project.selector.project.list.project.name.column");
+      case PROJECT_ID_COLUMN:
+        return GctBundle.getString("project.selector.project.list.project.id.column");
+    }
+
+    return "";
+  }
+
+  String getProjectNameAtRow(int row) {
+    return getValueAt(row, ProjectListTableModel.PROJECT_NAME_COLUMN).toString();
+  }
+
+  void setProjectList(List<Project> updatedList) {
+    projectList.clear();
+    projectList.addAll(updatedList);
+    fireTableDataChanged();
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.form
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.cloud.tools.intellij.project.ProjectSelectionDialog">
+  <grid id="27dc6" binding="centerPanel" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="5" left="5" bottom="0" right="5"/>
+    <constraints>
+      <xy x="20" y="21" width="699" height="504"/>
+    </constraints>
+    <properties>
+      <minimumSize width="500" height="200"/>
+      <preferredSize width="700" height="496"/>
+    </properties>
+    <border type="empty"/>
+    <children>
+      <component id="3d6c8" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Account:"/>
+        </properties>
+      </component>
+      <component id="ed8e3" class="javax.swing.JComboBox" binding="accountComboBox" custom-create="true">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="e9f8a" class="javax.swing.JButton" binding="addAccountButton" custom-create="true" default-binding="true">
+        <constraints>
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Add Account"/>
+        </properties>
+      </component>
+      <component id="9b612" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Filter Name/ID:"/>
+        </properties>
+      </component>
+      <component id="12896" class="javax.swing.JTextField" binding="filterTextField" custom-create="true">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <scrollpane id="f2f70">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="6771" class="javax.swing.JTable" binding="projectListTable" custom-create="true">
+            <constraints/>
+            <properties/>
+          </component>
+        </children>
+      </scrollpane>
+    </children>
+  </grid>
+</form>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.form
@@ -38,7 +38,7 @@
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Filter Name/ID:"/>
+          <text value="Search by Name or ID:"/>
         </properties>
       </component>
       <component id="12896" class="javax.swing.JTextField" binding="filterTextField" custom-create="true">

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
@@ -121,10 +121,10 @@ public class ProjectSelectionDialog {
                       .connect(dialogWrapper.getDisposable() /* disconnect once dialog is gone. */)
                       .subscribe(
                           GoogleLoginListener.GOOGLE_LOGIN_LISTENER_TOPIC,
-                          this::loadUsersAndProjects));
+                          this::loadAllProjects));
     }
 
-    loadUsersAndProjects();
+    loadAllProjects();
     setSelectedProject(cloudProject);
 
     DialogManager.show(dialogWrapper);
@@ -155,7 +155,7 @@ public class ProjectSelectionDialog {
   }
 
   @VisibleForTesting
-  void loadUsersAndProjects() {
+  void loadAllProjects() {
     Collection<CredentialedUser> credentialedUsers =
         Services.getLoginService().getAllUsers().values();
     if (credentialedUsers.isEmpty()) {
@@ -430,7 +430,7 @@ public class ProjectSelectionDialog {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-      loadUsersAndProjects();
+      loadAllProjects();
     }
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
@@ -120,8 +120,7 @@ public class ProjectSelectionDialog {
                       .getMessageBus()
                       .connect(dialogWrapper.getDisposable() /* disconnect once dialog is gone. */)
                       .subscribe(
-                          GoogleLoginListener.GOOGLE_LOGIN_LISTENER_TOPIC,
-                          this::loadAllProjects));
+                          GoogleLoginListener.GOOGLE_LOGIN_LISTENER_TOPIC, this::loadAllProjects));
     }
 
     loadAllProjects();
@@ -151,7 +150,7 @@ public class ProjectSelectionDialog {
   @VisibleForTesting
   CloudProject getSelectedProject() {
     CredentialedUser user = accountComboBox.getItemAt(accountComboBox.getSelectedIndex());
-    return CloudProject.create(getSelectedProjectName(), user.getEmail());
+    return CloudProject.create(getSelectedProjectName(), getSelectedProjectId(), user.getEmail());
   }
 
   @VisibleForTesting
@@ -333,6 +332,14 @@ public class ProjectSelectionDialog {
     int actualSelectedRow =
         projectListTable.getRowSorter().convertRowIndexToModel(projectListTable.getSelectedRow());
     return projectListTableModel.getProjectNameAtRow(actualSelectedRow);
+  }
+
+  @VisibleForTesting
+  String getSelectedProjectId() {
+    // row number change based on filtering state.
+    int actualSelectedRow =
+        projectListTable.getRowSorter().convertRowIndexToModel(projectListTable.getSelectedRow());
+    return projectListTableModel.getProjectIdAtRow(actualSelectedRow);
   }
 
   @VisibleForTesting

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
@@ -125,23 +125,22 @@ public class ProjectSelectionDialog {
     }
 
     loadUsersAndProjects();
-    setCloudProject(cloudProject);
+    setSelectedProject(cloudProject);
 
     DialogManager.show(dialogWrapper);
 
     int result = dialogWrapper.getExitCode();
-    return result == DialogWrapper.OK_EXIT_CODE ? getCloudProject() : null;
+    return result == DialogWrapper.OK_EXIT_CODE ? getSelectedProject() : null;
   }
 
   @VisibleForTesting
-  void setCloudProject(CloudProject cloudProject) {
+  void setSelectedProject(CloudProject cloudProject) {
     if (cloudProject != null && !Strings.isNullOrEmpty(cloudProject.googleUsername())) {
       Optional<CredentialedUser> loggedInUser =
           Services.getLoginService().getLoggedInUser(cloudProject.googleUsername());
       if (loggedInUser.isPresent()) {
         selectedProjectsByAccount.put(loggedInUser.get(), cloudProject.projectName());
         accountComboBox.setSelectedItem(loggedInUser.get());
-        updateProjectList(loggedInUser.get());
       } else {
         // specified user is not in logged in user list, clear the account selection.
         accountComboBox.setSelectedItem(null);
@@ -150,7 +149,7 @@ public class ProjectSelectionDialog {
   }
 
   @VisibleForTesting
-  CloudProject getCloudProject() {
+  CloudProject getSelectedProject() {
     CredentialedUser user = accountComboBox.getItemAt(accountComboBox.getSelectedIndex());
     return CloudProject.create(getSelectedProjectName(), user.getEmail());
   }
@@ -307,8 +306,11 @@ public class ProjectSelectionDialog {
   private void validateProjectSelection() {
     if (projectListTable.getSelectedRow() >= 0) {
       dialogWrapper.setOKActionEnabled(true);
+      selectedProjectsByAccount.put(
+          (CredentialedUser) accountComboBox.getSelectedItem(), getSelectedProjectName());
     } else {
       dialogWrapper.setOKActionEnabled(false);
+      selectedProjectsByAccount.remove((CredentialedUser) accountComboBox.getSelectedItem());
     }
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
@@ -16,14 +16,75 @@
 
 package com.google.cloud.tools.intellij.project;
 
+import com.google.api.services.cloudresourcemanager.model.Project;
+import com.google.cloud.tools.intellij.login.CredentialedUser;
+import com.google.cloud.tools.intellij.login.GoogleLoginListener;
+import com.google.cloud.tools.intellij.login.Services;
+import com.google.cloud.tools.intellij.login.ui.GoogleLoginIcons;
+import com.google.cloud.tools.intellij.ui.GoogleCloudToolsIcons;
+import com.google.cloud.tools.intellij.util.GctBundle;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.ValidationInfo;
+import com.intellij.ui.DocumentAdapter;
+import com.intellij.ui.ListCellRendererWrapper;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.ui.table.JBTable;
+import git4idea.DialogManager;
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
+import org.jdesktop.swingx.sort.RowFilters.GeneralFilter;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Modal project and account selection dialog. Contains account drop-down with user list, table with
  * project list and simple filter. {@link ProjectSelector} calls {@link #showDialog(CloudProject)}.
  */
-// TODO(ivanporty) implementation in the following PRs
 public class ProjectSelectionDialog {
+
+  private JComboBox<CredentialedUser> accountComboBox;
+  private JButton addAccountButton;
+  private JTextField filterTextField;
+  private JTable projectListTable;
+  private JPanel centerPanel;
+
+  private ProjectSelectionDialogWrapper dialogWrapper;
+
+  private JPanel centerPanelWrapper;
+  private ProjectSelectorSignInPanel signInScreen = new ProjectSelectorSignInPanel();
+
+  private RefreshAction refreshAction;
+
+  private CloudProject cloudProject;
+  private ProjectListTableModel projectListTableModel;
+
+  private ProjectLoader projectLoader = new ProjectLoader();
 
   /**
    * Creates and shows modal dialog to select project/account. Blocks EDT until choice is made.
@@ -33,6 +94,320 @@ public class ProjectSelectionDialog {
    */
   @Nullable
   CloudProject showDialog(@Nullable CloudProject cloudProject) {
-    return cloudProject;
+    // create dialog wrapper for the form once, create services and subscribe to login changes once.
+    if (dialogWrapper == null) {
+      dialogWrapper = new ProjectSelectionDialogWrapper();
+
+      dialogWrapper.setTitle(GctBundle.getString("project.selector.dialog.title"));
+      // disabled unless project is selected in the list.
+      dialogWrapper.setOKActionEnabled(false);
+
+      Stream.of(ProjectManager.getInstance().getOpenProjects())
+          .forEach(
+              project ->
+                  project
+                      .getMessageBus()
+                      .connect(dialogWrapper.getDisposable() /* disconnect once dialog is gone. */)
+                      .subscribe(
+                          GoogleLoginListener.GOOGLE_LOGIN_LISTENER_TOPIC,
+                          this::loadUsersAndProjects));
+    }
+
+    loadUsersAndProjects();
+    setCloudProject(cloudProject);
+
+    DialogManager.show(dialogWrapper);
+
+    int result = dialogWrapper.getExitCode();
+    return result == DialogWrapper.OK_EXIT_CODE ? getCloudProject() : null;
+  }
+
+  @VisibleForTesting
+  void createUIComponents() {
+    addAccountButton = new JButton();
+    addAccountButton.addActionListener((event) -> Services.getLoginService().logIn());
+
+    // prepare table model and rendering.
+    projectListTable = new JBTable();
+    projectListTableModel = new ProjectListTableModel();
+    projectListTable.setModel(projectListTableModel);
+    projectListTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    projectListTable.getSelectionModel().addListSelectionListener(e -> validateProjectSelection());
+    FilteredTextTableCellRenderer filterRenderer = new FilteredTextTableCellRenderer();
+    projectListTable.setDefaultRenderer(Object.class, filterRenderer);
+
+    // filter rows based on text field content.
+    filterTextField = new JBTextField();
+    TableRowSorter<TableModel> sorter = new TableRowSorter<>(projectListTableModel);
+    projectListTable.setRowSorter(sorter);
+
+    GeneralFilter filter =
+        new GeneralFilter() {
+          @Override
+          protected boolean include(Entry value, int index) {
+            return value
+                .getStringValue(index)
+                .toLowerCase()
+                .contains(filterTextField.getText().toLowerCase());
+          }
+        };
+    sorter.setRowFilter(filter);
+    // on filter types, update row filter and renderer.
+    filterTextField
+        .getDocument()
+        .addDocumentListener(
+            new DocumentAdapter() {
+              @Override
+              protected void textChanged(DocumentEvent e) {
+                sorter.allRowsChanged();
+                filterRenderer.setFilterText(filterTextField.getText());
+              }
+            });
+
+    refreshAction = new RefreshAction();
+
+    // prepare account combobox model and rendering.
+    accountComboBox = new ComboBox<>();
+    accountComboBox.setRenderer(new AccountComboBoxRenderer());
+    accountComboBox.addActionListener((event) -> updateProjectList());
+
+    // wrapper for center panel that holds either project selection or sign in screen.
+    centerPanelWrapper = new JPanel(new BorderLayout());
+  }
+
+  @VisibleForTesting
+  void setCloudProject(CloudProject cloudProject) {
+    this.cloudProject = cloudProject;
+    updateProjectAccountInformation();
+  }
+
+  private CloudProject getCloudProject() {
+    CredentialedUser user = accountComboBox.getItemAt(accountComboBox.getSelectedIndex());
+    return CloudProject.create(getSelectedProjectName(), user.getEmail());
+  }
+
+  @VisibleForTesting
+  void loadUsersAndProjects() {
+    Collection<CredentialedUser> credentialedUsers =
+        Services.getLoginService().getAllUsers().values();
+    if (credentialedUsers.isEmpty()) {
+      showSignInRequest();
+    } else {
+      hideSignInRequest();
+      accountComboBox.removeAllItems();
+      for (CredentialedUser user : credentialedUsers) {
+        accountComboBox.addItem(user);
+      }
+      accountComboBox.setSelectedItem(Services.getLoginService().getActiveUser());
+      // no need to update project list - account combo box will generate an event.
+    }
+  }
+
+  private void updateProjectList() {
+    // clear list and reload for selected user, empty if user is not logged in/selection empty.
+    projectListTableModel.setProjectList(Collections.emptyList());
+    CredentialedUser user = (CredentialedUser) accountComboBox.getSelectedItem();
+    if (user != null) {
+      ((JBTable) projectListTable).setPaintBusy(true);
+      ListenableFuture<List<Project>> futureResult =
+          projectLoader.loadUserProjectsInBackground(user);
+      addProjectListFutureCallback(
+          futureResult,
+          new FutureCallback<List<Project>>() {
+            @Override
+            public void onSuccess(List<Project> projects) {
+              SwingUtilities.invokeLater(
+                  () -> {
+                    projectListTableModel.setProjectList(projects);
+                    ((JBTable) projectListTable).setPaintBusy(false);
+                    if (cloudProject != null) {
+                      showProjectInList(cloudProject.projectName());
+                    }
+                  });
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) {
+              ((JBTable) projectListTable).setPaintBusy(false);
+              dialogWrapper.setErrorInfoAll(
+                  Collections.singletonList(new ValidationInfo(throwable.getMessage())));
+            }
+          });
+    }
+  }
+
+  private void updateProjectAccountInformation() {
+    if (cloudProject != null && !Strings.isNullOrEmpty(cloudProject.googleUsername())) {
+      Optional<CredentialedUser> loggedInUser =
+          Services.getLoginService().getLoggedInUser(cloudProject.googleUsername());
+      if (loggedInUser.isPresent()) {
+        accountComboBox.setSelectedItem(loggedInUser.get());
+      } else {
+        // specified user is not in logged in user list, clear the account selection.
+        accountComboBox.setSelectedItem(null);
+      }
+      // no need to update project list - account combo box will generate an event.
+    }
+  }
+
+  private void showSignInRequest() {
+    centerPanelWrapper.removeAll();
+    centerPanelWrapper.add(signInScreen);
+    getDialogButton(refreshAction).setVisible(false);
+    dialogWrapper.validate();
+  }
+
+  private void hideSignInRequest() {
+    if (!centerPanel.isShowing()) {
+      centerPanelWrapper.removeAll();
+      centerPanelWrapper.add(centerPanel);
+      Optional.ofNullable(getDialogButton(refreshAction)).ifPresent(b -> b.setVisible(true));
+      dialogWrapper.validate();
+      dialogWrapper.pack();
+    }
+  }
+
+  private void validateProjectSelection() {
+    if (projectListTable.getSelectedRow() >= 0) {
+      dialogWrapper.setOKActionEnabled(true);
+    } else {
+      dialogWrapper.setOKActionEnabled(false);
+    }
+  }
+
+  // finds if project list contains the project with given name, selects and scrolls to it.
+  private void showProjectInList(String projectName) {
+    for (int i = 0; i < projectListTableModel.getRowCount(); i++) {
+      String projectNameAtRow = projectListTableModel.getProjectNameAtRow(i);
+      if (projectNameAtRow.equals(projectName)) {
+        projectListTable.getSelectionModel().setSelectionInterval(i, i);
+        projectListTable.scrollRectToVisible(projectListTable.getCellRect(i, 0, true));
+        break;
+      }
+    }
+  }
+
+  @VisibleForTesting
+  String getSelectedProjectName() {
+    // row number change based on filtering state.
+    int actualSelectedRow =
+        projectListTable.getRowSorter().convertRowIndexToModel(projectListTable.getSelectedRow());
+    return projectListTableModel.getProjectNameAtRow(actualSelectedRow);
+  }
+
+  @VisibleForTesting
+  JButton getDialogButton(@NotNull Action action) {
+    return dialogWrapper.getButton(action);
+  }
+
+  @VisibleForTesting
+  JComboBox<CredentialedUser> getAccountComboBox() {
+    return accountComboBox;
+  }
+
+  @VisibleForTesting
+  JTable getProjectListTable() {
+    return projectListTable;
+  }
+
+  @VisibleForTesting
+  ProjectListTableModel getProjectListTableModel() {
+    return projectListTableModel;
+  }
+
+  @VisibleForTesting
+  JPanel getCenterPanelWrapper() {
+    return centerPanelWrapper;
+  }
+
+  @VisibleForTesting
+  void setProjectLoader(ProjectLoader projectLoader) {
+    this.projectLoader = projectLoader;
+  }
+
+  @VisibleForTesting
+  void setDialogWrapper(ProjectSelectionDialogWrapper dialogWrapper) {
+    this.dialogWrapper = dialogWrapper;
+  }
+
+  @VisibleForTesting
+  void addProjectListFutureCallback(
+      ListenableFuture<List<Project>> future, FutureCallback<List<Project>> callback) {
+    Futures.addCallback(future, callback);
+  }
+
+  /**
+   * Wraps this form as an IDEA dialog instead of inheriting dialog internals.
+   */
+  @VisibleForTesting
+  class ProjectSelectionDialogWrapper extends DialogWrapper {
+
+    private ProjectSelectionDialogWrapper() {
+      super(false /* cannot be parent */);
+      init();
+    }
+
+    @Nullable
+    @Override
+    protected JComponent createCenterPanel() {
+      return centerPanelWrapper;
+    }
+
+    // IntelliJ API - creates actions (buttons) for "left side" of the dialog bottom panel.
+    @NotNull
+    @Override
+    protected Action[] createLeftSideActions() {
+      return new Action[]{refreshAction};
+    }
+
+    @Override
+    public void setOKActionEnabled(boolean isEnabled) {
+      super.setOKActionEnabled(isEnabled);
+    }
+
+    @Override
+    protected void setErrorInfoAll(@NotNull List<ValidationInfo> info) {
+      super.setErrorInfoAll(info);
+    }
+
+    @Nullable
+    @Override
+    protected JButton getButton(@NotNull Action action) {
+      return super.getButton(action);
+    }
+
+    @Nullable
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+      return filterTextField;
+    }
+  }
+
+  // re-queries all signed in users and projects.
+  private final class RefreshAction extends AbstractAction {
+
+    private RefreshAction() {
+      putValue(Action.SMALL_ICON, GoogleCloudToolsIcons.REFRESH);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+      loadUsersAndProjects();
+    }
+  }
+
+  private static final class AccountComboBoxRenderer
+      extends ListCellRendererWrapper<CredentialedUser> {
+
+    @Override
+    public void customize(
+        JList list, CredentialedUser user, int index, boolean selected, boolean hasFocus) {
+      if (user != null) {
+        // use just email if no name is set or email in "()" if set.
+        setText(String
+            .format("%s (%s)", Strings.nullToEmpty(user.getName()), user.getEmail()));
+        setIcon(GoogleLoginIcons.getScaledUserIcon(ProjectSelector.ACCOUNT_ICON_SIZE, user));
+      }
+    }
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
@@ -99,7 +99,7 @@ public class ProjectSelectionDialog {
     if (dialogWrapper == null) {
       dialogWrapper = new ProjectSelectionDialogWrapper();
 
-      dialogWrapper.setTitle(GctBundle.getString("project.selector.dialog.title"));
+      dialogWrapper.setTitle(GctBundle.getString("cloud.project.selector.dialog.title"));
       // disabled unless project is selected in the list.
       dialogWrapper.setOKActionEnabled(false);
       // install additional IDEA UI.

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
@@ -34,6 +34,7 @@ import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.ui.DocumentAdapter;
 import com.intellij.ui.ListCellRendererWrapper;
+import com.intellij.ui.TableSpeedSearch;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.ui.table.JBTable;
 import git4idea.DialogManager;
@@ -135,6 +136,16 @@ public class ProjectSelectionDialog {
     projectListTable.getSelectionModel().addListSelectionListener(e -> validateProjectSelection());
     FilteredTextTableCellRenderer filterRenderer = new FilteredTextTableCellRenderer();
     projectListTable.setDefaultRenderer(Object.class, filterRenderer);
+
+    // IDEA implementation of instant type-search within a table.
+    new TableSpeedSearch(projectListTable) {
+      // reflect this text in the filter text field.
+      @Override
+      protected void selectElement(Object element, String selectedText) {
+        filterTextField.setText(selectedText);
+        super.selectElement(element, selectedText);
+      }
+    };
 
     // filter rows based on text field content.
     filterTextField = new JBTextField();

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
@@ -94,7 +94,7 @@ public class ProjectSelector extends JPanel {
 
   private void createUIComponents() {
     projectNameLabel = new HyperlinkLabelWithStateAccess();
-    projectNameLabel.setHyperlinkText(GctBundle.getString("project.selector.no.selected.project"));
+    projectNameLabel.setHyperlinkText(GctBundle.getString("cloud.project.selector.no.selected.project"));
     projectNameLabel.addHyperlinkListener(
         (event) -> {
           if (event.getEventType() == EventType.ACTIVATED) {
@@ -132,7 +132,7 @@ public class ProjectSelector extends JPanel {
   }
 
   private void updateEmptySelection() {
-    projectNameLabel.setHyperlinkText(GctBundle.getString("project.selector.no.selected.project"));
+    projectNameLabel.setHyperlinkText(GctBundle.getString("cloud.project.selector.no.selected.project"));
     accountInfoLabel.setHyperlinkText("");
     accountInfoLabel.setIcon(null);
     projectAccountSeparatorLabel.setVisible(false);

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
@@ -144,7 +144,7 @@ public class ProjectSelector extends JPanel {
     // first just show account email, then expand with name/picture if this account is signed in.
     accountInfoLabel.setHyperlinkText(selection.googleUsername());
     Optional<CredentialedUser> loggedInUser =
-        Services.getLoginService().getLoggedInUser(selection.projectName());
+        Services.getLoginService().getLoggedInUser(selection.googleUsername());
     if (loggedInUser.isPresent()) {
       accountInfoLabel.setHyperlinkText(
           String.format("%s (%s)", loggedInUser.get().getName(), loggedInUser.get().getEmail()));

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectorSignInPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectorSignInPanel.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.project;
+
+import com.google.cloud.tools.intellij.login.Services;
+import com.google.cloud.tools.intellij.login.util.AccountMessageBundle;
+import com.google.cloud.tools.intellij.resources.BaseGoogleLoginUi;
+import com.google.cloud.tools.intellij.util.GctBundle;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+
+/** Sign in panel shown in {@link ProjectSelectionDialog} when no users are logged in. */
+class ProjectSelectorSignInPanel extends BaseGoogleLoginUi {
+
+  ProjectSelectorSignInPanel() {
+    super(GctBundle.message("select.project.signin"));
+    init();
+  }
+
+  private void init() {
+    JButton signInButton = new JButton(new SignInAction());
+    GridBagConstraints constraints = new GridBagConstraints();
+    constraints.gridy = 2; // below sign in text.
+    constraints.anchor = GridBagConstraints.NORTHWEST;
+    add(signInButton, constraints);
+  }
+
+  private static final class SignInAction extends AbstractAction {
+    private SignInAction() {
+      putValue(Action.NAME, AccountMessageBundle.message("login.panel.sign.in.button.text"));
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+      Services.getLoginService().logIn();
+    }
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectorSignInPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectorSignInPanel.java
@@ -20,7 +20,6 @@ import com.google.cloud.tools.intellij.login.Services;
 import com.google.cloud.tools.intellij.login.util.AccountMessageBundle;
 import com.google.cloud.tools.intellij.resources.BaseGoogleLoginUi;
 import com.google.cloud.tools.intellij.util.GctBundle;
-import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.event.ActionEvent;
 import javax.swing.AbstractAction;
@@ -31,7 +30,7 @@ import javax.swing.JButton;
 class ProjectSelectorSignInPanel extends BaseGoogleLoginUi {
 
   ProjectSelectorSignInPanel() {
-    super(GctBundle.message("select.project.signin"));
+    super(GctBundle.message("cloud.project.selector.signin.message"));
     init();
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/BaseGoogleLoginUi.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/resources/BaseGoogleLoginUi.java
@@ -36,7 +36,7 @@ import javax.swing.SwingConstants;
 /**
  * UI for the node that prompts for Google Login.
  */
-class BaseGoogleLoginUi extends JPanel {
+public class BaseGoogleLoginUi extends JPanel {
 
   public static final int PREFERRED_HEIGHT = 150;
   public static final int MIN_WIDTH = 450;

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/FilteredTextTableCellRendererTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/FilteredTextTableCellRendererTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.project;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class FilteredTextTableCellRendererTest {
+  private static final String SAMPLE_TEXT = "your project name and project id.";
+
+  private FilteredTextTableCellRenderer renderer;
+
+  @Before
+  public void setUp() {
+    renderer = new FilteredTextTableCellRenderer();
+  }
+
+  @Test
+  public void accepts_nullInputs() {
+    String result = renderer.highlightFilterText(null, null);
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void accepts_emptyInputs() {
+    String result = renderer.highlightFilterText("", "");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void emptyFilter_doesNotChangeText() {
+    String result = renderer.highlightFilterText("", SAMPLE_TEXT);
+
+    assertThat(result).isEqualTo(SAMPLE_TEXT);
+  }
+
+  @Test
+  public void highlights_matchingText() {
+    String result = renderer.highlightFilterText("project", SAMPLE_TEXT);
+    String expected = "<html>your <b>project</b> name and <b>project</b> id.";
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  public void highlights_matchingText_atStart() {
+    String result = renderer.highlightFilterText("you", SAMPLE_TEXT);
+    String expected = "<html><b>you</b>r project name and project id.";
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  public void highlights_matchingText_atEnd() {
+    String result = renderer.highlightFilterText("id.", SAMPLE_TEXT);
+    String expected = "<html>your project name and project <b>id.</b>";
+
+    assertThat(result).isEqualTo(expected);
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectListTableModelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectListTableModelTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.project;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.services.cloudresourcemanager.model.Project;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+
+/** tests for {@link ProjectListTableModel} */
+public class ProjectListTableModelTest {
+  private ProjectListTableModel model;
+  private Project testProject1, testProject2;
+
+  @Before
+  public void setUp() {
+    model = new ProjectListTableModel();
+    testProject1 = new Project();
+    testProject1.setName("test-project");
+    testProject1.setProjectId("test-project-ID");
+    testProject2 = new Project();
+    testProject2.setName("test-project-2");
+    testProject2.setProjectId("test-project-2-ID");
+  }
+
+  @Test
+  public void starts_Empty() {
+    assertThat(model.getColumnCount()).isEqualTo(2);
+    assertThat(model.getRowCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void setProjectList() {
+    model.setProjectList(Arrays.asList(testProject1, testProject2));
+
+    assertThat(model.getRowCount()).isEqualTo(2);
+  }
+
+  @Test
+  public void returns_validProjectName() {
+    model.setProjectList(Arrays.asList(testProject1, testProject2));
+
+    assertThat(model.getProjectNameAtRow(0)).isEqualTo(testProject1.getName());
+    assertThat(model.getProjectNameAtRow(1)).isEqualTo(testProject2.getName());
+  }
+
+  @Test
+  public void setProjectList_clearsPreviousState() {
+    model.setProjectList(Arrays.asList(testProject1, testProject2));
+    model.setProjectList(Collections.singletonList(testProject2));
+
+    assertThat(model.getRowCount()).isEqualTo(1);
+    assertThat(model.getProjectNameAtRow(0)).isEqualTo(testProject2.getName());
+  }
+
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectListTableModelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectListTableModelTest.java
@@ -62,6 +62,14 @@ public class ProjectListTableModelTest {
   }
 
   @Test
+  public void returns_validProjectId() {
+    model.setProjectList(Arrays.asList(testProject1, testProject2));
+
+    assertThat(model.getProjectIdAtRow(0)).isEqualTo(testProject1.getProjectId());
+    assertThat(model.getProjectIdAtRow(1)).isEqualTo(testProject2.getProjectId());
+  }
+
+  @Test
   public void setProjectList_clearsPreviousState() {
     model.setProjectList(Arrays.asList(testProject1, testProject2));
     model.setProjectList(Collections.singletonList(testProject2));

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.intellij.project;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -76,6 +77,7 @@ public class ProjectSelectionDialogTest {
     projectSelectionDialog.setDialogWrapper(dialogWrapper);
     doReturn(mockDialogButton).when(projectSelectionDialog).getDialogButton(any());
     doNothing().when(projectSelectionDialog).installTableSpeedSearch(any());
+    doNothing().when(projectSelectionDialog).setLoading(anyBoolean());
 
     projectSelectionDialog.createUIComponents();
     projectSelectionDialog.loadAllProjects();

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
@@ -179,8 +179,8 @@ public class ProjectSelectionDialogTest {
   private void prepareOneTestUserOneTestProjectDialog(CloudProject selectedProject) {
     mockUserList(Collections.singletonList(mockTestUser));
     mockUserProjects(mockTestUser, Collections.singletonList(testGoogleProject));
-    projectSelectionDialog.setCloudProject(selectedProject);
     cleanLoadUsersAndProjects();
+    projectSelectionDialog.setCloudProject(selectedProject);
   }
 
   /** Loads users and projects and ensures UI events are processed before returning. */

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
@@ -99,7 +99,7 @@ public class ProjectSelectionDialogTest {
 
   @Test
   public void existingSignedInUser_signInScreen_notVisible() {
-    mockUserList(Collections.singletonList(mockTestUser));
+    prepareOneTestUserOneTestProjectDialog(testUiProject);
 
     cleanLoadUsersAndProjects();
 

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
@@ -77,7 +77,7 @@ public class ProjectSelectionDialogTest {
     doNothing().when(projectSelectionDialog).installTableSpeedSearch(any());
 
     projectSelectionDialog.createUIComponents();
-    projectSelectionDialog.loadUsersAndProjects();
+    projectSelectionDialog.loadAllProjects();
 
     testUiProject = CloudProject.create(TEST_PROJECT_NAME, TEST_USER_EMAIL);
     testGoogleProject = new Project();
@@ -187,7 +187,7 @@ public class ProjectSelectionDialogTest {
   private void cleanLoadUsersAndProjects() {
     // wait until UI events are processed.
     try {
-      SwingUtilities.invokeAndWait(() -> projectSelectionDialog.loadUsersAndProjects());
+      SwingUtilities.invokeAndWait(() -> projectSelectionDialog.loadAllProjects());
       // second call to wait until project list is updated via invokeLater().
       SwingUtilities.invokeAndWait(() -> {});
     } catch (Exception ex) {

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.project;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.api.services.cloudresourcemanager.model.Project;
+import com.google.cloud.tools.intellij.login.CredentialedUser;
+import com.google.cloud.tools.intellij.login.IntegratedGoogleLoginService;
+import com.google.cloud.tools.intellij.project.ProjectSelectionDialog.ProjectSelectionDialogWrapper;
+import com.google.cloud.tools.intellij.testing.CloudToolsRule;
+import com.google.cloud.tools.intellij.testing.TestService;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.swing.JButton;
+import javax.swing.SwingUtilities;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+/** Tests {@link ProjectSelectionDialog} data model and UI interactions. */
+public class ProjectSelectionDialogTest {
+
+  @Rule public CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
+
+  private static final String TEST_USER_EMAIL = "test@google.com";
+  private static final String TEST_PROJECT_NAME = "test-1";
+
+  private CloudProject testUiProject;
+  private Project testCloudProject;
+
+  @TestService @Mock private IntegratedGoogleLoginService googleLoginService;
+  @Mock private CredentialedUser mockTestUser;
+  @Mock private ProjectLoader mockProjectLoader;
+  @Mock private ListenableFuture<List<Project>> mockFuture;
+
+  @Mock private JButton mockDialogButton;
+  @Mock private ProjectSelectionDialogWrapper dialogWrapper;
+
+  @Spy private ProjectSelectionDialog projectSelectionDialog;
+
+  @Before
+  public void setUp() throws Exception {
+    when(mockProjectLoader.loadUserProjectsInBackground(any())).thenReturn(mockFuture);
+
+    projectSelectionDialog.setProjectLoader(mockProjectLoader);
+    projectSelectionDialog.setDialogWrapper(dialogWrapper);
+    doReturn(mockDialogButton).when(projectSelectionDialog).getDialogButton(any());
+
+    projectSelectionDialog.createUIComponents();
+    projectSelectionDialog.loadUsersAndProjects();
+
+    testUiProject = CloudProject.create(TEST_PROJECT_NAME, TEST_USER_EMAIL);
+    testCloudProject = new Project();
+    testCloudProject.setName(TEST_PROJECT_NAME);
+    testCloudProject.setProjectId(TEST_PROJECT_NAME + "-id");
+
+    when(mockTestUser.getEmail()).thenReturn(TEST_USER_EMAIL);
+  }
+
+  @Test
+  public void starts_empty_signInScreen_noSelection() {
+    assertThat(projectSelectionDialog.getCenterPanelWrapper().getComponent(0))
+        .isInstanceOf(ProjectSelectorSignInPanel.class);
+
+    assertThat(projectSelectionDialog.getAccountComboBox().getSelectedItem()).isNull();
+    assertThat(projectSelectionDialog.getProjectListTable().getSelectedRow()).isLessThan(0);
+    assertThat(projectSelectionDialog.getProjectListTableModel().getRowCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void existingSignedInUser_signInScreen_notVisible() {
+    mockUserList(Collections.singletonList(mockTestUser));
+    projectSelectionDialog.loadUsersAndProjects();
+
+    assertThat(projectSelectionDialog.getCenterPanelWrapper().getComponent(0))
+        .isNotInstanceOf(ProjectSelectorSignInPanel.class);
+  }
+
+  @Test
+  public void nullProject_activeUser_selected_noProject_selected() {
+    prepareOneTestUserOneTestProjectDialog(null);
+
+    assertThat(projectSelectionDialog.getAccountComboBox().getSelectedItem())
+        .isEqualTo(mockTestUser);
+    assertThat(projectSelectionDialog.getProjectListTableModel().getRowCount()).isEqualTo(1);
+    assertThat(projectSelectionDialog.getProjectListTable().getSelectedRow()).isEqualTo(-1);
+  }
+
+  @Test
+  public void emptyCloudProject_activeUser_selected_noProject_selected() {
+    prepareOneTestUserOneTestProjectDialog(CloudProject.create("", ""));
+
+    assertThat(projectSelectionDialog.getAccountComboBox().getSelectedItem())
+        .isEqualTo(mockTestUser);
+    assertThat(projectSelectionDialog.getProjectListTableModel().getRowCount()).isEqualTo(1);
+    assertThat(projectSelectionDialog.getProjectListTable().getSelectedRow()).isEqualTo(-1);
+  }
+
+  @Test
+  public void setCloudProject_updatesUi() {
+    prepareOneTestUserOneTestProjectDialog(testUiProject);
+
+    assertThat(projectSelectionDialog.getAccountComboBox().getSelectedItem())
+        .isEqualTo(mockTestUser);
+    assertThat(projectSelectionDialog.getSelectedProjectName())
+        .isEqualTo(testCloudProject.getName());
+    assertThat(projectSelectionDialog.getProjectListTable().getSelectedRow()).isEqualTo(0);
+  }
+
+  @Test
+  public void addActiveAccount_noProjects_clearsProjectList()
+      throws InvocationTargetException, InterruptedException {
+    prepareOneTestUserOneTestProjectDialog(testUiProject);
+    String activeUserEmail = "active-test@google.com";
+    CredentialedUser mockAnotherUser = mock(CredentialedUser.class);
+    when(mockAnotherUser.getEmail()).thenReturn(activeUserEmail);
+    mockUserList(Arrays.asList(mockAnotherUser /* active */, mockTestUser));
+
+    SwingUtilities.invokeAndWait(() -> {
+      projectSelectionDialog.loadUsersAndProjects();
+    });
+
+    assertThat(projectSelectionDialog.getAccountComboBox().getSelectedItem())
+        .isEqualTo(mockAnotherUser);
+    assertThat(projectSelectionDialog.getProjectListTableModel().getRowCount()).isEqualTo(0);
+    assertThat(projectSelectionDialog.getProjectListTable().getSelectedRow()).isEqualTo(-1);
+  }
+
+  /**
+   * Prepares common test case with test user (active) and its one test project.
+   *
+   * @param selectedProject Project to set as selected for the dialog, may be null/empty.
+   */
+  private void prepareOneTestUserOneTestProjectDialog(CloudProject selectedProject) {
+    mockUserList(Collections.singletonList(mockTestUser));
+    mockUserProjects(Collections.singletonList(testCloudProject));
+
+    // wait until UI events are processed.
+    try {
+      SwingUtilities.invokeAndWait(() -> {
+        projectSelectionDialog.loadUsersAndProjects();
+        projectSelectionDialog.setCloudProject(selectedProject);
+      });
+      SwingUtilities.invokeAndWait(() -> {});
+    } catch (Exception ex) {
+      // this should not happen in the test.
+      throw new AssertionError(ex);
+    }
+  }
+
+  /** Mocks list of currently signed in users returned by login service. First user is active. */
+  private void mockUserList(List<CredentialedUser> userList) {
+    Map<String, CredentialedUser> emailUserMap =
+        userList
+            .stream()
+            .collect(Collectors.toMap(CredentialedUser::getEmail, Function.identity()));
+    when(googleLoginService.getAllUsers()).thenReturn(emailUserMap);
+    when(googleLoginService.getActiveUser()).thenReturn(userList.get(0));
+
+    for (CredentialedUser user : userList) {
+      when(googleLoginService.ensureLoggedIn(user.getEmail())).thenReturn(true);
+      when(googleLoginService.getLoggedInUser(user.getEmail())).thenReturn(Optional.of(user));
+    }
+  }
+
+  /** Mocks list of project returned for a user when selection dialog calls for it. */
+  private void mockUserProjects(List<Project> projectList) {
+    doAnswer(new Answer() {
+      @Override
+      @SuppressWarnings("unchecked")
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        ((FutureCallback<List<Project>>)invocation.getArgument(1)).onSuccess(projectList);
+        return null;
+      }
+    }).when(projectSelectionDialog).addProjectListFutureCallback(any(), any());
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
@@ -148,7 +148,7 @@ public class ProjectSelectionDialogTest {
 
     cleanLoadUsersAndProjects();
     projectSelectionDialog.showProjectInList(secondProject.getName());
-    CloudProject selectedProject = projectSelectionDialog.getCloudProject();
+    CloudProject selectedProject = projectSelectionDialog.getSelectedProject();
 
     CloudProject expected = CloudProject.create(secondProject.getName(), mockTestUser.getEmail());
     assertThat(selectedProject).isEqualTo(expected);
@@ -180,7 +180,7 @@ public class ProjectSelectionDialogTest {
     mockUserList(Collections.singletonList(mockTestUser));
     mockUserProjects(mockTestUser, Collections.singletonList(testGoogleProject));
     cleanLoadUsersAndProjects();
-    projectSelectionDialog.setCloudProject(selectedProject);
+    projectSelectionDialog.setSelectedProject(selectedProject);
   }
 
   /** Loads users and projects and ensures UI events are processed before returning. */

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
@@ -56,6 +56,7 @@ public class ProjectSelectionDialogTest {
 
   private static final String TEST_USER_EMAIL = "test@google.com";
   private static final String TEST_PROJECT_NAME = "test-1";
+  private static final String TEST_PROJECT_ID = "test-1-id";
 
   private CloudProject testUiProject;
   private Project testGoogleProject;
@@ -79,7 +80,7 @@ public class ProjectSelectionDialogTest {
     projectSelectionDialog.createUIComponents();
     projectSelectionDialog.loadAllProjects();
 
-    testUiProject = CloudProject.create(TEST_PROJECT_NAME, TEST_USER_EMAIL);
+    testUiProject = CloudProject.create(TEST_PROJECT_NAME, TEST_PROJECT_ID, TEST_USER_EMAIL);
     testGoogleProject = new Project();
     testGoogleProject.setName(TEST_PROJECT_NAME);
     testGoogleProject.setProjectId(TEST_PROJECT_NAME + "-id");
@@ -119,7 +120,7 @@ public class ProjectSelectionDialogTest {
 
   @Test
   public void emptyCloudProject_activeUser_noUiSelection() {
-    prepareOneTestUserOneTestProjectDialog(CloudProject.create("", ""));
+    prepareOneTestUserOneTestProjectDialog(CloudProject.create("", "", ""));
 
     assertThat(projectSelectionDialog.getAccountComboBox().getSelectedItem())
         .isEqualTo(mockTestUser);
@@ -135,6 +136,8 @@ public class ProjectSelectionDialogTest {
         .isEqualTo(mockTestUser);
     assertThat(projectSelectionDialog.getSelectedProjectName())
         .isEqualTo(testGoogleProject.getName());
+    assertThat(projectSelectionDialog.getSelectedProjectId())
+        .isEqualTo(testGoogleProject.getProjectId());
     assertThat(projectSelectionDialog.getProjectListTable().getSelectedRow()).isEqualTo(0);
   }
 
@@ -150,7 +153,9 @@ public class ProjectSelectionDialogTest {
     projectSelectionDialog.showProjectInList(secondProject.getName());
     CloudProject selectedProject = projectSelectionDialog.getSelectedProject();
 
-    CloudProject expected = CloudProject.create(secondProject.getName(), mockTestUser.getEmail());
+    CloudProject expected =
+        CloudProject.create(
+            secondProject.getName(), secondProject.getProjectId(), mockTestUser.getEmail());
     assertThat(selectedProject).isEqualTo(expected);
   }
 

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectorTest.java
@@ -38,7 +38,8 @@ public class ProjectSelectorTest {
   @Mock private ProjectSelectionListener projectSelectionListener;
   @Mock private ProjectSelectionDialog projectSelectionDialog;
 
-  private static final CloudProject TEST_PROJECT = CloudProject.create("test-1", "test@google.com");
+  private static final CloudProject TEST_PROJECT =
+      CloudProject.create("test-1", "test-1-id", "test@google.com");
 
   @Before
   public void setUp() {
@@ -71,8 +72,7 @@ public class ProjectSelectorTest {
 
     projectSelector.handleOpenProjectSelectionDialog();
 
-    assertThat(projectSelector.getSelectedProject())
-        .isEqualTo(TEST_PROJECT);
+    assertThat(projectSelector.getSelectedProject()).isEqualTo(TEST_PROJECT);
   }
 
   @Test
@@ -128,7 +128,7 @@ public class ProjectSelectorTest {
 
   @Test
   public void setEmptyProject_acceptsAndUpdatesUi() {
-    projectSelector.setSelectedProject(CloudProject.create("", ""));
+    projectSelector.setSelectedProject(CloudProject.create("", "", ""));
 
     verifyUiStateForProject(null);
   }
@@ -142,8 +142,7 @@ public class ProjectSelectorTest {
       assertThat(projectSelector.getAccountInfoLabel().getText()).isEmpty();
       assertThat(projectSelector.getAccountInfoLabel().getIcon()).isNull();
     } else {
-      assertThat(projectSelector.getProjectNameLabel().getText())
-          .isEqualTo(project.projectName());
+      assertThat(projectSelector.getProjectNameLabel().getText()).isEqualTo(project.projectName());
       assertThat(projectSelector.getProjectAccountSeparatorLabel().isVisible()).isTrue();
       assertThat(projectSelector.getAccountInfoLabel().getText())
           .isEqualTo(project.googleUsername());

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectorTest.java
@@ -136,7 +136,7 @@ public class ProjectSelectorTest {
   private void verifyUiStateForProject(CloudProject project) {
     if (project == null) {
       assertThat(projectSelector.getProjectNameLabel().getText())
-          .isEqualTo(GctBundle.getString("project.selector.no.selected.project"));
+          .isEqualTo(GctBundle.getString("cloud.project.selector.no.selected.project"));
       // no account information UI is visible/populated.
       assertThat(projectSelector.getProjectAccountSeparatorLabel().isVisible()).isFalse();
       assertThat(projectSelector.getAccountInfoLabel().getText()).isEmpty();


### PR DESCRIPTION
Final part of project selection change - dialog.
This looks like a large PR but it's actually not - at least 400 LOC are form XML/copyright headers/imports/visible for testing lines, and the rest cannot be split logically and should be straightforward to review.

You can review FilteredTextTableCellRenderer.java and ProjectListTableModelTest.java and their tests first - those are very small and independent, and continue with ProjectSelectionDialog.

Initial state - no logged in users:
![sign_in_screen](https://user-images.githubusercontent.com/11686100/33856504-532c2106-de96-11e7-9c6c-1bb1653d40fe.png)

Logged in users, no project selection:
![dialog](https://user-images.githubusercontent.com/11686100/33856331-cf7a1ad4-de95-11e7-9c69-803856bf18b9.png)

Filtered projects - both in our field and IDEA speed search on table (they are synced):
![dialog-filter](https://user-images.githubusercontent.com/11686100/33856452-31226eda-de96-11e7-83c4-f76bd863c027.png)



