### PR TITLE
use xi:include to pull in other plugin modules

### DIFF
--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<idea-plugin>
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
   <id>com.google.gct.core</id>
   <name>Google Cloud Tools</name>
   <description>
@@ -360,10 +360,10 @@
     ]]>
   </change-notes>
 
+  <xi:include href="/META-INF/google-cloud-core.xml" xpointer="xpointer(/idea-plugin/*)"/>
   <depends optional="true" config-file="javaee-integration.xml">com.intellij.javaee</depends>
   <depends optional="true" config-file="gwt-integration.xml">com.intellij.gwt</depends>
   <depends optional="true" config-file="google-app-engine-maven-support.xml">org.jetbrains.idea.maven</depends>
-  <depends optional="true" config-file="google-cloud-core.xml">com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>
   <depends>com.intellij.modules.vcs</depends>
   <depends>com.intellij.modules.xml</depends>


### PR DESCRIPTION
This didn't work the last time I tried it, but for some weird reason appears to be working on my machine.

The reason I'm doing this is because using `<depends>` seems to only allow one <depends> per key (e.g. com.intellij.modules.platform), so if I add another `<depends>` with the same key for a GCS module it'll overwrite the core config.