### PR TITLE
Disallow hiding account hyperlink for ProjectSelector.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
@@ -30,6 +30,7 @@ import java.awt.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import javax.swing.BoxLayout;
 import javax.swing.Icon;
 import javax.swing.JPanel;
 import javax.swing.UIManager;
@@ -151,6 +152,7 @@ public class ProjectSelector extends JPanel {
 
     hyperlinksPanel = new JPanel();
     hyperlinksPanel.setBorder(UIManager.getBorder("TextField.border"));
+    hyperlinksPanel.setLayout(new BoxLayout(hyperlinksPanel, BoxLayout.X_AXIS));
 
     browseButton = new FixedSizeButton(hyperlinksPanel);
     browseButton.addActionListener((actionEvent) -> handleOpenProjectSelectionDialog());


### PR DESCRIPTION
Fixes #1831.

Seems like this issue only reproduces on Mac.
Replaced FlowLayout with horizontal BoxLayout to avoid wrapping components to the next row if there is no enough space.
This layout is not supported by GUI designer so the change is in `createUIComponents()`.

@nbashirbello for some reason I am not able to add you to reviewers, can you please add yourself or maybe @etanshaul can take a look why the reviewers list is so short?