### PR TITLE
Adding a plugin.xml for core unit tests 

### DIFF
--- a/google-cloud-tools-plugin/google-cloud-core/testResources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/google-cloud-core/testResources/META-INF/plugin.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2018 Google Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+    <name>Google Cloud Core Tests</name>
+    <id>com.google.gct.core</id>
+    <xi:include href="/META-INF/google-cloud-core.xml" xpointer="xpointer(/idea-plugin/*)"/>
+</idea-plugin>


### PR DESCRIPTION
since the plugin fragments from our modules don't get used to setup fixture environments by default