### PR TITLE
Exclude version of protobuf incompatible with error feedback code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release notes
 This page documents production updates to Cloud Tools for IntelliJ. You can check this page for announcements about new or updated features, bug fixes, known issues, and deprecated functionality.
 
+## 18.1.1
+
+### Fixed
+  - Fixed broken error reporting mechanism. [1842](https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/1842)
+
 ## 17.12.2
 
 ### Fixed

--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -62,6 +62,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.google.oauth-client', module: 'google-oauth-client'
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
+        exclude group: 'com.google.protobuf', module: 'protobuf-java-util'
     }
     compile ('com.google.cloud.tools:appengine-plugins-core:' + toolsLibVersion) {
         exclude group: 'com.google.guava', module: 'guava'

--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -61,6 +61,7 @@ dependencies {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.google.oauth-client', module: 'google-oauth-client'
+        exclude group: 'com.google.protobuf', module: 'protobuf-java'
     }
     compile ('com.google.cloud.tools:appengine-plugins-core:' + toolsLibVersion) {
         exclude group: 'com.google.guava', module: 'guava'

--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -45,6 +45,13 @@
       </p>
       <br/>
 
+      <h2>[18.1.1]</h2>
+
+      <h3>Fixed</h3>
+      <ul>
+        <li>Fixed broken error reporting mechanism. (<a href="https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/1842">#1842</a>)</li>
+      </ul>
+
       <h2>[17.12.2]</h2>
 
       <h3>Fixed</h3>


### PR DESCRIPTION
Do not merge.

This is for a patch release. Branched off of tag 17.2.2 (last release tag).