### PR TITLE
Fix test to not call method that is protected in 2017.2

### DIFF
--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectorTest.java
@@ -199,7 +199,7 @@ public class ProjectSelectorTest {
     when(mockLoginService.isLoggedIn()).thenReturn(false);
     projectSelector.setSelectedProject(TEST_PROJECT);
 
-    assertThat(projectSelector.getAccountInfoLabel().getText())
+    assertThat(projectSelector.getAccountInfoLabel().getHyperlinkText())
         .isEqualTo(
             GoogleCloudCoreMessageBundle.message(
                 "cloud.project.selector.not.signed.in", TEST_PROJECT.googleUsername()));
@@ -228,7 +228,7 @@ public class ProjectSelectorTest {
     // drain UI events.
     ApplicationManager.getApplication().invokeAndWait(() -> {});
 
-    assertThat(projectSelector.getAccountInfoLabel().getText())
+    assertThat(projectSelector.getAccountInfoLabel().getHyperlinkText())
         .isEqualTo(
             GoogleCloudCoreMessageBundle.message(
                 "cloud.project.selector.not.signed.in", TEST_PROJECT.googleUsername()));


### PR DESCRIPTION
Discovered after setting up the CI for the previous version of IntelliJ (2017.2):

`HyperLinkLabel#getText` is protected in 2017.2 so tests were failing. Updates to use the public `HyperLinkLabel#getHyperLinkText`