### PR TITLE
Moves project selection to the parent library selector panel

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -227,11 +227,14 @@ cloud.apis.enabled.title=APIs Enabled on GCP
 cloud.apis.enabled.message=<html><body>The following APIs were enabled on GCP project ''{0}'':<br>{1}</body></html>
 cloud.apis.enable.error.title=Error Enabling API on GCP
 cloud.apis.enable.error.message=<html><body>An error was encountered enabling the following APIs on GCP:<br>{0}</body></html>
+cloud.apis.enable.skipped.title=Enabling API on GCP Canceled
+cloud.apis.enable.skipped.message=<html><body>Enabling the following APIs on GCP was skipped:<br>{0}</body></html>
 cloud.apis.management.section.title=Google Cloud Platform API Management
 cloud.apis.management.section.info.text=Select the API and choose a GCP Project to enable APIs and manage service accounts
 cloud.apis.management.dialog.title=Enable GCP APIs and Update Service Accounts Confirmation
 cloud.apis.management.dialog.header=The following APIs will be enabled on Google Cloud Platform:
 cloud.apis.enable.progress.title=Enabling APIs on Google Cloud Platform
+cloud.apis.enable.progress.message=Enabling {0} on GCP project ''{1}''
 
 cloud.repository.dialog.project.label=Cloud Project:
 cloud.repository.dialog.repository.label=Cloud Repository:

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -228,8 +228,9 @@ cloud.apis.enabled.message=<html><body>The following APIs were enabled on GCP pr
 cloud.apis.enable.error.title=Error Enabling API on GCP
 cloud.apis.enable.error.message=<html><body>An error was encountered enabling the following APIs on GCP:<br>{0}</body></html>
 cloud.apis.management.section.title=Google Cloud Platform API Management
-cloud.apis.management.dialog.title=Enable APIs and Update Service Accounts
-cloud.apis.management.dialog.header=Select a cloud project to enable APIs on GCP and to create / update service account keys:
+cloud.apis.management.section.info.text=Select the API and choose a GCP Project to enable APIs and manage service accounts
+cloud.apis.management.dialog.title=Enable GCP APIs and Update Service Accounts Confirmation
+cloud.apis.management.dialog.header=The following APIs will be enabled on Google Cloud Platform:
 cloud.apis.enable.progress.title=Enabling APIs on Google Cloud Platform
 
 cloud.repository.dialog.project.label=Cloud Project:

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.form
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.cloud.tools.intellij.apis.CloudApiManagementDialog">
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.cloud.tools.intellij.apis.CloudApiManagementConfirmationDialog">
   <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
@@ -8,11 +8,6 @@
     <properties/>
     <border type="none"/>
     <children>
-      <nested-form id="14d75" form-file="com/google/cloud/tools/intellij/project/ProjectSelector.form" binding="projectSelector">
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </nested-form>
       <vspacer id="dad8a">
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
@@ -26,6 +21,22 @@
           <text resource-bundle="messages/CloudToolsBundle" key="cloud.apis.management.dialog.header"/>
         </properties>
       </component>
+      <scrollpane id="21d05">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="cf36d" class="javax.swing.JList" binding="apisToEnableList">
+            <constraints/>
+            <properties>
+              <enabled value="false"/>
+              <focusable value="true"/>
+            </properties>
+          </component>
+        </children>
+      </scrollpane>
     </children>
   </grid>
 </form>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.java
@@ -17,12 +17,14 @@
 package com.google.cloud.tools.intellij.apis;
 
 import com.google.cloud.tools.intellij.project.CloudProject;
-import com.google.cloud.tools.intellij.project.ProjectSelector;
 import com.google.cloud.tools.intellij.util.GctBundle;
-import com.google.common.annotations.VisibleForTesting;
+import com.google.cloud.tools.libraries.json.CloudLibrary;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
+import java.util.Set;
+import javax.swing.DefaultListModel;
 import javax.swing.JComponent;
+import javax.swing.JList;
 import javax.swing.JPanel;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,37 +32,30 @@ import org.jetbrains.annotations.Nullable;
  * Dialog confirming GCP API management actions such as API enablement. Allows selection of a {@link
  * CloudProject CloudProject} on which to perform the actions.
  */
