### PR TITLE
Remove the status label from the client library details panel

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -222,7 +222,6 @@ cloud.libraries.module.selector.label=Add Google Cloud Library to Module:
 cloud.libraries.bom.selector.label=Google Cloud Libraries Version:
 cloud.libraries.ok.button.text=Add Client Library
 cloud.libraries.source.link=Source
-cloud.libraries.status.label=Status: {0}
 cloud.libraries.version.label=Version: {0}
 cloud.apis.enable.checkbox.text=Enable the API on the Google Cloud Platform
 cloud.apis.enable.checkbox.tooltip.text=If you plan to deploy your application to GCP or access GCP APIs remotely, then note that some APIs need to be explicitly enabled. Enabling the API associates it with the specified project, enables billing, and more.

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.form
@@ -6,8 +6,6 @@
     <rowspec value="center:p:noGrow"/>
     <rowspec value="center:p:noGrow"/>
     <rowspec value="center:p:noGrow"/>
-    <rowspec value="center:p:noGrow"/>
-    <rowspec value="center:p:noGrow"/>
     <rowspec value="top:3dlu:noGrow"/>
     <rowspec value="center:max(d;4px):noGrow"/>
     <colspec value="fill:d:grow"/>
@@ -49,15 +47,6 @@
           <text value=""/>
         </properties>
       </component>
-      <component id="83d58" class="javax.swing.JLabel" binding="statusLabel">
-        <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-          <forms top="15" left="0" bottom="0" right="0"/>
-        </constraints>
-        <properties>
-          <text value=""/>
-        </properties>
-      </component>
       <grid id="c0909" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="15" left="0" bottom="0" right="0"/>
         <constraints>
@@ -88,7 +77,7 @@
       <grid id="d7866" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="15" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
           <forms/>
         </constraints>
         <properties/>
@@ -115,7 +104,7 @@
       <grid id="1821f" binding="apiManagementPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
           <forms/>
         </constraints>
         <properties>

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/GoogleCloudApiDetailsPanel.java
@@ -51,7 +51,6 @@ public final class GoogleCloudApiDetailsPanel {
   private JLabel icon;
   private JLabel nameLabel;
   private JLabel versionLabel;
-  private JLabel statusLabel;
   private JPanel panel;
   private JTextPane descriptionTextPane;
   private JTextPane linksTextPane;
@@ -120,12 +119,6 @@ public final class GoogleCloudApiDetailsPanel {
   @VisibleForTesting
   JLabel getVersionLabel() {
     return versionLabel;
-  }
-
-  /** Returns the {@link JLabel} that holds the library's status. */
-  @VisibleForTesting
-  JLabel getStatusLabel() {
-    return statusLabel;
   }
 
   /** Returns the {@link JTextPane} that holds the library's description. */
@@ -216,9 +209,6 @@ public final class GoogleCloudApiDetailsPanel {
                             client.getMavenCoordinates().getVersion()));
                   }
                 }
-
-                statusLabel.setText(
-                    GctBundle.message("cloud.libraries.status.label", client.getLaunchStage()));
 
                 Optional<String> docsLink =
                     makeLink(

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/apis/GoogleCloudApiSelectorPanelTest.java
@@ -655,9 +655,6 @@ public final class GoogleCloudApiSelectorPanelTest {
             : "Version: " + client.mavenCoordinates().version();
     assertThat(panel.getVersionLabel().getText()).isEqualTo(expectedVersion);
 
-    String expectedStatus = client.launchStage().isEmpty() ? "" : "Status: " + client.launchStage();
-    assertThat(panel.getStatusLabel().getText()).isEqualTo(expectedStatus);
-
     Map<String, String> actualUrlMap = buildActualUrlMap(panel.getLinksTextPane().getText());
     Map<String, String> expectedUrlMap = buildExpectedUrlMap(library, client);
     assertThat(actualUrlMap).containsExactlyEntriesIn(expectedUrlMap);


### PR DESCRIPTION
Fixes #1955 

status label removed:
![image](https://user-images.githubusercontent.com/1735744/37784805-080a8d06-2dcf-11e8-8830-75e1b38daab2.png)
