### PR TITLE
remove old account plugin modules compiler config

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -17,8 +17,6 @@
       <module name="common-lib_test" target="1.8" />
       <module name="common-test-lib_main" target="1.8" />
       <module name="common-test-lib_test" target="1.8" />
-      <module name="google-account-plugin_main" target="1.8" />
-      <module name="google-account-plugin_test" target="1.8" />
       <module name="google-account_main" target="1.8" />
       <module name="google-account_test" target="1.8" />
       <module name="google-cloud-tools-plugin_main" target="1.8" />


### PR DESCRIPTION
not sure why only my os x workspace does this update, but it appears to be valid since those modules no longer exist.