-public class CloudApiManagementDialog extends DialogWrapper {
+public class CloudApiManagementConfirmationDialog extends DialogWrapper {
 
   private JPanel panel;
-  private ProjectSelector projectSelector;
+  private JList<String> apisToEnableList;
 
   /**
-   * Initializes the dialog and enables the OK button if a {@link CloudProject CloudProject} is
-   * selected and disables it otherwise.
+   * Initializes the Cloud API management confirmation dialog.
+   *
+   * @param project the current {@link Project}
+   * @param apisToEnable the set of APIs to be enabled on GCP
    */
-  CloudApiManagementDialog(@Nullable Project project) {
+  CloudApiManagementConfirmationDialog(@Nullable Project project, Set<CloudLibrary> apisToEnable) {
     super(project);
     init();
     setTitle(GctBundle.message("cloud.apis.management.dialog.title"));
 
-    setOKActionEnabled(getCloudProject() != null);
-    projectSelector.addProjectSelectionListener(cloudProject -> setOKActionEnabled(true));
-  }
-
-  @Nullable
-  CloudProject getCloudProject() {
-    return projectSelector.getSelectedProject();
+    DefaultListModel<String> apiListModel = new DefaultListModel<>();
+    apisToEnable.forEach(library -> apiListModel.addElement(library.getName()));
+    apisToEnableList.setModel(apiListModel);
   }
 
   @Nullable
   @Override
   protected JComponent createCenterPanel() {
     return panel;
-  }
-
-  @VisibleForTesting
-  public ProjectSelector getProjectSelector() {
-    return projectSelector;
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManager.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManager.java
@@ -64,7 +64,8 @@ class CloudApiManager {
    * the user of the success / failure of API enablement via messages on the event log.
    *
    * @param libraries the set of {@link CloudLibrary CloudLibraries} to enable on GCP
-   * @param cloudProject the {@link CloudProject CloudProject} on which to enable the APIs
+   * @param cloudProject the {@link CloudProject} on which to enable the APIs
+   * @param project the currently open IntelliJ {@link Project}
    */
   static void enableApis(Set<CloudLibrary> libraries, CloudProject cloudProject, Project project) {
     Optional<CredentialedUser> user =

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.form
@@ -112,7 +112,7 @@
           </component>
         </children>
       </grid>
-      <grid id="1821f" binding="apiManagementPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="1821f" binding="apiManagementPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -125,7 +125,7 @@
         <children>
           <component id="4c671" class="javax.swing.JCheckBox" binding="enableApiCheckbox" custom-create="true">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <enabled value="false"/>
@@ -134,14 +134,45 @@
           </component>
           <component id="b5e18" class="javax.swing.JLabel">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="3" use-parent-layout="false"/>
+              <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="3" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <icon value="general/information.png"/>
+              <icon value="general/help_small.png"/>
               <text value=""/>
               <toolTipText resource-bundle="messages/CloudToolsBundle" key="cloud.apis.enable.checkbox.tooltip.text"/>
             </properties>
           </component>
+          <grid id="3f210" binding="managementInfoPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <visible value="true"/>
+            </properties>
+            <border type="none"/>
+            <children>
+              <component id="b74c8" class="javax.swing.JTextPane" binding="managementInfoTextPane">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="50"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <font swing-font="Label.font"/>
+                </properties>
+              </component>
+              <component id="14d7d" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <icon value="general/information.png"/>
+                  <text value=""/>
+                </properties>
+              </component>
+            </children>
+          </grid>
         </children>
       </grid>
     </children>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.form
@@ -152,7 +152,7 @@
             </properties>
             <border type="none"/>
             <children>
-              <component id="b74c8" class="javax.swing.JTextPane" binding="managementInfoTextPane">
+              <component id="b74c8" class="javax.swing.JTextPane" binding="managementInfoTextPane" custom-create="true">
                 <constraints>
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="50"/>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.java
@@ -59,6 +59,8 @@ public final class GoogleCloudApiDetailsPanel {
   private JTextPane linksTextPane;
   private JPanel apiManagementPanel;
   private JCheckBox enableApiCheckbox;
+  private JPanel managementInfoPanel;
+  private JTextPane managementInfoTextPane;
 
   private CloudLibrary currentCloudLibrary;
   private CloudApiManagementSpec currentCloudApiManagementSpec;
@@ -93,6 +95,7 @@ public final class GoogleCloudApiDetailsPanel {
    * @param enabled whether to enable or disable the the management UI components
    */
   void setManagementUIEnabled(boolean enabled) {
+    managementInfoPanel.setVisible(!enabled);
     enableApiCheckbox.setEnabled(enabled);
   }
 
@@ -139,6 +142,15 @@ public final class GoogleCloudApiDetailsPanel {
   }
 
   /**
+   * Returns the {@link JPanel} containing the wording explaining how to enable the management
+   * controls.
+   */
+  @VisibleForTesting
+  JPanel getManagementInfoPanel() {
+    return managementInfoPanel;
+  }
+
+  /**
    * Initializes some UI components in this panel that require special set-up.
    *
    * <p>This is automatically called by the IDEA SDK and should not be directly invoked.
@@ -171,6 +183,9 @@ public final class GoogleCloudApiDetailsPanel {
     apiManagementPanel.setBorder(
         IdeBorderFactory.createTitledBorder(
             GctBundle.message("cloud.apis.management.section.title")));
+
+    managementInfoTextPane = new JTextPane();
+    managementInfoTextPane.setOpaque(false);
 
     enableApiCheckbox = new JCheckBox();
     enableApiCheckbox.addItemListener(
@@ -225,6 +240,7 @@ public final class GoogleCloudApiDetailsPanel {
     }
 
     enableApiCheckbox.setSelected(currentCloudApiManagementSpec.shouldEnable());
+    managementInfoTextPane.setText(GctBundle.message("cloud.apis.management.section.info.text"));
   }
 
   /**

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.form
@@ -41,7 +41,7 @@
           </nested-form>
         </children>
       </scrollpane>
-      <grid id="57a30" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="57a30" layout-manager="GridLayoutManager" row-count="1" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="10" right="0"/>
         <constraints border-constraint="North"/>
         <properties/>
@@ -55,12 +55,30 @@
               <text resource-bundle="messages/CloudToolsBundle" key="cloud.libraries.module.selector.label"/>
             </properties>
           </component>
+          <component id="8cb02" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="GCP Project:"/>
+            </properties>
+          </component>
           <component id="ec336" class="com.intellij.application.options.ModulesComboBox" binding="modulesComboBox" custom-create="true">
             <constraints>
               <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
+          <nested-form id="9c4a1" form-file="com/google/cloud/tools/intellij/project/ProjectSelector.form" binding="projectSelector" custom-create="true">
+            <constraints>
+              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </nested-form>
+          <hspacer id="c1d1d">
+            <constraints>
+              <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
         </children>
       </grid>
     </children>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.form
@@ -41,7 +41,7 @@
           </nested-form>
         </children>
       </scrollpane>
-      <grid id="57a30" layout-manager="GridLayoutManager" row-count="1" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="57a30" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="10" right="0"/>
         <constraints border-constraint="North"/>
         <properties/>
@@ -71,14 +71,9 @@
           </component>
           <nested-form id="9c4a1" form-file="com/google/cloud/tools/intellij/project/ProjectSelector.form" binding="projectSelector" custom-create="true">
             <constraints>
-              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </nested-form>
-          <hspacer id="c1d1d">
-            <constraints>
-              <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
         </children>
       </grid>
     </children>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.form
@@ -41,7 +41,7 @@
           </nested-form>
         </children>
       </scrollpane>
-      <grid id="57a30" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="57a30" layout-manager="GridLayoutManager" row-count="1" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="10" right="0"/>
         <constraints border-constraint="North"/>
         <properties/>
@@ -57,7 +57,7 @@
           </component>
           <component id="8cb02" class="javax.swing.JLabel">
             <constraints>
-              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="GCP Project:"/>
@@ -71,9 +71,14 @@
           </component>
           <nested-form id="9c4a1" form-file="com/google/cloud/tools/intellij/project/ProjectSelector.form" binding="projectSelector" custom-create="true">
             <constraints>
-              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
           </nested-form>
+          <hspacer id="77da2">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
         </children>
       </grid>
     </children>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.java
@@ -161,6 +161,12 @@ final class GoogleCloudApiSelectorPanel {
     return apiManagementMap;
   }
 
+  /** Returns the {@link ProjectSelector} in this panel. */
+  @VisibleForTesting
+  ProjectSelector getProjectSelector() {
+    return projectSelector;
+  }
+
   /**
    * Initializes some UI components in this panel that require special set-up.
    *

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.java
@@ -211,7 +211,9 @@ final class GoogleCloudApiSelectorPanel {
   private void updateManagementUI() {
     TableModel model = cloudLibrariesTable.getModel();
     boolean addLibrary =
-        (boolean) model.getValueAt(cloudLibrariesTable.getSelectedRow(), CLOUD_LIBRARY_SELECT_COL);
+        cloudLibrariesTable.getSelectedRow() != -1
+            && (boolean)
+                model.getValueAt(cloudLibrariesTable.getSelectedRow(), CLOUD_LIBRARY_SELECT_COL);
     detailsPanel.setManagementUIEnabled(addLibrary && projectSelector.getSelectedProject() != null);
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanel.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.intellij.apis;
 
+import com.google.cloud.tools.intellij.project.CloudProject;
+import com.google.cloud.tools.intellij.project.ProjectSelector;
 import com.google.cloud.tools.libraries.json.CloudLibrary;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -71,6 +73,7 @@ final class GoogleCloudApiSelectorPanel {
   private JTable cloudLibrariesTable;
   private JLabel modulesLabel;
   private ModulesComboBox modulesComboBox;
+  private ProjectSelector projectSelector;
 
   private final Map<CloudLibrary, CloudApiManagementSpec> apiManagementMap;
   private final List<CloudLibrary> libraries;
@@ -114,6 +117,10 @@ final class GoogleCloudApiSelectorPanel {
   /** Returns the set of selected {@link CloudLibrary CloudLibraries}. */
   Set<CloudLibrary> getSelectedLibraries() {
     return ((CloudLibraryTableModel) cloudLibrariesTable.getModel()).getSelectedLibraries();
+  }
+
+  CloudProject getCloudProject() {
+    return projectSelector.getSelectedProject();
   }
 
   Set<CloudLibrary> getApisToEnable() {
@@ -190,13 +197,16 @@ final class GoogleCloudApiSelectorPanel {
               }
             });
     cloudLibrariesTable.getModel().addTableModelListener(e -> updateManagementUI());
+
+    projectSelector = new ProjectSelector();
+    projectSelector.addProjectSelectionListener(cloudProject -> updateManagementUI());
   }
 
   private void updateManagementUI() {
     TableModel model = cloudLibrariesTable.getModel();
     boolean addLibrary =
         (boolean) model.getValueAt(cloudLibrariesTable.getSelectedRow(), CLOUD_LIBRARY_SELECT_COL);
-    detailsPanel.setManagementUIEnabled(addLibrary);
+    detailsPanel.setManagementUIEnabled(addLibrary && projectSelector.getSelectedProject() != null);
   }
 
   /** The custom {@link JBTable} for the table of supported Cloud libraries. */

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.intellij.apis;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.cloud.tools.intellij.project.CloudProject;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.TestFixture;
 import com.google.cloud.tools.intellij.testing.TestModule;
@@ -419,7 +420,6 @@ public final class GoogleCloudApiSelectorPanelTest {
     panel.getDetailsPanel().setCloudLibrary(library, panel.getApiManagementMap().get(library));
 
     assertThat(panel.getDetailsPanel().getEnableApiCheckbox().isEnabled()).isFalse();
-    assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isTrue();
   }
 
   @Test
@@ -434,9 +434,35 @@ public final class GoogleCloudApiSelectorPanelTest {
     panel.getDetailsPanel().setCloudLibrary(library, panel.getApiManagementMap().get(library));
 
     assertThat(panel.getDetailsPanel().getEnableApiCheckbox().isEnabled()).isTrue();
-    assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isFalse();
   }
 
+  @Test
+  public void getManagementInfoPanel_withProjectAndLibraryUnselected_isHidden() {
+    CloudLibrary library = LIBRARY_1.toCloudLibrary();
+
+    GoogleCloudApiSelectorPanel panel =
+        new GoogleCloudApiSelectorPanel(ImmutableList.of(library), testFixture.getProject());
+
+    panel.getDetailsPanel().setCloudLibrary(library, panel.getApiManagementMap().get(library));
+
+    assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isTrue();
+  }
+
+  @Test
+  public void getManagementInfoPanel_withProjectAndLibrarySelected_isVisible() {
+    CloudLibrary library = LIBRARY_1.toCloudLibrary();
+
+    GoogleCloudApiSelectorPanel panel =
+        new GoogleCloudApiSelectorPanel(ImmutableList.of(library), testFixture.getProject());
+
+    panel.getDetailsPanel().setCloudLibrary(library, panel.getApiManagementMap().get(library));
+    JTable table = panel.getCloudLibrariesTable();
+    checkCheckbox(table, 0);
+
+    panel.getProjectSelector().setSelectedProject(CloudProject.create("name", "id", "user"));
+
+    assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isFalse();
+  }
   /**
    * Forcibly checks the checkbox in the given {@link JTable} at the given row number.
    *

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.intellij.apis;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.tools.intellij.project.CloudProject;
+import com.google.cloud.tools.intellij.project.ProjectSelector;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.TestFixture;
 import com.google.cloud.tools.intellij.testing.TestModule;
@@ -411,7 +412,7 @@ public final class GoogleCloudApiSelectorPanelTest {
   }
 
   @Test
-  public void getEnableCheckbox_withLibraryUnselected_isDisabled() {
+  public void getManagementUI_withLibraryAndProjectUnselected_isDisabled() {
     CloudLibrary library = LIBRARY_1.toCloudLibrary();
 
     GoogleCloudApiSelectorPanel panel =
@@ -420,20 +421,29 @@ public final class GoogleCloudApiSelectorPanelTest {
     panel.getDetailsPanel().setCloudLibrary(library, panel.getApiManagementMap().get(library));
 
     assertThat(panel.getDetailsPanel().getEnableApiCheckbox().isEnabled()).isFalse();
+    assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isTrue();
   }
 
   @Test
-  public void getEnableCheckbox_withLibrarySelected_isEnabled() {
+  public void getManagementUI_withLibraryAndProjectSelected_isEnabled() {
     CloudLibrary library = LIBRARY_1.toCloudLibrary();
 
     GoogleCloudApiSelectorPanel panel =
         new GoogleCloudApiSelectorPanel(ImmutableList.of(library), testFixture.getProject());
     JTable table = panel.getCloudLibrariesTable();
-    checkCheckbox(table, 0);
 
+    checkCheckbox(table, 0);
     panel.getDetailsPanel().setCloudLibrary(library, panel.getApiManagementMap().get(library));
 
+    CloudProject cloudProject = CloudProject.create("name", "id", "user");
+    ProjectSelector projectSelector = panel.getProjectSelector();
+    projectSelector.setSelectedProject(cloudProject);
+    projectSelector
+        .getProjectSelectionListeners()
+        .forEach(listener -> listener.projectSelected(cloudProject));
+
     assertThat(panel.getDetailsPanel().getEnableApiCheckbox().isEnabled()).isTrue();
+    assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isFalse();
   }
 
   @Test
@@ -448,21 +458,6 @@ public final class GoogleCloudApiSelectorPanelTest {
     assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isTrue();
   }
 
-  @Test
-  public void getManagementInfoPanel_withProjectAndLibrarySelected_isHidden() {
-    CloudLibrary library = LIBRARY_1.toCloudLibrary();
-
-    GoogleCloudApiSelectorPanel panel =
-        new GoogleCloudApiSelectorPanel(ImmutableList.of(library), testFixture.getProject());
-
-    panel.getDetailsPanel().setCloudLibrary(library, panel.getApiManagementMap().get(library));
-    JTable table = panel.getCloudLibrariesTable();
-    checkCheckbox(table, 0);
-
-    panel.getProjectSelector().setSelectedProject(CloudProject.create("name", "id", "user"));
-
-    assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isFalse();
-  }
   /**
    * Forcibly checks the checkbox in the given {@link JTable} at the given row number.
    *

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
@@ -446,18 +446,6 @@ public final class GoogleCloudApiSelectorPanelTest {
     assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isFalse();
   }
 
-  @Test
-  public void getManagementInfoPanel_withProjectAndLibraryUnselected_isVisible() {
-    CloudLibrary library = LIBRARY_1.toCloudLibrary();
-
-    GoogleCloudApiSelectorPanel panel =
-        new GoogleCloudApiSelectorPanel(ImmutableList.of(library), testFixture.getProject());
-
-    panel.getDetailsPanel().setCloudLibrary(library, panel.getApiManagementMap().get(library));
-
-    assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isTrue();
-  }
-
   /**
    * Forcibly checks the checkbox in the given {@link JTable} at the given row number.
    *

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
@@ -437,7 +437,7 @@ public final class GoogleCloudApiSelectorPanelTest {
   }
 
   @Test
-  public void getManagementInfoPanel_withProjectAndLibraryUnselected_isHidden() {
+  public void getManagementInfoPanel_withProjectAndLibraryUnselected_isVisible() {
     CloudLibrary library = LIBRARY_1.toCloudLibrary();
 
     GoogleCloudApiSelectorPanel panel =
@@ -449,7 +449,7 @@ public final class GoogleCloudApiSelectorPanelTest {
   }
 
   @Test
-  public void getManagementInfoPanel_withProjectAndLibrarySelected_isVisible() {
+  public void getManagementInfoPanel_withProjectAndLibrarySelected_isHidden() {
     CloudLibrary library = LIBRARY_1.toCloudLibrary();
 
     GoogleCloudApiSelectorPanel panel =

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
@@ -419,6 +419,7 @@ public final class GoogleCloudApiSelectorPanelTest {
     panel.getDetailsPanel().setCloudLibrary(library, panel.getApiManagementMap().get(library));
 
     assertThat(panel.getDetailsPanel().getEnableApiCheckbox().isEnabled()).isFalse();
+    assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isTrue();
   }
 
   @Test
@@ -433,6 +434,7 @@ public final class GoogleCloudApiSelectorPanelTest {
     panel.getDetailsPanel().setCloudLibrary(library, panel.getApiManagementMap().get(library));
 
     assertThat(panel.getDetailsPanel().getEnableApiCheckbox().isEnabled()).isTrue();
+    assertThat(panel.getDetailsPanel().getManagementInfoPanel().isVisible()).isFalse();
   }
 
   /**


### PR DESCRIPTION
In support of service account work I'm doing (#1808)

**What does this PR do?**
- Moves the project selector out of the popup dialog as implemented in https://github.com/GoogleCloudPlatform/google-cloud-intellij/pull/1802 and into the parent client library panel
- Repurposes the popup dialog into a confirmation dialog - confirming the GCP API changes about to be made on the user's project

**Why?**

I realized to support service accounts as I intended, we need to know the target cloud project earlier. I intend to add service account features into the right details panel (see the 2nd screenshot below) and these require knowledge of the cloud project.

**Screenshots**

library not selected and cloud project not chosen:
![image](https://user-images.githubusercontent.com/1735744/34625778-fe6f17f4-f227-11e7-8399-635c768ccd73.png)

selections made:
![image](https://user-images.githubusercontent.com/1735744/34625874-61c73c3c-f228-11e7-9ad3-e0da17a58169.png)

After clicking 'OK' on the library selection panel, with APIs to enable on GCP:
![image](https://user-images.githubusercontent.com/1735744/34625815-29cff06c-f228-11e7-8d1b-763911e1340b.png)
  