### PR TITLE
Fix NPE with null MavenDomProjectModel

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryProjectState.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryProjectState.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.intellij.apis;
 
 import com.google.cloud.tools.libraries.json.CloudLibrary;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.intellij.openapi.application.ApplicationManager;
@@ -103,7 +104,7 @@ public class CloudLibraryProjectState implements ProjectComponent {
   private Set<CloudLibrary> loadManagedLibraries(Module module) {
     List<MavenDomDependency> moduleDependencies = getModuleDependencies(module);
 
-    if (moduleDependencies == null || moduleDependencies.isEmpty()) {
+    if (moduleDependencies.isEmpty()) {
       return ImmutableSet.of();
     }
 
@@ -124,7 +125,7 @@ public class CloudLibraryProjectState implements ProjectComponent {
   private List<MavenDomDependency> getModuleDependencies(Module module) {
     MavenProject mavenProject = MavenProjectsManager.getInstance(project).findProject(module);
     if (mavenProject == null) {
-      return null;
+      return ImmutableList.of();
     }
 
     return ApplicationManager.getApplication()
@@ -134,7 +135,9 @@ public class CloudLibraryProjectState implements ProjectComponent {
                   MavenDomProjectModel model =
                       MavenDomUtil.getMavenDomProjectModel(project, mavenProject.getFile());
 
-                  return model != null ? model.getDependencies().getDependencies() : null;
+                  return model != null
+                      ? model.getDependencies().getDependencies()
+                      : ImmutableList.of();
                 });
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryProjectState.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryProjectState.java
@@ -104,7 +104,7 @@ public class CloudLibraryProjectState implements ProjectComponent {
   private Set<CloudLibrary> loadManagedLibraries(Module module) {
     List<MavenDomDependency> moduleDependencies = getModuleDependencies(module);
 
-    if (moduleDependencies.isEmpty()) {
+    if (moduleDependencies != null && moduleDependencies.isEmpty()) {
       return ImmutableSet.of();
     }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryProjectState.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryProjectState.java
@@ -104,7 +104,7 @@ public class CloudLibraryProjectState implements ProjectComponent {
   private Set<CloudLibrary> loadManagedLibraries(Module module) {
     List<MavenDomDependency> moduleDependencies = getModuleDependencies(module);
 
-    if (moduleDependencies != null && moduleDependencies.isEmpty()) {
+    if (moduleDependencies == null || moduleDependencies.isEmpty()) {
       return ImmutableSet.of();
     }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryProjectState.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryProjectState.java
@@ -134,7 +134,7 @@ public class CloudLibraryProjectState implements ProjectComponent {
                   MavenDomProjectModel model =
                       MavenDomUtil.getMavenDomProjectModel(project, mavenProject.getFile());
 
-                  return model.getDependencies().getDependencies();
+                  return model != null ? model.getDependencies().getDependencies() : null;
                 });
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ ideaVersion = 2017.3
 intellijRepoUrl = https://www.jetbrains.com/intellij-repository
 javaVersion = 1.8
 ijPluginRepoChannel = alpha
-version = 18.3.2-SNAPSHOT
+version = 18.3.3-SNAPSHOT
 toolsLibVersion = 0.4.3
 systemProp.idea.log.leaked.projects.in.tests=false


### PR DESCRIPTION
fixes #1980 

The model could be null if its a maven project, but the pom is invalid in some way. In this case, we just return no dependencies.

Updated the method to not return null lists, and added a unit test to cover the bug.