### PR TITLE
ProjectSelector prompts to login if no users are logged in.

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -417,6 +417,7 @@ account.plugin.removal.requires.restart.text=The Google Account plugin is no lon
 cloud.project.selector.signin.message=Sign in with your Google account to list your Google Developers Console projects.
 cloud.project.selector.open.dialog.tooltip=Opens a dialog to select a Google Cloud project
 cloud.project.selector.no.selected.project=Select a Google Cloud project
+cloud.project.selector.not.signed.in=Sign in with your Google account
 cloud.project.selector.dialog.title=Select Google Cloud Project
 cloud.project.selector.project.list.project.name.column=Project Name
 cloud.project.selector.project.list.project.id.column=Project ID

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.form
@@ -34,7 +34,7 @@
               <component id="6cf34" class="com.intellij.ui.components.JBLabel" binding="projectAccountSeparatorLabel" custom-create="true">
                 <constraints>
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-                  <gridbag weightx="0.0" weighty="0.0"/>
+                  <gridbag weightx="0.0" weighty="0.0" ipadx="2"/>
                 </constraints>
                 <properties>
                   <text value="/"/>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
@@ -127,8 +127,12 @@ public class ProjectSelector extends JPanel {
             .map(p -> ActiveCloudProjectManager.getInstance().getActiveCloudProject(p));
     projectOptional.ifPresent(
         activeCloudProject -> {
-          setSelectedProject(activeCloudProject);
-          notifyProjectSelectionListeners();
+          // do not preset and notify on active project if not signed in to avoid misleading client
+          // code to assume project selection is made with an active account.
+          if (Services.getLoginService().isLoggedIn()) {
+            setSelectedProject(activeCloudProject);
+            notifyProjectSelectionListeners();
+          }
         });
   }
 


### PR DESCRIPTION
Fixes #1876.
Fixes #1875.

When no users are signed in, project selector will show prompt to sign in instead of account name and generic icon. This prompt leads directly to account sign in page. Once signed in, project selector behavior changes to default.

![projectselector-sign-in](https://user-images.githubusercontent.com/11686100/35646904-c661634a-069e-11e8-96e2-c20231afb3df.png)
