### PR TITLE
Make sure validation message in project selection in case of an error is not null.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelectionDialog.java
@@ -205,8 +205,12 @@ public class ProjectSelectionDialog {
               SwingUtilities.invokeLater(
                   () -> {
                     runningProjectLoaderJobs.remove(user);
+                    // validation message should not be null, use exception name if needed.
+                    String errorMessage =
+                        Optional.ofNullable(throwable.getMessage())
+                            .orElse(throwable.getClass().getName());
                     dialogWrapper.setErrorInfoAll(
-                        Collections.singletonList(new ValidationInfo(throwable.getMessage())));
+                        Collections.singletonList(new ValidationInfo(errorMessage)));
                     refreshProjectListUi(user);
                   });
             }


### PR DESCRIPTION
Fixes #1934.
A user had project loading error without additional error message which caused NPE in validation code. Proposed change is use exception name in this case.