### PR TITLE
Don't bring in Groovy for community

### DIFF
--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -23,9 +23,8 @@ sourceSets.test.resources.srcDirs = ['testResources', 'testData']
 apply plugin: 'org.jetbrains.intellij'
 
 intellij {
-
     pluginName = 'google-cloud-tools'
-    plugins 'Groovy', 'gradle', 'git4idea', 'properties', 'junit', 'maven', 'yaml'
+    plugins 'gradle', 'git4idea', 'properties', 'junit', 'maven', 'yaml'
 }
 
 publishPlugin {


### PR DESCRIPTION
Fixes #1933 

It looks like this isn't needed. The plugin runs fine in CE and the groovy jars are brought in still (transitively I assume):

<img width="440" alt="screen shot 2018-03-05 at 1 07 13 pm" src="https://user-images.githubusercontent.com/1735744/36991590-264412f8-2076-11e8-893d-0069ade77c77.png">
