### PR TITLE
Fix for 'Region' field in deploy config dialog not auto-populating when dialog is opened

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineApplicationInfoPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineApplicationInfoPanel.java
@@ -68,7 +68,7 @@ public class AppEngineApplicationInfoPanel extends JPanel {
   @SuppressWarnings("FutureReturnValueIgnored")
   public void refresh(final String projectId, final Credential credential) {
     ApplicationManager.getApplication()
-        .executeOnPooledThread(
+        .invokeLater(
             () -> {
               if (projectId.isEmpty()) {
                 clearMessage();


### PR DESCRIPTION
When a GCP project has been previously selected, it is automatically filled in the deployment configuration dialog when the dialog is reopened, however the region field was empty. The region field now shows the value when dialog is opened.

Fixes #1686