### PR TITLE
Add validation and default values to service account management form

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -245,6 +245,9 @@ cloud.apis.management.dialog.serviceaccount.downloadpath.label=Download path:
 cloud.apis.management.dialog.serviceaccount.select.roles.label=Select the roles to add to the service account:
 cloud.apis.management.dialog.serviceaccount.checkbox.text=Create a new service account and download the key
 cloud.apis.management.dialog.serviceaccount.download.warning.text=Keep the key secure and do not check it into source control
+cloud.apis.management.dialog.serviceaccount.key.browser.title=Select Folder to Download Service Account Key
+cloud.apis.management.dialog.serviceaccount.name.error=Enter a name for the service account
+cloud.apis.management.dialog.serviceaccount.key.path.error=Select a download location for the service account key
 
 cloud.apis.enable.progress.title=Enabling APIs on Google Cloud Platform
 cloud.apis.enable.progress.message=Enabling {0} on GCP project ''{1}''

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -247,7 +247,8 @@ cloud.apis.management.dialog.serviceaccount.checkbox.text=Create a new service a
 cloud.apis.management.dialog.serviceaccount.download.warning.text=Keep the key secure and do not check it into source control
 cloud.apis.management.dialog.serviceaccount.key.browser.title=Select Folder to Download Service Account Key
 cloud.apis.management.dialog.serviceaccount.name.error=Enter a name for the service account
-cloud.apis.management.dialog.serviceaccount.key.path.error=Select a download location for the service account key
+cloud.apis.management.dialog.serviceaccount.key.path.empty.error=Select a download location for the service account key
+cloud.apis.management.dialog.serviceaccount.key.path.invalid.error=The service service account key path entered is not a valid directory
 
 cloud.apis.enable.progress.title=Enabling APIs on Google Cloud Platform
 cloud.apis.enable.progress.message=Enabling {0} on GCP project ''{1}''

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.form
@@ -257,13 +257,13 @@
                           <text resource-bundle="messages/CloudToolsBundle" key="cloud.apis.management.dialog.serviceaccount.downloadpath.label"/>
                         </properties>
                       </component>
-                      <component id="a30c6" class="com.intellij.openapi.ui.TextFieldWithBrowseButton">
+                      <component id="a30c6" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="serviceKeyPathSelector">
                         <constraints>
                           <grid row="1" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties/>
                       </component>
-                      <component id="55898" class="javax.swing.JTextField" default-binding="true">
+                      <component id="55898" class="javax.swing.JTextField" binding="serviceAccountNameTextField">
                         <constraints>
                           <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                             <preferred-size width="150" height="-1"/>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.java
@@ -160,10 +160,13 @@ public class CloudApiManagementConfirmationDialog extends DialogWrapper {
         return new ValidationInfo(
             GctBundle.message("cloud.apis.management.dialog.serviceaccount.name.error"),
             serviceAccountNameTextField);
-      } else if (StringUtils.isEmpty(serviceKeyPathSelector.getText())
-          || !isValidDirectory(serviceKeyPathSelector.getText())) {
+      } else if (StringUtils.isEmpty(serviceKeyPathSelector.getText())) {
         return new ValidationInfo(
-            GctBundle.message("cloud.apis.management.dialog.serviceaccount.key.path.error"),
+            GctBundle.message("cloud.apis.management.dialog.serviceaccount.key.path.empty.error"),
+            serviceKeyPathSelector);
+      } else if (!isValidDirectory(serviceKeyPathSelector.getText())) {
+        return new ValidationInfo(
+            GctBundle.message("cloud.apis.management.dialog.serviceaccount.key.path.invalid.error"),
             serviceKeyPathSelector);
       }
     }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.java
@@ -39,6 +39,7 @@ import com.intellij.util.ui.UIUtil;
 import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.event.ActionListener;
