### PR TITLE
Ask for a specific account sign-in even if another account is already signed in.

### DIFF
--- a/google-cloud-tools-plugin/google-cloud-core/resources/messages/CoreMessageBundle.properties
+++ b/google-cloud-tools-plugin/google-cloud-core/resources/messages/CoreMessageBundle.properties
@@ -18,7 +18,7 @@
 cloud.project.selector.signin.message=Sign in with your Google account to list your Google Developers Console projects.
 cloud.project.selector.open.dialog.tooltip=Opens a dialog to select a Google Cloud project
 cloud.project.selector.no.selected.project=Select a Google Cloud project
-cloud.project.selector.not.signed.in=Sign in with your Google account
+cloud.project.selector.not.signed.in=Sign in with your {0} Google account
 cloud.project.selector.dialog.title=Select Google Cloud Project
 cloud.project.selector.project.list.project.name.column=Project Name
 cloud.project.selector.project.list.project.id.column=Project ID

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
@@ -234,9 +234,9 @@ public class ProjectSelector extends JPanel {
     Optional<CredentialedUser> loggedInUser =
         loginService.getLoggedInUser(selection.googleUsername());
 
-    if (!loginService.isLoggedIn()) {
+    if (!loggedInUser.isPresent()) {
       accountInfoLabel.setHyperlinkText(
-          GoogleCloudCoreMessageBundle.message("cloud.project.selector.not.signed.in"));
+          GoogleCloudCoreMessageBundle.message("cloud.project.selector.not.signed.in", selection.googleUsername()));
     } else if (loggedInUser.isPresent()) {
       accountInfoLabel.setHyperlinkText(
           String.format(

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/project/ProjectSelector.java
@@ -236,7 +236,8 @@ public class ProjectSelector extends JPanel {
 
     if (!loggedInUser.isPresent()) {
       accountInfoLabel.setHyperlinkText(
-          GoogleCloudCoreMessageBundle.message("cloud.project.selector.not.signed.in", selection.googleUsername()));
+          GoogleCloudCoreMessageBundle.message(
+              "cloud.project.selector.not.signed.in", selection.googleUsername()));
     } else if (loggedInUser.isPresent()) {
       accountInfoLabel.setHyperlinkText(
           String.format(


### PR DESCRIPTION
Fixes #1883.

In this screenshot, another account is already signed in, but it's not the one assigned to project selector, so it asks to sign in with that specific account to work with this specific project (or select a different one with another account).

![gcs-different-account](https://user-images.githubusercontent.com/11686100/37412030-8e1c2658-277a-11e8-9d9b-70f5291ab869.png)
