### PR TITLE
Marks timer thread as long running to avoid thread leak check.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/CloudDebugProcessStateController.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/debugger/CloudDebugProcessStateController.java
@@ -26,6 +26,7 @@ import com.google.api.services.clouddebugger.v2.model.SetBreakpointResponse;
 import com.google.api.services.clouddebugger.v2.model.SourceLocation;
 import com.google.cloud.tools.intellij.service.PluginInfoService;
 import com.google.cloud.tools.intellij.util.GctBundle;
+import com.google.common.annotations.VisibleForTesting;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -53,6 +54,7 @@ public class CloudDebugProcessStateController {
   private static final int INITIAL_DELAY_MS = 2000;
   private static final Logger LOG = Logger.getInstance(CloudDebugProcessStateController.class);
   private static final int PERIOD_MS = 500;
+  @VisibleForTesting static final String LIST_BREAKPOINTS_TIMER_NAME = "list breakpoints";
   private final List<CloudBreakpointListener> breakpointListChangedListeners = new ArrayList<>();
   private final ConcurrentHashMap<String, Breakpoint> fullFinalBreakpoints =
       new ConcurrentHashMap<>();
@@ -282,7 +284,7 @@ public class CloudDebugProcessStateController {
   public void startBackgroundListening() {
     assert state != null;
     if (listBreakpointsJob == null) {
-      listBreakpointsJob = new Timer("list breakpoints");
+      listBreakpointsJob = new Timer(LIST_BREAKPOINTS_TIMER_NAME);
       final Runnable runnable =
           new Runnable() {
             @Override

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/CloudDebugProcessTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/debugger/CloudDebugProcessTest.java
@@ -42,9 +42,11 @@ import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.actionSystem.IdeActions;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.impl.ProjectImpl;
 import com.intellij.testFramework.PlatformTestCase;
+import com.intellij.testFramework.ThreadTracker;
 import com.intellij.ui.content.Content;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.ui.UIUtil;
@@ -72,6 +74,10 @@ public class CloudDebugProcessTest extends PlatformTestCase {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
+
+    ThreadTracker.longRunningThreadCreated(
+        ApplicationManager.getApplication(),
+        CloudDebugProcessStateController.LIST_BREAKPOINTS_TIMER_NAME);
 
     XDebugSession session = mock(XDebugSession.class);
     when(session.getProject()).thenReturn(this.getProject());


### PR DESCRIPTION
`CloudDebugProcessStateController` uses java `Timer` and although it cancels it, under some timing it might still be finishing at the end of unit test, this check marks this thread "long running".