### PR TITLE
Refactor immutable map collector

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.java
@@ -89,11 +89,9 @@ final class GoogleCloudApiSelectorPanel {
         libraries
             .stream()
             .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toMap(
-                        Function.identity(),
-                        lib -> new CloudApiManagementSpec(SHOULD_ENABLE_API_DEFAULT)),
-                    ImmutableMap::copyOf));
+                ImmutableMap.toImmutableMap(
+                    Function.identity(),
+                    lib -> new CloudApiManagementSpec(SHOULD_ENABLE_API_DEFAULT)));
 
     panel.setPreferredSize(new Dimension(800, 600));
   }


### PR DESCRIPTION
Simple code cleanup: guava has an immutable map collector so no need to make a copy.

Also fixes the following type inference issue in the IDE:
![image](https://user-images.githubusercontent.com/1735744/34616159-4fc66878-f205-11e7-8f63-eac1f16bf955.png)
