### PR TITLE
Managed SDK enhancements

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceManager.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceManager.java
@@ -139,8 +139,9 @@ public class CloudSdkServiceManager {
       String progressMessage,
       CloudSdkStatusHandler sdkLogging) {
     CloudSdkService cloudSdkService = CloudSdkService.getInstance();
-    // if not ready, attempt to fix and install now.
-    if (!isSdkReady() && cloudSdkService.isInstallSupported()) {
+    // if install supported, make sure SDK is in good shape and installed.
+    // even if status is READY, this will double-check the current state from the last install.
+    if (cloudSdkService.isInstallSupported()) {
       cloudSdkService.install();
     }
 
@@ -207,10 +208,6 @@ public class CloudSdkServiceManager {
   /** Checks if current SDK service is currently installing and not ready for operations. */
   private boolean isInstallInProgress() {
     return CloudSdkService.getInstance().getStatus() == SdkStatus.INSTALLING;
-  }
-
-  private boolean isSdkReady() {
-    return CloudSdkService.getInstance().getStatus() == SdkStatus.READY;
   }
 
   /** Exposes process window so that installation / dependent processes are explicitly visible. */

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettings.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettings.java
@@ -62,7 +62,7 @@ public class CloudSdkServiceUserSettings {
       sdkType = DEFAULT_SDK_TYPE;
       // sdk type is unset - probably previous version of the SDK support didn't have it.
       // check for custom SDK path and use custom if it's set.
-      if (getCustomSdkPath() != null) {
+      if (!Strings.isNullOrEmpty(getCustomSdkPath())) {
         sdkType = CloudSdkServiceType.CUSTOM_SDK;
       }
     }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettings.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettings.java
@@ -60,6 +60,11 @@ public class CloudSdkServiceUserSettings {
       sdkType = CloudSdkServiceType.valueOf(Strings.nullToEmpty(sdkTypeName));
     } catch (Exception ex) {
       sdkType = DEFAULT_SDK_TYPE;
+      // sdk type is unset - probably previous version of the SDK support didn't have it.
+      // check for custom SDK path and use custom if it's set.
+      if (getCustomSdkPath() != null) {
+        sdkType = CloudSdkServiceType.CUSTOM_SDK;
+      }
     }
 
     // override result based on feature status until feature is done.

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkService.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkService.java
@@ -55,7 +55,7 @@ public class ManagedCloudSdkService implements CloudSdkService {
 
   private final Collection<SdkStatusUpdateListener> statusUpdateListeners = Lists.newArrayList();
 
-  private volatile ListenableFuture<Path> managedSdkBackgroundJob;
+  private volatile ListenableFuture<ManagedSdkJobResult> managedSdkBackgroundJob;
 
   private ProgressListener progressListener;
 
@@ -154,7 +154,8 @@ public class ManagedCloudSdkService implements CloudSdkService {
    * @param managedSdkTask Task to execute.
    * @return {@code true} if task started, {@code false} if Managed SDK is not supported at all.
    */
-  private boolean executeManagedSdkJob(ManagedSdkJobType jobType, Callable<Path> managedSdkTask) {
+  private boolean executeManagedSdkJob(
+      ManagedSdkJobType jobType, Callable<ManagedSdkJobResult> managedSdkTask) {
     if (!isInstallSupported()) {
       return false;
     }
@@ -175,27 +176,33 @@ public class ManagedCloudSdkService implements CloudSdkService {
    * @throws InterruptedException if Managed Cloud SDK has been interrupted by {@link
    *     #cancelInstallOrUpdate()} ()}
    */
-  private Path installManagedSdk() throws Exception {
-    Path installedManagedSdkPath = installSdk();
-    installAppEngineJavaComponent();
+  private ManagedSdkJobResult installManagedSdk() throws Exception {
+    ManagedSdkJobResult installResult = installSdk();
+    ManagedSdkJobResult appEngineJavaResult = installAppEngineJavaComponent();
 
-    return installedManagedSdkPath;
+    // return up-to-date only if both SDK and app engine Java were up-to-date
+    return (installResult == ManagedSdkJobResult.UP_TO_DATE
+            && appEngineJavaResult == ManagedSdkJobResult.UP_TO_DATE)
+        ? ManagedSdkJobResult.UP_TO_DATE
+        : ManagedSdkJobResult.PROCESSED;
   }
 
   /** Installs core managed SDK if needed and returns its path if successful. */
-  private Path installSdk() throws Exception {
+  private ManagedSdkJobResult installSdk() throws Exception {
     if (!safeCheckSdkStatus(() -> managedCloudSdk.isInstalled())) {
       ConsoleListener sdkConsoleListener = logger::debug;
       progressListener =
           ManagedCloudSdkServiceUiPresenter.getInstance().createProgressListener(this);
 
-      return managedCloudSdk.newInstaller().install(progressListener, sdkConsoleListener);
+      managedCloudSdk.newInstaller().install(progressListener, sdkConsoleListener);
+
+      return ManagedSdkJobResult.PROCESSED;
     }
 
-    return managedCloudSdk.getSdkHome();
+    return ManagedSdkJobResult.UP_TO_DATE;
   }
 
-  private void installAppEngineJavaComponent() throws Exception {
+  private ManagedSdkJobResult installAppEngineJavaComponent() throws Exception {
     if (!safeCheckSdkStatus(() -> managedCloudSdk.hasComponent(SdkComponent.APP_ENGINE_JAVA))) {
       ConsoleListener appEngineConsoleListener = logger::debug;
 
@@ -205,19 +212,25 @@ public class ManagedCloudSdkService implements CloudSdkService {
           .newComponentInstaller()
           .installComponent(
               SdkComponent.APP_ENGINE_JAVA, progressListener, appEngineConsoleListener);
+
+      return ManagedSdkJobResult.PROCESSED;
+    } else {
+      return ManagedSdkJobResult.UP_TO_DATE;
     }
   }
 
-  private Path updateManagedSdk() throws Exception {
+  private ManagedSdkJobResult updateManagedSdk() throws Exception {
     if (!safeCheckSdkStatus(() -> managedCloudSdk.isUpToDate())) {
       ConsoleListener sdkUpdateListener = logger::debug;
       progressListener =
           ManagedCloudSdkServiceUiPresenter.getInstance().createProgressListener(this);
 
       managedCloudSdk.newUpdater().update(progressListener, sdkUpdateListener);
-    }
 
-    return managedCloudSdk.getSdkHome();
+      return ManagedSdkJobResult.PROCESSED;
+    } else {
+      return ManagedSdkJobResult.UP_TO_DATE;
+    }
   }
 
   /**
@@ -255,11 +268,18 @@ public class ManagedCloudSdkService implements CloudSdkService {
     UPDATE
   }
 
+  enum ManagedSdkJobResult {
+    // work has been done and completed
+    PROCESSED,
+    // no work has been done since SDK is up-to-date.
+    UP_TO_DATE
+  }
+
   /**
    * Managed SDK Job future listener, handles success/error logic, logs errors, shows notifications
    * to a user, updates SDK service statuses.
    */
-  private final class ManagedSdkJobListener implements FutureCallback<Path> {
+  private final class ManagedSdkJobListener implements FutureCallback<ManagedSdkJobResult> {
     private final ManagedSdkJobType jobType;
 
     private ManagedSdkJobListener(ManagedSdkJobType jobType) {
@@ -267,12 +287,13 @@ public class ManagedCloudSdkService implements CloudSdkService {
     }
 
     @Override
-    public void onSuccess(Path path) {
-      logger.info("Managed Google Cloud SDK successfully installed/updated at: " + path);
+    public void onSuccess(ManagedSdkJobResult result) {
+      logger.info(
+          "Managed Google Cloud SDK successfully installed/updated at: " + getSdkHomePath());
 
       updateStatus(SdkStatus.READY);
 
-      ManagedCloudSdkServiceUiPresenter.getInstance().notifyManagedSdkJobSuccess(jobType);
+      ManagedCloudSdkServiceUiPresenter.getInstance().notifyManagedSdkJobSuccess(jobType, result);
     }
 
     @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkServiceUiPresenter.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkServiceUiPresenter.java
@@ -57,8 +57,7 @@ public class ManagedCloudSdkServiceUiPresenter {
     switch (jobResult) {
       case PROCESSED:
         showNotification(message, NotificationType.INFORMATION);
-        break;
-      case UP_TO_DATE:
+        return;
       default:
         // do nothing, everything is up-to-date.
     }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkServiceUiPresenter.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkServiceUiPresenter.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.intellij.appengine.sdk;
 
 import com.google.cloud.tools.intellij.GoogleCloudCoreIcons;
+import com.google.cloud.tools.intellij.appengine.sdk.ManagedCloudSdkService.ManagedSdkJobResult;
 import com.google.cloud.tools.intellij.appengine.sdk.ManagedCloudSdkService.ManagedSdkJobType;
 import com.google.cloud.tools.intellij.flags.PropertiesFileFlagReader;
 import com.google.cloud.tools.intellij.util.GctBundle;
@@ -51,9 +52,16 @@ public class ManagedCloudSdkServiceUiPresenter {
     ManagedCloudSdkServiceUiPresenter.instance = uiPresenter;
   }
 
-  public void notifyManagedSdkJobSuccess(ManagedSdkJobType jobType) {
+  public void notifyManagedSdkJobSuccess(ManagedSdkJobType jobType, ManagedSdkJobResult jobResult) {
     String message = GctBundle.message("managedsdk.success." + jobType.name().toLowerCase());
-    showNotification(message, NotificationType.INFORMATION);
+    switch (jobResult) {
+      case PROCESSED:
+        showNotification(message, NotificationType.INFORMATION);
+        break;
+      case UP_TO_DATE:
+      default:
+        // do nothing, everything is up-to-date.
+    }
   }
 
   public void notifyManagedSdkJobFailure(ManagedSdkJobType jobType, String errorMessage) {

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettingsTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettingsTest.java
@@ -54,6 +54,14 @@ public class CloudSdkServiceUserSettingsTest {
   }
 
   @Test
+  public void empty_sdkPath_managedSdk_selectedByDefault() {
+    userSettings.setCustomSdkPath("");
+
+    assertThat(userSettings.getUserSelectedSdkServiceType())
+        .isEqualTo(CloudSdkServiceType.MANAGED_SDK);
+  }
+
+  @Test
   public void previous_sdkPath_exists_customSdk_type_selectedByDefault() {
     userSettings.setCustomSdkPath("/home/gcloud");
 

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettingsTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/CloudSdkServiceUserSettingsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.sdk;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.tools.intellij.GctFeature;
+import com.google.cloud.tools.intellij.service.PluginInfoService;
+import com.google.cloud.tools.intellij.testing.CloudToolsRule;
+import com.google.cloud.tools.intellij.testing.TestService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+
+/** Unit tests for {@link CloudSdkServiceUserSettings} */
+public class CloudSdkServiceUserSettingsTest {
+
+  @Rule public CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
+
+  @Mock @TestService private PluginInfoService pluginInfoService;
+
+  private CloudSdkServiceUserSettings userSettings;
+
+  @Before
+  public void setUp() throws Exception {
+    // enable managed SDK UI - remove when feature is rolled out.
+    when(pluginInfoService.shouldEnable(GctFeature.MANAGED_SDK)).thenReturn(true);
+
+    userSettings = new CloudSdkServiceUserSettings();
+    // clear persisted values between unit test runs.
+    CloudSdkServiceUserSettings.reset();
+  }
+
+  @Test
+  public void emptySettings_managedSdk_selectedByDefault() {
+    assertThat(userSettings.getUserSelectedSdkServiceType())
+        .isEqualTo(CloudSdkServiceType.MANAGED_SDK);
+  }
+
+  @Test
+  public void previous_sdkPath_exists_customSdk_type_selectedByDefault() {
+    userSettings.setCustomSdkPath("/home/gcloud");
+
+    assertThat(userSettings.getUserSelectedSdkServiceType())
+        .isEqualTo(CloudSdkServiceType.CUSTOM_SDK);
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkServiceTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkServiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkService.SdkStatus;
+import com.google.cloud.tools.intellij.appengine.sdk.ManagedCloudSdkService.ManagedSdkJobResult;
 import com.google.cloud.tools.intellij.appengine.sdk.ManagedCloudSdkService.ManagedSdkJobType;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.log.TestInMemoryLogger;
@@ -167,7 +168,8 @@ public class ManagedCloudSdkServiceTest {
     emulateMockSdkInstallationProcess(MOCK_SDK_PATH);
     sdkService.install();
 
-    verify(mockUiPresenter).notifyManagedSdkJobSuccess(ManagedSdkJobType.INSTALL);
+    verify(mockUiPresenter)
+        .notifyManagedSdkJobSuccess(ManagedSdkJobType.INSTALL, ManagedSdkJobResult.PROCESSED);
   }
 
   @Test
@@ -285,7 +287,8 @@ public class ManagedCloudSdkServiceTest {
 
     sdkService.update();
 
-    verify(mockUiPresenter).notifyManagedSdkJobSuccess(ManagedSdkJobType.UPDATE);
+    verify(mockUiPresenter)
+        .notifyManagedSdkJobSuccess(ManagedSdkJobType.UPDATE, ManagedSdkJobResult.PROCESSED);
   }
 
   @Test

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkServiceTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/sdk/ManagedCloudSdkServiceTest.java
@@ -35,6 +35,7 @@ import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.log.TestInMemoryLogger;
 import com.google.cloud.tools.intellij.util.ThreadUtil;
 import com.google.cloud.tools.managedcloudsdk.ManagedCloudSdk;
+import com.google.cloud.tools.managedcloudsdk.ManagedSdkVerificationException;
 import com.google.cloud.tools.managedcloudsdk.ProgressListener;
 import com.google.cloud.tools.managedcloudsdk.UnsupportedOsException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExecutionException;
@@ -173,6 +174,15 @@ public class ManagedCloudSdkServiceTest {
   }
 
   @Test
+  public void sdkUpToDate_install_passes_valid_jobSuccessResult() {
+    makeMockSdkInstalled(MOCK_SDK_PATH);
+    sdkService.install();
+
+    verify(mockUiPresenter)
+        .notifyManagedSdkJobSuccess(ManagedSdkJobType.INSTALL, ManagedSdkJobResult.UP_TO_DATE);
+  }
+
+  @Test
   public void failed_install_changesSdkStatus_inProgress() throws Exception {
     sdkService.addStatusUpdateListener(mockStatusUpdateListener);
     emulateMockSdkInstallationProcess(MOCK_SDK_PATH);
@@ -289,6 +299,17 @@ public class ManagedCloudSdkServiceTest {
 
     verify(mockUiPresenter)
         .notifyManagedSdkJobSuccess(ManagedSdkJobType.UPDATE, ManagedSdkJobResult.PROCESSED);
+  }
+
+  @Test
+  public void upToDate_sdk_passes_valid_jobSuccessResult() throws ManagedSdkVerificationException {
+    makeMockSdkInstalled(MOCK_SDK_PATH);
+    when(mockManagedCloudSdk.isUpToDate()).thenReturn(true);
+
+    sdkService.update();
+
+    verify(mockUiPresenter)
+        .notifyManagedSdkJobSuccess(ManagedSdkJobType.UPDATE, ManagedSdkJobResult.UP_TO_DATE);
   }
 
   @Test


### PR DESCRIPTION
Closes #673.
Fixes #1992.
Makes sure custom SDK is used by default if custom SDK path was already configured and non-empty.
Fixes #1993.
Resiliency - ensures managed SDK status is correct (calls `install()` regardless of ready or not to double check current SDK state) prior to deployments / local run 
Fixes #1964.
Will not show notification and balloons for managed SDK successful operations if managed SDK was already up-to-date and no install / update actually happened.