### PR TITLE
Use application wide message bus for project selector.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
@@ -29,7 +29,7 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.ValidationInfo;
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;
@@ -122,17 +121,12 @@ public class ProjectSelectionDialog {
       installTableSpeedSearch(projectListTable);
       installProgressBar(dialogWrapper);
 
-      Stream.of(ProjectManager.getInstance().getOpenProjects())
-          .forEach(
-              project ->
-                  project
-                      .getMessageBus()
-                      .connect(dialogWrapper.getDisposable() /* disconnect once dialog is gone. */)
-                      .subscribe(
-                          GoogleLoginListener.GOOGLE_LOGIN_LISTENER_TOPIC,
-                          () -> {
-                            refreshDialog(Services.getLoginService().getActiveUser());
-                          }));
+      ApplicationManager.getApplication()
+          .getMessageBus()
+          .connect(dialogWrapper.getDisposable())
+          .subscribe(
+              GoogleLoginListener.GOOGLE_LOGIN_LISTENER_TOPIC,
+              () -> refreshDialog(Services.getLoginService().getActiveUser()));
     }
 
     loadAllProjects();

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
@@ -26,7 +26,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.ui.FixedSizeButton;
 import com.intellij.ui.HyperlinkLabel;
 import com.intellij.ui.components.JBLabel;
@@ -35,9 +34,6 @@ import java.awt.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.swing.Icon;
 import javax.swing.JPanel;
 import javax.swing.UIManager;
@@ -73,7 +69,7 @@ public class ProjectSelector extends JPanel {
   private Project ideProject;
 
   @VisibleForTesting GoogleLoginListener googleLoginListener;
-  private Set<MessageBusConnection> messageBusConnections;
+  private MessageBusConnection messageBusConnection;
 
   /** @param ideProject IDE {@link Project} to be used to update active cloud project settings. */
   public ProjectSelector(@Nullable Project ideProject) {
@@ -91,14 +87,9 @@ public class ProjectSelector extends JPanel {
                     });
           }
         };
-    messageBusConnections =
-        Stream.of(ProjectManager.getInstance().getOpenProjects())
-            .map(p -> p.getMessageBus().connect())
-            .collect(Collectors.toSet());
-    messageBusConnections.forEach(
-        connection ->
-            connection.subscribe(
-                GoogleLoginListener.GOOGLE_LOGIN_LISTENER_TOPIC, googleLoginListener));
+    messageBusConnection = ApplicationManager.getApplication().getMessageBus().connect();
+    messageBusConnection.subscribe(
+        GoogleLoginListener.GOOGLE_LOGIN_LISTENER_TOPIC, googleLoginListener);
   }
 
   /** Returns project selection or null if no project is selected. */
@@ -167,8 +158,7 @@ public class ProjectSelector extends JPanel {
   @Override
   public void removeNotify() {
     super.removeNotify();
-    messageBusConnections.forEach(MessageBusConnection::disconnect);
-    messageBusConnections.clear();
+    messageBusConnection.disconnect();
   }
 
   private void createUIComponents() {


### PR DESCRIPTION
Fixes #1904.

Project selection components now listen to application wide login events instead of set of open projects (which caused event not to be delivered in case of no open projects).