+import java.io.File;
 import java.util.Comparator;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -159,7 +160,8 @@ public class CloudApiManagementConfirmationDialog extends DialogWrapper {
         return new ValidationInfo(
             GctBundle.message("cloud.apis.management.dialog.serviceaccount.name.error"),
             serviceAccountNameTextField);
-      } else if (StringUtils.isEmpty(serviceKeyPathSelector.getText())) {
+      } else if (StringUtils.isEmpty(serviceKeyPathSelector.getText())
+          || !isValidDirectory(serviceKeyPathSelector.getText())) {
         return new ValidationInfo(
             GctBundle.message("cloud.apis.management.dialog.serviceaccount.key.path.error"),
             serviceKeyPathSelector);
@@ -191,6 +193,11 @@ public class CloudApiManagementConfirmationDialog extends DialogWrapper {
 
   private void createUIComponents() {
     roleTable = new ServiceAccountRolesTable(roles);
+  }
+
+  private static boolean isValidDirectory(String path) {
+    File file = new File(path);
+    return file.exists() && file.isDirectory() && file.canWrite();
   }
 
   private static final class ServiceAccountRolesTable extends JBTable {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialog.java
@@ -145,7 +145,7 @@ public class CloudApiManagementConfirmationDialog extends DialogWrapper {
         null /*description*/,
         null /*project - null on purpose so that the path isn't defaulted to the project root*/,
         FileChooserDescriptorFactory.createSingleFolderDescriptor());
-    serviceKeyPathSelector.setText(getServiceKeyPathSelectorDefaultText());
+    serviceKeyPathSelector.setText(getDefaultServiceKeyPath());
   }
 
   Set<Role> getSelectedRoles() {
@@ -183,7 +183,7 @@ public class CloudApiManagementConfirmationDialog extends DialogWrapper {
     return e -> serviceAccountDetailsPane.setVisible(((JCheckBox) e.getSource()).isSelected());
   }
 
-  private String getServiceKeyPathSelectorDefaultText() {
+  private String getDefaultServiceKeyPath() {
     VirtualFile homeVirtualFile = VfsUtil.getUserHomeDir();
     return homeVirtualFile == null ? "" : homeVirtualFile.getPath();
   }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialogTest.java
@@ -166,4 +166,71 @@ public class CloudApiManagementConfirmationDialogTest {
               assertThat(dialog.getSelectedRoles()).containsExactlyElementsIn(roles);
             });
   }
+
+  @Test
+  public void serviceAccount_whenServiceAccountNameEmpty_showsValidationError() {
+    ApplicationManager.getApplication()
+        .invokeAndWait(
+            () -> {
+              CloudApiManagementConfirmationDialog dialog =
+                  new CloudApiManagementConfirmationDialog(
+                      module,
+                      cloudProject,
+                      ImmutableSet.of(),
+                      ImmutableSet.of(),
+                      ImmutableSet.of());
+
+              dialog.getServiceAccountNameTextField().setText("");
+              dialog.getServiceKeyPathSelector().setText("/some/path");
+
+              assertThat(dialog.doValidate()).isNotNull();
+              assertThat(dialog.doValidate().component)
+                  .isEqualTo(dialog.getServiceAccountNameTextField());
+            });
+  }
+
+  @Test
+  public void serviceAccount_whenServiceKeyPathEmpty_showsValidationError() {
+    ApplicationManager.getApplication()
+        .invokeAndWait(
+            () -> {
+              CloudApiManagementConfirmationDialog dialog =
+                  new CloudApiManagementConfirmationDialog(
+                      module,
+                      cloudProject,
+                      ImmutableSet.of(),
+                      ImmutableSet.of(),
+                      ImmutableSet.of());
+
+              dialog.getServiceKeyPathSelector().setText("");
+              dialog.getServiceAccountNameTextField().setText("my-name");
+
+              assertThat(dialog.doValidate()).isNotNull();
+              assertThat(dialog.doValidate().component)
+                  .isEqualTo(dialog.getServiceKeyPathSelector());
+            });
+  }
+
+  @Test
+  public void
+      serviceAccount_whenCreateServiceAccountUnchecked_andFieldsEmpty_showsNoValidationError() {
+    ApplicationManager.getApplication()
+        .invokeAndWait(
+            () -> {
+              CloudApiManagementConfirmationDialog dialog =
+                  new CloudApiManagementConfirmationDialog(
+                      module,
+                      cloudProject,
+                      ImmutableSet.of(),
+                      ImmutableSet.of(),
+                      ImmutableSet.of());
+
+              dialog.getNewServiceAccountCheckbox().setSelected(false);
+
+              dialog.getServiceKeyPathSelector().setText("");
+              dialog.getServiceAccountNameTextField().setText("");
+
+              assertThat(dialog.doValidate()).isNull();
+            });
+  }
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialogTest.java
@@ -22,7 +22,6 @@ import com.google.api.services.iam.v1.model.Role;
 import com.google.cloud.tools.intellij.project.CloudProject;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.TestDirectory;
-import com.google.cloud.tools.intellij.testing.TestFile;
 import com.google.cloud.tools.intellij.testing.TestFixture;
 import com.google.cloud.tools.intellij.testing.TestModule;
 import com.google.cloud.tools.intellij.testing.apis.TestCloudLibrary;

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/CloudApiManagementConfirmationDialogTest.java
@@ -21,6 +21,8 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.api.services.iam.v1.model.Role;
 import com.google.cloud.tools.intellij.project.CloudProject;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
+import com.google.cloud.tools.intellij.testing.TestDirectory;
+import com.google.cloud.tools.intellij.testing.TestFile;
 import com.google.cloud.tools.intellij.testing.TestFixture;
 import com.google.cloud.tools.intellij.testing.TestModule;
 import com.google.cloud.tools.intellij.testing.apis.TestCloudLibrary;
@@ -29,6 +31,7 @@ import com.google.common.collect.ImmutableSet;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
+import java.io.File;
 import java.util.Set;
 import javax.swing.table.TableModel;
 import org.junit.Rule;
@@ -40,6 +43,9 @@ public class CloudApiManagementConfirmationDialogTest {
   @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
   @TestFixture private IdeaProjectTestFixture testFixture;
   @TestModule private Module module;
+
+  @TestDirectory(name = "testDir")
+  private File testDir;
 
   private static final CloudProject cloudProject = CloudProject.create("name", "id", "user");
 
@@ -168,6 +174,26 @@ public class CloudApiManagementConfirmationDialogTest {
   }
 
   @Test
+  public void serviceAccount_whenFieldsCorrectlyPopulated_showsNoValidationError() {
+    ApplicationManager.getApplication()
+        .invokeAndWait(
+            () -> {
+              CloudApiManagementConfirmationDialog dialog =
+                  new CloudApiManagementConfirmationDialog(
+                      module,
+                      cloudProject,
+                      ImmutableSet.of(),
+                      ImmutableSet.of(),
+                      ImmutableSet.of());
+
+              dialog.getServiceAccountNameTextField().setText("my-name");
+              dialog.getServiceKeyPathSelector().setText(testDir.getPath());
+
+              assertThat(dialog.doValidate()).isNull();
+            });
+  }
+
+  @Test
   public void serviceAccount_whenServiceAccountNameEmpty_showsValidationError() {
     ApplicationManager.getApplication()
         .invokeAndWait(
@@ -231,6 +257,26 @@ public class CloudApiManagementConfirmationDialogTest {
               dialog.getServiceAccountNameTextField().setText("");
 
               assertThat(dialog.doValidate()).isNull();
+            });
+  }
+
+  @Test
+  public void serviceAccount_whenKeyDownloadPathInvalid_showsValidationError() {
+    ApplicationManager.getApplication()
+        .invokeAndWait(
+            () -> {
+              CloudApiManagementConfirmationDialog dialog =
+                  new CloudApiManagementConfirmationDialog(
+                      module,
+                      cloudProject,
+                      ImmutableSet.of(),
+                      ImmutableSet.of(),
+                      ImmutableSet.of());
+
+              dialog.getServiceKeyPathSelector().setText("/some/invalid/path");
+              dialog.getServiceAccountNameTextField().setText("my-name");
+
+              assertThat(dialog.doValidate()).isNotNull();
             });
   }
 }


### PR DESCRIPTION
- Add validation on the service account name and download path fields. Uses the built in dialog wrapper validation mechanism. When first opening the dialog, if in an error state, then the message is not shown until clicking "ok'
![image](https://user-images.githubusercontent.com/1735744/35885534-2ac3ed28-0b5c-11e8-84f1-8c37211fb080.png)
![image](https://user-images.githubusercontent.com/1735744/35885548-35f1e3bc-0b5c-11e8-9196-2bfd354f9fbe.png)

- defaults the service account name to the name of the module:
![image](https://user-images.githubusercontent.com/1735744/35885625-6eedf282-0b5c-11e8-865c-af3f9b4f6a25.png)

- attempts to default the download path to the user's home directory; if this fails, it will leave it empty (and the above validation will warn the user) 