### PR TITLE
Convert App Engine Region styled text to system font.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/application/AppEngineApplicationCreateDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/application/AppEngineApplicationCreateDialog.java
@@ -21,6 +21,7 @@ import com.google.api.services.appengine.v1.model.Location;
 import com.google.cloud.tools.intellij.analytics.GctTracking;
 import com.google.cloud.tools.intellij.analytics.UsageTrackerProvider;
 import com.google.cloud.tools.intellij.ui.BrowserOpeningHyperLinkListener;
+import com.google.cloud.tools.intellij.ui.FontUtils;
 import com.google.cloud.tools.intellij.util.GctBundle;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
@@ -51,8 +52,8 @@ public class AppEngineApplicationCreateDialog extends DialogWrapper {
       "https://cloud.google.com/appengine/docs/flexible";
   private static final String STANDARD_DOCUMENTATION_URL =
       "https://cloud.google.com/appengine/docs/about-the-standard-environment";
-  private static final String HTML_OPEN_TAG = "<html><font face='sans' size='-1'>";
-  private static final String HTML_CLOSE_TAG = "</font></html>";
+  private static final String HTML_OPEN_TAG = "<html>";
+  private static final String HTML_CLOSE_TAG = "</html>";
 
   private JPanel panel;
   private JTextPane instructionsTextPane;
@@ -102,6 +103,8 @@ public class AppEngineApplicationCreateDialog extends DialogWrapper {
                 "</a>")
             + "</p>"
             + HTML_CLOSE_TAG);
+
+    FontUtils.convertStyledDocumentFontToDefault(instructionsTextPane.getStyledDocument());
   }
 
   @Override
@@ -252,6 +255,8 @@ public class AppEngineApplicationCreateDialog extends DialogWrapper {
 
     displayText += "</ul>" + HTML_CLOSE_TAG;
     regionDetailPane.setText(displayText);
+
+    FontUtils.convertStyledDocumentFontToDefault(regionDetailPane.getStyledDocument());
   }
 
   @Nullable

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudConfigurable.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudConfigurable.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.intellij.appengine.cloud;
 
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkPanel;
 import com.google.cloud.tools.intellij.ui.BrowserOpeningHyperLinkListener;
+import com.google.cloud.tools.intellij.ui.FontUtils;
 import com.google.cloud.tools.intellij.util.GctBundle;
 import com.google.common.annotations.VisibleForTesting;
 import com.intellij.openapi.options.Configurable;
@@ -47,6 +48,7 @@ public class AppEngineCloudConfigurable extends RemoteServerConfigurable impleme
         GctBundle.message("appengine.more.info", MORE_INFO_URI_OPEN_TAG, MORE_INFO_URI_CLOSE_TAG));
     appEngineMoreInfoLabel.addHyperlinkListener(new BrowserOpeningHyperLinkListener());
     appEngineMoreInfoLabel.setBackground(mainPanel.getBackground());
+    FontUtils.convertStyledDocumentFontToDefault(appEngineMoreInfoLabel.getStyledDocument());
   }
 
   @Nls

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/ui/FontUtils.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/ui/FontUtils.java
@@ -34,14 +34,15 @@ public class FontUtils {
    * @param styledDocument {@link StyledDocument} to update, see {@link javax.swing.JTextPane}
    */
   public static void convertStyledDocumentFontToDefault(StyledDocument styledDocument) {
-    for (int ch = 0; ch < styledDocument.getLength(); ch++) {
-      AttributeSet defaultStyle = styledDocument.getCharacterElement(ch).getAttributes();
+    for (int i = 0; i < styledDocument.getLength(); i++) {
+      AttributeSet defaultStyle = styledDocument.getCharacterElement(i).getAttributes();
       MutableAttributeSet updatedFontAttrbutes = new SimpleAttributeSet(defaultStyle);
       Font defaultFont = UIManager.getFont("Label.font");
       StyleConstants.setFontFamily(updatedFontAttrbutes, defaultFont.getFamily());
       StyleConstants.setFontSize(updatedFontAttrbutes, defaultFont.getSize());
 
-      styledDocument.setCharacterAttributes(ch, 1, updatedFontAttrbutes, true);
+      styledDocument.setCharacterAttributes(
+          i, 1 /* apply for 1 char only */, updatedFontAttrbutes, true /*replace old style.*/);
     }
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/ui/FontUtils.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/ui/FontUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.ui;
+
+import java.awt.Font;
+import javax.swing.UIManager;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledDocument;
+
+/** Tools to work with fonts when standard settings are not sufficient. */
+public class FontUtils {
+
+  /**
+   * Converts font for all characters in {@link StyledDocument} to system default font. Does not
+   * change or affect newly added characters.
+   *
+   * @param styledDocument {@link StyledDocument} to update, see {@link javax.swing.JTextPane}
+   */
+  public static void convertStyledDocumentFontToDefault(StyledDocument styledDocument) {
+    for (int ch = 0; ch < styledDocument.getLength(); ch++) {
+      AttributeSet defaultStyle = styledDocument.getCharacterElement(ch).getAttributes();
+      MutableAttributeSet updatedFontAttrbutes = new SimpleAttributeSet(defaultStyle);
+      Font defaultFont = UIManager.getFont("Label.font");
+      StyleConstants.setFontFamily(updatedFontAttrbutes, defaultFont.getFamily());
+      StyleConstants.setFontSize(updatedFontAttrbutes, defaultFont.getSize());
+
+      styledDocument.setCharacterAttributes(ch, 1, updatedFontAttrbutes, true);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1664 

Introduces utility to convert styled document to default system font keeping other attributes (i.e. hyperlinks).

![gae-region-font](https://user-images.githubusercontent.com/11686100/37303280-5fe3b32c-2604-11e8-8d9f-836f2cfca45e.png)
