### PR TITLE
Disable leaked test projects check Gradle way.

### DIFF
--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -102,7 +102,7 @@ artifacts {
 }
 
 test {
-    systemProperty "idea.log.leaked.projects.in.tests", System.getProperty("idea.log.leaked.projects.in.tests")
+    // systemProperty "idea.log.leaked.projects.in.tests", System.getProperty("idea.log.leaked.projects.in.tests")
 
     testLogging {
         events "skipped", "failed"

--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -102,6 +102,8 @@ artifacts {
 }
 
 test {
+    systemProperty "idea.log.leaked.projects.in.tests", System.getProperty("idea.log.leaked.projects.in.tests")
+
     testLogging {
         events "skipped", "failed"
         exceptionFormat "full"

--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -102,7 +102,7 @@ artifacts {
 }
 
 test {
-    // systemProperty "idea.log.leaked.projects.in.tests", System.getProperty("idea.log.leaked.projects.in.tests")
+    systemProperty "idea.log.leaked.projects.in.tests", System.getProperty("idea.log.leaked.projects.in.tests")
 
     testLogging {
         events "skipped", "failed"


### PR DESCRIPTION
Seems for some reason Gradle test runner loads classes before the system property is passed to VM. 

Looks like we need to explicitly specify the property before the test target runs.

Testing: do not review yet.