### PR TITLE
Remove reference to fields becoming private in EAP.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiMavenService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiMavenService.java
@@ -21,7 +21,6 @@ import com.intellij.jarRepository.JarRepositoryManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import java.util.List;
-import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.version.Version;
 import org.jetbrains.idea.maven.aether.ArtifactKind;
 import org.jetbrains.idea.maven.aether.ArtifactRepositoryManager;
@@ -45,13 +44,9 @@ public class CloudApiMavenService {
    * @return returns the {@link Version versions} of the BOMs
    */
   List<Version> getBomVersions() {
-    List<RemoteRepository> remoteRepositories =
-        ImmutableList.of(ArtifactRepositoryManager.MAVEN_CENTRAL_REPOSITORY);
     ArtifactRepositoryManager repositoryManager =
         new ArtifactRepositoryManager(
-            JarRepositoryManager.getLocalRepositoryPath(),
-            remoteRepositories,
-            ProgressConsumer.DEAF);
+            JarRepositoryManager.getLocalRepositoryPath(), ProgressConsumer.DEAF);
 
     try {
       return repositoryManager.getAvailableVersions(

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiMavenService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudApiMavenService.java
@@ -21,6 +21,7 @@ import com.intellij.jarRepository.JarRepositoryManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import java.util.List;
+import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.version.Version;
 import org.jetbrains.idea.maven.aether.ArtifactKind;
 import org.jetbrains.idea.maven.aether.ArtifactRepositoryManager;
@@ -34,6 +35,9 @@ public class CloudApiMavenService {
   private static final String GOOGLE_CLOUD_JAVA_BOM_ARTIFACT_NAME = "google-cloud-bom";
   private static final String GOOGLE_CLOUD_JAVA_BOM_VERSION_CONSTRAINT = "[0,)";
 
+  private static final RemoteRepository MAVEN_CENTRAL_REPOSITORY =
+      ArtifactRepositoryManager.createRemoteRepository("central", "http://repo1.maven.org/maven2/");
+
   static CloudApiMavenService getInstance() {
     return ServiceManager.getService(CloudApiMavenService.class);
   }
@@ -46,7 +50,9 @@ public class CloudApiMavenService {
   List<Version> getBomVersions() {
     ArtifactRepositoryManager repositoryManager =
         new ArtifactRepositoryManager(
-            JarRepositoryManager.getLocalRepositoryPath(), ProgressConsumer.DEAF);
+            JarRepositoryManager.getLocalRepositoryPath(),
+            ImmutableList.of(MAVEN_CENTRAL_REPOSITORY),
+            ProgressConsumer.DEAF);
 
     try {
       return repositoryManager.getAvailableVersions(


### PR DESCRIPTION
Fixes #1941.

Repository fields are private in upcoming releases, so we can use shorter version of constructor that takes two public repositories by default. I quickly tested and it seems to work fine.