### PR TITLE
Upgrade gradle-intellij-plugin to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.1.10'
         classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
         classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.6"
         classpath "net.ltgt.gradle:gradle-apt-plugin:0.13"
@@ -29,6 +28,7 @@ buildscript {
 
 plugins {
     id 'net.researchgate.release' version '2.3.4'
+    id "org.jetbrains.intellij" version "0.2.17" apply false
 }
 
 subprojects {

--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -26,13 +26,12 @@ intellij {
 
     pluginName = 'google-cloud-tools'
     plugins 'Groovy', 'gradle', 'git4idea', 'properties', 'junit', 'maven', 'yaml'
+}
 
-    publish {
-        pluginId '8079'
-        username System.getenv('IJ_REPO_USERNAME')
-        password System.getenv('IJ_REPO_PASSWORD')
-        channel ijPluginRepoChannel
-    }
+publishPlugin {
+    username System.getenv('IJ_REPO_USERNAME')
+    password System.getenv('IJ_REPO_PASSWORD')
+    channels ijPluginRepoChannel
 }
 
 project.afterEvaluate {


### PR DESCRIPTION
It just worked. They must have improved the multi-module support.

I had to also update the publish section since the old method is now deprecated.

TODOs

1) Test the plugin publish to make sure it still works
2) pluginId from the 'publish' section is now deprecated. Instead, the plugin id is pulled from the ID of plugin.xml. Does this mean we need to update the ID in the plugin.xml for the publish to work (and what are the effects of doing that)? 