### PR TITLE
Cloud SDK service management

### DIFF
--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -390,8 +390,8 @@
     <applicationService serviceInterface="com.google.cloud.tools.intellij.service.ApplicationPluginInfoService"
                         serviceImplementation="com.google.cloud.tools.intellij.service.DefaultApplicationPluginInfoService"/>
 
-    <applicationService serviceInterface="com.google.cloud.tools.intellij.appengine.sdk.CloudSdkService"
-                        serviceImplementation="com.google.cloud.tools.intellij.appengine.sdk.DefaultCloudSdkService"/>
+    <applicationService serviceImplementation="com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceManager"/>
+
     <applicationService serviceImplementation="com.google.cloud.tools.intellij.appengine.sdk.CloudSdkValidator"/>
 
     <applicationService serviceInterface="com.google.cloud.tools.intellij.appengine.facet.standard.AppEngineStandardWebIntegration"

--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -391,7 +391,8 @@
                         serviceImplementation="com.google.cloud.tools.intellij.service.DefaultApplicationPluginInfoService"/>
 
     <applicationService serviceImplementation="com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceManager"/>
-
+    <applicationService serviceInterface="com.google.cloud.tools.intellij.appengine.sdk.CloudSdkService"
+                        serviceImplementation="com.google.cloud.tools.intellij.appengine.sdk.DefaultCloudSdkService"/>
     <applicationService serviceImplementation="com.google.cloud.tools.intellij.appengine.sdk.CloudSdkValidator"/>
 
     <applicationService serviceInterface="com.google.cloud.tools.intellij.appengine.facet.standard.AppEngineStandardWebIntegration"

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleSupportProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/flexible/AppEngineFlexibleSupportProvider.java
@@ -26,6 +26,7 @@ import com.google.cloud.tools.intellij.appengine.project.AppEngineProjectService
 import com.google.cloud.tools.intellij.appengine.project.AppEngineProjectService.FlexibleRuntime;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkPanel;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkService;
+import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceUserSettings;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkValidationResult;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkValidator;
 import com.google.common.annotations.VisibleForTesting;
@@ -201,7 +202,8 @@ public class AppEngineFlexibleSupportProvider extends FrameworkSupportInModulePr
       if (!sdkValidator
           .validateCloudSdk(cloudSdkPanel.getCloudSdkDirectoryText())
           .contains(CloudSdkValidationResult.MALFORMED_PATH)) {
-        sdkService.setSdkHomePath(cloudSdkPanel.getCloudSdkDirectoryText());
+        CloudSdkServiceUserSettings.getInstance()
+            .setCustomSdkPath(cloudSdkPanel.getCloudSdkDirectoryText());
       }
     }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/standard/AppEngineStandardSupportProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/facet/standard/AppEngineStandardSupportProvider.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.intellij.analytics.UsageTrackerProvider;
 import com.google.cloud.tools.intellij.appengine.facet.flexible.AppEngineFlexibleFacetType;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkPanel;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkService;
+import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceUserSettings;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkValidationResult;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkValidator;
 import com.google.cloud.tools.intellij.appengine.util.AppEngineUtil;
