### PR TITLE
update gradle run IDE task

### DIFF
--- a/.idea/runConfigurations/Cloud_Tools_on_IntelliJ.xml
+++ b/.idea/runConfigurations/Cloud_Tools_on_IntelliJ.xml
@@ -10,7 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="runIdea" />
+          <option value="runIde" />
         </list>
       </option>
       <option name="vmOptions" value="" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Other useful targets while developing include:
 * $ ./gradlew test: run tests
 * $ ./gradlew check: run static analysis tools
 * $ ./gradlew clean: remove all build artifacts
-* $ ./gradlew runIdea: run IntelliJ preconfigured with the plugins from this project.
+* $ ./gradlew runIde: run IntelliJ preconfigured with the plugins from this project.
 
 ## Configuring and Debugging in IntelliJ
 


### PR DESCRIPTION
just noticed that the intellij gradle plugin was complaining that runIdea has been deprecated for runIde.

@etanshaul 
@nbashirbello 