### PR TITLE
Fix google java format intellij settings

### DIFF
--- a/.idea/google-java-format.xml
+++ b/.idea/google-java-format.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="GoogleJavaFormatSettings">
-    <option name="state" value="ENABLED" />
+    <option name="enabled" value="true" />
   </component>
 </project>


### PR DESCRIPTION
This was changed in #1908. The result was that the google-java-format plugin was disabled in my IDE. I wonder if this is a difference between versions of intellij?