@@ -292,7 +293,8 @@ public class AppEngineStandardSupportProvider extends FrameworkSupportInModulePr
       if (!sdkValidator
           .validateCloudSdk(cloudSdkPanel.getCloudSdkDirectoryText())
           .contains(CloudSdkValidationResult.MALFORMED_PATH)) {
-        sdkService.setSdkHomePath(cloudSdkPanel.getCloudSdkDirectoryText());
+        CloudSdkServiceUserSettings.getInstance()
+            .setCustomSdkPath(cloudSdkPanel.getCloudSdkDirectoryText());
       }
 
       AppEngineStandardSupportProvider.this.addSupport(

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.intellij.appengine.sdk;
 
 import com.google.cloud.tools.intellij.GctFeature;
-import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceUserSettings.CloudSdkServiceType;
 import com.google.cloud.tools.intellij.service.PluginInfoService;
 import com.google.cloud.tools.intellij.ui.BrowserOpeningHyperLinkListener;
 import com.google.cloud.tools.intellij.util.GctBundle;
@@ -69,7 +68,7 @@ public class CloudSdkPanel {
 
   private boolean settingsModified;
 
-  private CloudSdkServiceUserSettings.CloudSdkServiceType selectedCloudSdkServiceType;
+  private CloudSdkServiceType selectedCloudSdkServiceType;
 
   public CloudSdkPanel() {
     warningMessage.setVisible(false);
@@ -223,7 +222,7 @@ public class CloudSdkPanel {
   public void reset() {
     CloudSdkServiceUserSettings sdkServiceUserSettings = CloudSdkServiceUserSettings.getInstance();
 
-    CloudSdkServiceUserSettings.CloudSdkServiceType selectedSdkServiceType =
+    CloudSdkServiceType selectedSdkServiceType =
         sdkServiceUserSettings.getUserSelectedSdkServiceType();
     switch (selectedSdkServiceType) {
       case MANAGED_SDK:

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
@@ -208,7 +208,6 @@ public class CloudSdkPanel {
       }
 
       sdkServiceUserSettings.setCustomSdkPath(customSdkPathText);
-      CloudSdkService.getInstance().setSdkHomePath(customSdkPathText);
     }
 
     CloudSdkServiceType previousSdkType = sdkServiceUserSettings.getUserSelectedSdkServiceType();

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanel.java
@@ -211,6 +211,12 @@ public class CloudSdkPanel {
       CloudSdkService.getInstance().setSdkHomePath(customSdkPathText);
     }
 
+    CloudSdkServiceType previousSdkType = sdkServiceUserSettings.getUserSelectedSdkServiceType();
+    if (previousSdkType != selectedCloudSdkServiceType) {
+      // notify SDK manager about changed selection
+      ServiceManager.getService(CloudSdkServiceManager.class)
+          .onNewCloudSdkServiceTypeSelected(selectedCloudSdkServiceType);
+    }
     sdkServiceUserSettings.setUserSelectedSdkServiceType(selectedCloudSdkServiceType);
 
     sdkServiceUserSettings.setEnableAutomaticUpdates(enableAutomaticUpdatesCheckbox.isSelected());

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkService.java
@@ -34,10 +34,6 @@ public interface CloudSdkService {
   @Nullable
   Path getSdkHomePath();
 
-  /* TODO(ivanporty) to be removed from common interface, only applies for custom sdk service.*/
-  @Deprecated
-  void setSdkHomePath(String path);
-
   SdkStatus getStatus();
 
   /**

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkService.java
@@ -23,8 +23,9 @@ import org.jetbrains.annotations.Nullable;
 /** IntelliJ configured service for providing the path to the Cloud SDK. */
 public interface CloudSdkService {
 
+  /** Shortcut for getting currently active implementation of {@link CloudSdkService}. */
   static CloudSdkService getInstance() {
-    return ServiceManager.getService(CloudSdkService.class);
+    return ServiceManager.getService(CloudSdkServiceManager.class).getCloudSdkService();
   }
 
   /** Called when this service becomes primary choice for serving Cloud SDK. */

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceManager.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceManager.java
@@ -30,9 +30,8 @@ public class CloudSdkServiceManager {
   }
 
   public CloudSdkService getCloudSdkService() {
-    CloudSdkServiceType currentSdkServiceType =
-        CloudSdkServiceUserSettings.getInstance().getUserSelectedSdkServiceType();
-    return supportedCloudSdkServices.get(currentSdkServiceType);
+    return supportedCloudSdkServices.get(
+        CloudSdkServiceUserSettings.getInstance().getUserSelectedSdkServiceType());
   }
 
   /** Callback when a user selected and applied a new cloud sdk type. */

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceManager.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceManager.java
@@ -36,6 +36,16 @@ public class CloudSdkServiceManager {
 
   /** Callback when a user selected and applied a new cloud sdk type. */
   public void onNewCloudSdkServiceTypeSelected(CloudSdkServiceType newServiceType) {
-    supportedCloudSdkServices.get(newServiceType).activate();
+    if (supportedCloudSdkServices.containsKey(newServiceType)) {
+      supportedCloudSdkServices.get(newServiceType).activate();
+    } else {
+      throw new UnsupportedCloudSdkTypeException(newServiceType.name());
+    }
+  }
+
+  private static class UnsupportedCloudSdkTypeException extends RuntimeException {
+    private UnsupportedCloudSdkTypeException(String message) {
+      super(message);
+    }
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceManager.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceManager.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.sdk;
+
+import java.util.Map;
+import org.fest.util.Maps;
+
+/** Manages current selection of {@link CloudSdkService} implementation. */
+public class CloudSdkServiceManager {
+  private final Map<CloudSdkServiceType, CloudSdkService> supportedCloudSdkServices;
+
+  public CloudSdkServiceManager() {
+    supportedCloudSdkServices = Maps.newHashMap();
+    supportedCloudSdkServices.put(CloudSdkServiceType.CUSTOM_SDK, new DefaultCloudSdkService());
+    supportedCloudSdkServices.put(CloudSdkServiceType.MANAGED_SDK, new ManagedCloudSdkService());
+  }
+
+  public CloudSdkService getCloudSdkService() {
+    CloudSdkServiceType currentSdkServiceType =
+        CloudSdkServiceUserSettings.getInstance().getUserSelectedSdkServiceType();
+    return supportedCloudSdkServices.get(currentSdkServiceType);
+  }
+
+  /** Callback when a user selected and applied a new cloud sdk type. */
+  public void onNewCloudSdkServiceTypeSelected(CloudSdkServiceType newServiceType) {
+    supportedCloudSdkServices.get(newServiceType).activate();
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.sdk;
+
+/** Supported {@link CloudSdkService} types. */
+public enum CloudSdkServiceType {
+  MANAGED_SDK,
+  CUSTOM_SDK
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettings.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettings.java
@@ -25,7 +25,7 @@ import com.intellij.openapi.components.ServiceManager;
 import com.sun.istack.NotNull;
 
 /** Stores user settings for {@link CloudSdkService}, including choice of implementation. */
-class CloudSdkServiceUserSettings {
+public class CloudSdkServiceUserSettings {
   private static CloudSdkServiceUserSettings instance;
 
   private static final CloudSdkServiceType DEFAULT_SDK_TYPE = CloudSdkServiceType.MANAGED_SDK;
@@ -38,7 +38,7 @@ class CloudSdkServiceUserSettings {
 
   private PropertiesComponent propertiesComponent = PropertiesComponent.getInstance();
 
-  static CloudSdkServiceUserSettings getInstance() {
+  public static CloudSdkServiceUserSettings getInstance() {
     if (instance == null) {
       instance = new CloudSdkServiceUserSettings();
     }
@@ -86,11 +86,12 @@ class CloudSdkServiceUserSettings {
         DEFAULT_MANAGED_SDK_AUTOMATIC_UPDATES /* need to specify default to avoid removal */);
   }
 
-  String getCustomSdkPath() {
+  @VisibleForTesting
+  public String getCustomSdkPath() {
     return propertiesComponent.getValue(CUSTOM_CLOUD_SDK_PATH_PROPERTY_NAME);
   }
 
-  void setCustomSdkPath(String path) {
+  public void setCustomSdkPath(String path) {
     propertiesComponent.setValue(
         CUSTOM_CLOUD_SDK_PATH_PROPERTY_NAME, path, null /* default for path */);
   }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettings.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettings.java
@@ -94,9 +94,4 @@ class CloudSdkServiceUserSettings {
     propertiesComponent.setValue(
         CUSTOM_CLOUD_SDK_PATH_PROPERTY_NAME, path, null /* default for path */);
   }
-
-  enum CloudSdkServiceType {
-    MANAGED_SDK,
-    CUSTOM_SDK
-  }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/DefaultCloudSdkService.java
@@ -60,11 +60,6 @@ public class DefaultCloudSdkService implements CloudSdkService {
   }
 
   @Override
-  public void setSdkHomePath(String cloudSdkHomePath) {
-    CloudSdkServiceUserSettings.getInstance().setCustomSdkPath(cloudSdkHomePath);
-  }
-
-  @Override
   public SdkStatus getStatus() {
     String sdkPath = CloudSdkServiceUserSettings.getInstance().getCustomSdkPath();
     if (Strings.isNullOrEmpty(sdkPath)) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkService.java
@@ -78,11 +78,6 @@ public class ManagedCloudSdkService implements CloudSdkService {
   }
 
   @Override
-  public void setSdkHomePath(String path) {
-    /* unsupported, to be removed. */
-  }
-
-  @Override
   public SdkStatus getStatus() {
     return sdkStatus;
   }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/CloudToolsFeedbackActionTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/CloudToolsFeedbackActionTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkService;
+import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceManager;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.TestFile;
 import com.google.cloud.tools.intellij.testing.TestService;
@@ -41,6 +42,7 @@ public final class CloudToolsFeedbackActionTest {
 
   @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
 
+  @Mock @TestService private CloudSdkServiceManager mockCloudSdkServiceManager;
   @Mock @TestService private CloudSdkService sdkService;
   @Mock @TestService private BrowserLauncher browserLauncher;
 
@@ -50,7 +52,8 @@ public final class CloudToolsFeedbackActionTest {
   private CloudToolsFeedbackAction feedbackAction;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
+    when(mockCloudSdkServiceManager.getCloudSdkService()).thenReturn(sdkService);
     feedbackAction = new CloudToolsFeedbackAction();
   }
 

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudConfigurableTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudConfigurableTest.java
@@ -19,10 +19,11 @@ package com.google.cloud.tools.intellij.appengine.cloud;
 import static com.google.cloud.tools.intellij.appengine.sdk.CloudSdkValidationResult.CLOUD_SDK_NOT_FOUND;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkService;
+import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceManager;
+import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceUserSettings;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkValidator;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.TestService;
@@ -43,6 +44,7 @@ public final class AppEngineCloudConfigurableTest {
 
   @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
 
+  @Mock @TestService private CloudSdkServiceManager mockCloudSdkServiceManager;
   @Mock @TestService private CloudSdkService mockCloudSdkService;
 
   @Mock @TestService private CloudSdkValidator mockCloudSdkValidator;
@@ -56,6 +58,8 @@ public final class AppEngineCloudConfigurableTest {
 
   @Test
   public void reset_withSdkPath_doesSetFieldText() {
+    when(mockCloudSdkServiceManager.getCloudSdkService()).thenReturn(mockCloudSdkService);
+
     Path sdkPath = Paths.get("/some/sdk/path");
     when(mockCloudSdkService.getSdkHomePath()).thenReturn(sdkPath);
 
@@ -76,7 +80,7 @@ public final class AppEngineCloudConfigurableTest {
 
     appEngineCloudConfigurable.apply();
 
-    verify(mockCloudSdkService).setSdkHomePath(sdkPath);
+    assertThat(CloudSdkServiceUserSettings.getInstance().getCustomSdkPath()).isEqualTo(sdkPath);
   }
 
   @Test
@@ -89,6 +93,6 @@ public final class AppEngineCloudConfigurableTest {
 
     appEngineCloudConfigurable.apply();
 
-    verify(mockCloudSdkService).setSdkHomePath(sdkPath);
+    assertThat(CloudSdkServiceUserSettings.getInstance().getCustomSdkPath()).isEqualTo(sdkPath);
   }
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelperTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelperTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkService;
+import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceManager;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkValidationResult;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkValidator;
 import com.google.cloud.tools.intellij.login.CredentialedUser;
@@ -66,6 +67,8 @@ public class CloudSdkAppEngineHelperTest {
   @Mock private GoogleLoginState loginState;
   @Mock private LoggingHandler loggingHandler;
   @Mock private DeploymentOperationCallback callback;
+
+  @TestService @Mock private CloudSdkServiceManager mockCloudSdkServiceManager;
   @TestService @Mock private CloudSdkService sdkService;
   @TestService @Mock private CloudSdkValidator cloudSdkValidator;
   @Mock private DeploymentSource undeployableDeploymentSource;
@@ -73,6 +76,8 @@ public class CloudSdkAppEngineHelperTest {
   @Before
   public void initialize() {
     helper = new CloudSdkAppEngineHelper(testFixture.getProject());
+
+    when(mockCloudSdkServiceManager.getCloudSdkService()).thenReturn(sdkService);
   }
 
   @Test

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanelTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import com.google.cloud.tools.intellij.GctFeature;
-import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceUserSettings.CloudSdkServiceType;
 import com.google.cloud.tools.intellij.service.PluginInfoService;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.TestService;
@@ -262,7 +261,7 @@ public class CloudSdkPanelTest {
   }
 
   private void verifyCloudSdkSettings(
-      CloudSdkServiceUserSettings.CloudSdkServiceType cloudSdkServiceType,
+      CloudSdkServiceType cloudSdkServiceType,
       boolean enableAutomaticUpdates,
       String customSdkPath) {
     CloudSdkServiceUserSettings userSettings = CloudSdkServiceUserSettings.getInstance();

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanelTest.java
@@ -46,7 +46,8 @@ public class CloudSdkPanelTest {
 
   @Mock @TestService private PluginInfoService pluginInfoService;
 
-  @Mock @TestService private CloudSdkService cloudSdkService;
+  @Mock private CloudSdkService mockCloudSdkService;
+  @Mock @TestService private CloudSdkServiceManager mockCloudSdkServiceManager;
   @Mock @TestService private CloudSdkValidator cloudSdkValidator;
 
   private CloudSdkPanel panel;
@@ -62,6 +63,7 @@ public class CloudSdkPanelTest {
 
   @Before
   public void setUp() {
+    when(mockCloudSdkServiceManager.getCloudSdkService()).thenReturn(mockCloudSdkService);
     // enable managed SDK UI - remove when feature is rolled out.
     when(pluginInfoService.shouldEnable(GctFeature.MANAGED_SDK)).thenReturn(true);
     // now safe to create panel spy.

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkPanelTest.java
@@ -256,6 +256,31 @@ public class CloudSdkPanelTest {
             });
   }
 
+  @Test
+  public void changeSdkType_apply_callsChangedSdkTypeCallback() {
+    ApplicationManager.getApplication()
+        .invokeAndWait(
+            () -> {
+              // use non-spy panel as spy messes up with UI event thread field updates.
+              CloudSdkPanel sdkPanel = new CloudSdkPanel();
+              CloudSdkServiceUserSettings.getInstance()
+                  .setUserSelectedSdkServiceType(CloudSdkServiceType.MANAGED_SDK);
+              sdkPanel.reset();
+              sdkPanel.getCustomRadioButton().doClick();
+              String customSdkPath = "/home/gcloud";
+              sdkPanel.getCloudSdkDirectoryField().setText(customSdkPath);
+
+              try {
+                sdkPanel.apply();
+              } catch (ConfigurationException e) {
+                throw new AssertionError(e);
+              }
+
+              verify(mockCloudSdkServiceManager)
+                  .onNewCloudSdkServiceTypeSelected(CloudSdkServiceType.CUSTOM_SDK);
+            });
+  }
+
   private void setValidateCloudSdkResponse(CloudSdkValidationResult... results) {
     Set<CloudSdkValidationResult> validationResults = new HashSet<>();
     Collections.addAll(validationResults, results);


### PR DESCRIPTION
Adds `CloudSdkServiceManager` class as a IDE service which will manage instances of Cloud SDK service (between custom and managed), depending on a user selection.

`CloudSdkService.getInstance()` will now use this class to return current choice for SDK service.

Removed `CloudSdkService.setSdkHomePath()`, this is set in settings for custom SDK.

### Testing Managed SDK
Plugin will now use Managed SDK if selected in settings. You can test it after enabling feature flag in `config.properties`:
> feature.managed.sdk=false -> true

then go to Settings -> Google to select Managed SDK.
Once applied, managed SDK will install (you should see the progress in background). Once installed (success popup), it will be used everywhere.
