### PR TITLE
Bump appengine-plugins-core to 0.4.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ intellijRepoUrl = https://storage.googleapis.com/cloud-tools-for-java-team-kokor
 javaVersion = 1.8
 ijPluginRepoChannel = alpha
 version = 17.12.2-SNAPSHOT
-toolsLibVersion = 0.3.9
+toolsLibVersion = 0.4.2


### PR DESCRIPTION
to pick up updates exposing new api metadata added to the models (https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/512)