### PR TITLE
Fix possible NPE when evaluating web roots for appEngine web Xml

### DIFF
--- a/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineStandardUltimateWebIntegration.java
+++ b/google-cloud-tools-plugin/ultimate/src/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineStandardUltimateWebIntegration.java
@@ -97,22 +97,28 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
 
     for (WebRoot webRoot : webRoots) {
       VirtualFile parent = webRoot.getFile();
-      if (parent.getName().equals(WEB_INF)) {
-        return parent;
-      }
+      if (parent != null) {
+        if (WEB_INF.equals(parent.getName())) {
+          return parent;
+        }
 
-      VirtualFile child = parent.findChild(WEB_INF);
-      if (child != null) {
-        return child;
+        VirtualFile child = parent.findChild(WEB_INF);
+        if (child != null) {
+          return child;
+        }
       }
     }
 
     try {
-      return VfsUtil.createDirectoryIfMissing(webRoots.get(0).getFile(), WEB_INF);
+      VirtualFile webRootFile = webRoots.get(0).getFile();
+      if (webRootFile != null) {
+        return VfsUtil.createDirectoryIfMissing(webRootFile, WEB_INF);
+      }
     } catch (IOException ioe) {
       LOG.info(ioe);
-      return null;
     }
+
+    return null;
   }
 
   @Override

--- a/google-cloud-tools-plugin/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineStandardUltimateWebIntegrationTest.java
+++ b/google-cloud-tools-plugin/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/facet/impl/AppEngineStandardUltimateWebIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.intellij.appengine.facet.impl;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
@@ -106,5 +107,16 @@ public class AppEngineStandardUltimateWebIntegrationTest {
         webIntegration.suggestParentDirectoryForAppEngineWebXml(
             mockModule, mockModifiableRootModel);
     assertEquals(mockVirtualFile1, suggestedDirectory);
+  }
+
+  @Test
+  public void malformedWebRoot_noFile_suggestsNullDirectory() {
+    when(mockWebRoot.getFile()).thenReturn(null);
+
+    VirtualFile suggestedDirectory =
+        webIntegration.suggestParentDirectoryForAppEngineWebXml(
+            mockModule, mockModifiableRootModel);
+
+    assertThat(suggestedDirectory).isNull();
   }
 }


### PR DESCRIPTION
Fixes #1981.
Ensures malformed web roots without files or corrupted files do not cause NPEs.