### PR TITLE
Make usage tracker manager a service

### DIFF
--- a/google-cloud-tools-plugin/google-cloud-core/resources/META-INF/google-cloud-core.xml
+++ b/google-cloud-tools-plugin/google-cloud-core/resources/META-INF/google-cloud-core.xml
@@ -36,6 +36,10 @@
     <applicationConfigurable parentId="google.settings"
                              provider="com.google.cloud.tools.intellij.analytics.UsageTrackerConfigurableProvider"/>
 
+
+    <applicationService
+            serviceInterface="com.google.cloud.tools.intellij.analytics.UsageTrackingManagementService"
+            serviceImplementation="com.google.cloud.tools.intellij.analytics.UsageTrackerManager"/>
     <applicationService
             serviceInterface="com.google.cloud.tools.intellij.analytics.UsageTrackerProvider"
             serviceImplementation="com.google.cloud.tools.intellij.analytics.KeyedExtensionUsageTrackerProvider"/>

--- a/google-cloud-tools-plugin/google-cloud-core/resources/META-INF/google-cloud-core.xml
+++ b/google-cloud-tools-plugin/google-cloud-core/resources/META-INF/google-cloud-core.xml
@@ -39,7 +39,7 @@
 
     <applicationService
             serviceInterface="com.google.cloud.tools.intellij.analytics.UsageTrackingManagementService"
-            serviceImplementation="com.google.cloud.tools.intellij.analytics.UsageTrackerManager"/>
+            serviceImplementation="com.google.cloud.tools.intellij.analytics.DefaultUsageTrackingManagementService"/>
     <applicationService
             serviceInterface="com.google.cloud.tools.intellij.analytics.UsageTrackerProvider"
             serviceImplementation="com.google.cloud.tools.intellij.analytics.KeyedExtensionUsageTrackerProvider"/>

--- a/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/DefaultUsageTrackingManagementService.java
+++ b/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/DefaultUsageTrackingManagementService.java
@@ -24,7 +24,7 @@ import com.intellij.util.PlatformUtils;
 import org.jetbrains.annotations.Nullable;
 
 /** Stores the user's choice to opt in/out of sending usage metrics via the Google Usage Tracker. */
-public final class UsageTrackerManager implements UsageTrackingManagementService {
+public final class DefaultUsageTrackingManagementService implements UsageTrackingManagementService {
   @VisibleForTesting
   static final String USAGE_TRACKER_KEY = "GOOGLE_CLOUD_TOOLS_USAGE_TRACKER_OPT_IN";
 
@@ -34,13 +34,14 @@ public final class UsageTrackerManager implements UsageTrackingManagementService
   private PropertiesComponent datastore;
   private PluginFlags flags;
 
-  public UsageTrackerManager() {
+  public DefaultUsageTrackingManagementService() {
     datastore = PropertiesComponent.getInstance();
     flags = new PropertiesFilePluginFlags();
   }
 
   @VisibleForTesting
-  UsageTrackerManager(PropertiesComponent propertiesComponent, PluginFlags flags) {
+  DefaultUsageTrackingManagementService(
+      PropertiesComponent propertiesComponent, PluginFlags flags) {
     this.datastore = propertiesComponent;
     this.flags = flags;
   }

--- a/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/GoogleUsageTracker.java
+++ b/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/GoogleUsageTracker.java
@@ -104,7 +104,7 @@ public class GoogleUsageTracker implements UsageTracker, SendsEvents {
    * environment.
    */
   public GoogleUsageTracker() {
-    analyticsId = UsageTrackerManager.getInstance().getAnalyticsProperty();
+    analyticsId = UsageTrackingManagementService.getInstance().getAnalyticsProperty();
 
     PluginInfoService pluginInfo = ServiceManager.getService(PluginInfoService.class);
     externalPluginName = pluginInfo.getExternalPluginName();
@@ -130,7 +130,7 @@ public class GoogleUsageTracker implements UsageTracker, SendsEvents {
       @NotNull String eventAction,
       @Nullable Map<String, String> metadataMap) {
     if (!ApplicationManager.getApplication().isUnitTestMode()) {
-      if (UsageTrackerManager.getInstance().isTrackingEnabled()) {
+      if (UsageTrackingManagementService.getInstance().isTrackingEnabled()) {
         // For the semantics of each parameter, consult the followings:
         //
         // https://github.com/google/cloud-reporting/blob/master/src/main/java/com/google/cloud/metrics/MetricsUtils.java#L183

--- a/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerConfigurable.java
+++ b/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerConfigurable.java
@@ -27,10 +27,10 @@ import org.jetbrains.annotations.Nullable;
 public class UsageTrackerConfigurable implements Configurable {
 
   private UsageTrackerPanel usageTrackerPanel;
-  private UsageTrackerManager usageTrackerManager;
+  private UsageTrackingManagementService usageTrackerManager;
 
   public UsageTrackerConfigurable() {
-    usageTrackerManager = UsageTrackerManager.getInstance();
+    usageTrackerManager = UsageTrackingManagementService.getInstance();
   }
 
   @Nls

--- a/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerConfigurableProvider.java
+++ b/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerConfigurableProvider.java
@@ -40,6 +40,6 @@ public class UsageTrackerConfigurableProvider extends ConfigurableProvider {
     // other Google related account settings in the IJ UI.
     // Create a sub-menu item for the cloud SDK and hide the usage tracker if not avaible
     return PlatformUtils.isIntelliJ()
-        && UsageTrackerManager.getInstance().isUsageTrackingAvailable();
+        && UsageTrackingManagementService.getInstance().isUsageTrackingAvailable();
   }
 }

--- a/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerManager.java
+++ b/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerManager.java
@@ -24,20 +24,17 @@ import com.intellij.util.PlatformUtils;
 import org.jetbrains.annotations.Nullable;
 
 /** Stores the user's choice to opt in/out of sending usage metrics via the Google Usage Tracker. */
-// TODO: Refactor to an IntelliJ service
-public final class UsageTrackerManager {
+public final class UsageTrackerManager implements UsageTrackingManagementService {
   @VisibleForTesting
   static final String USAGE_TRACKER_KEY = "GOOGLE_CLOUD_TOOLS_USAGE_TRACKER_OPT_IN";
 
   @VisibleForTesting
   static final String USAGE_TRACKER_PROPERTY_PLACEHOLDER = "${usageTrackerProperty}";
 
-  private static UsageTrackerManager instance;
   private PropertiesComponent datastore;
   private PluginFlags flags;
-  private static final Object factoryLock = new Object();
 
-  private UsageTrackerManager() {
+  public UsageTrackerManager() {
     datastore = PropertiesComponent.getInstance();
     flags = new PropertiesFilePluginFlags();
   }
@@ -48,46 +45,29 @@ public final class UsageTrackerManager {
     this.flags = flags;
   }
 
-  /** Return an instance of this manager. */
-  public static UsageTrackerManager getInstance() {
-    synchronized (factoryLock) {
-      if (instance == null) {
-        instance = new UsageTrackerManager();
-      }
-      return instance;
-    }
-  }
-
+  @Override
   public void setTrackingPreference(boolean optIn) {
     datastore.setValue(USAGE_TRACKER_KEY, String.valueOf(optIn));
   }
 
+  @Override
   public boolean hasUserOptedIn() {
     return datastore.getBoolean(USAGE_TRACKER_KEY, false);
   }
 
-  /**
-   * Returns {@code true} if the user has opted in or out of usage tracking, and {@code false} if
-   * the user has yet to indicate a tracking preference.
-   */
+  @Override
   public boolean hasUserRecordedTrackingPreference() {
     return datastore.getValue(USAGE_TRACKER_KEY) != null;
   }
 
-  /**
-   * Indicates whether usage tracking is configured for this plugin's release and platform. This is
-   * independent of whether the user is opted in to usage tracking.
-   *
-   * <p>{@code isUsageTrackingAvailable()} and {@link #hasUserOptedIn()} both need to return {@code
-   * true} for tracking to be enabled. Call {@link #isTrackingEnabled()} to determine whether to do
-   * user tracking.
-   */
+  @Override
   public boolean isUsageTrackingAvailable() {
     return PlatformUtils.isIntelliJ() && (getAnalyticsProperty() != null);
   }
 
+  @Override
   @Nullable
-  protected String getAnalyticsProperty() {
+  public String getAnalyticsProperty() {
     String analyticsId = flags.getAnalyticsId();
     if (!USAGE_TRACKER_PROPERTY_PLACEHOLDER.equals(analyticsId)) {
       return analyticsId;
@@ -95,6 +75,7 @@ public final class UsageTrackerManager {
     return null;
   }
 
+  @Override
   public boolean isTrackingEnabled() {
     return isUsageTrackingAvailable() && hasUserOptedIn();
   }

--- a/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerNotification.java
+++ b/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerNotification.java
@@ -33,10 +33,10 @@ public class UsageTrackerNotification {
 
   private static final Logger LOG = Logger.getInstance(UsageTrackerNotification.class);
   private static final UsageTrackerNotification INSTANCE = new UsageTrackerNotification();
-  private final UsageTrackerManager usageTrackerManager;
+  private final UsageTrackingManagementService usageTrackingManagementService;
 
   private UsageTrackerNotification() {
-    usageTrackerManager = UsageTrackerManager.getInstance();
+    usageTrackingManagementService = UsageTrackingManagementService.getInstance();
   }
 
   public static UsageTrackerNotification getInstance() {
@@ -52,11 +52,10 @@ public class UsageTrackerNotification {
             if (event.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
               final String description = event.getDescription();
               if ("allow".equals(description)) {
-                usageTrackerManager.setTrackingPreference(true);
+                usageTrackingManagementService.setTrackingPreference(true);
                 notification.expire();
               } else if ("decline".equals(description)) {
-                UsageTrackerManager usageTrackerManager = UsageTrackerManager.getInstance();
-                usageTrackerManager.setTrackingPreference(false);
+                usageTrackingManagementService.setTrackingPreference(false);
                 notification.expire();
               } else if ("policy".equals(description)) {
                 try {

--- a/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerPanel.java
+++ b/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerPanel.java
@@ -38,17 +38,17 @@ public class UsageTrackerPanel {
   private JCheckBox enableUsageTrackerBox;
   private JPanel mainPanel;
   private JLabel privacyPolicyText;
-  private UsageTrackerManager usageTrackerManager;
+  private UsageTrackingManagementService usageTrackingManagementService;
 
-  public UsageTrackerPanel(UsageTrackerManager usageTrackerManager) {
-    this.usageTrackerManager = usageTrackerManager;
+  public UsageTrackerPanel(UsageTrackingManagementService usageTrackingManagementService) {
+    this.usageTrackingManagementService = usageTrackingManagementService;
 
-    enableUsageTrackerBox.setSelected(usageTrackerManager.hasUserOptedIn());
+    enableUsageTrackerBox.setSelected(usageTrackingManagementService.hasUserOptedIn());
     privacyPolicyText.setText(
         TrackerMessageBundle.message("settings.privacy.policy.comment", PRIVACY_POLICY_URL));
 
     // Disable checkbox if usage tracker property has not been configured
-    if (!usageTrackerManager.isUsageTrackingAvailable()) {
+    if (!usageTrackingManagementService.isUsageTrackingAvailable()) {
       enableUsageTrackerBox.setEnabled(false);
     }
 
@@ -76,19 +76,19 @@ public class UsageTrackerPanel {
   }
 
   public boolean isModified() {
-    return usageTrackerManager.isUsageTrackingAvailable()
-        && usageTrackerManager.hasUserOptedIn() != enableUsageTrackerBox.isSelected();
+    return usageTrackingManagementService.isUsageTrackingAvailable()
+        && usageTrackingManagementService.hasUserOptedIn() != enableUsageTrackerBox.isSelected();
   }
 
   public void apply() {
-    if (usageTrackerManager.isUsageTrackingAvailable()) {
-      usageTrackerManager.setTrackingPreference(enableUsageTrackerBox.isSelected());
+    if (usageTrackingManagementService.isUsageTrackingAvailable()) {
+      usageTrackingManagementService.setTrackingPreference(enableUsageTrackerBox.isSelected());
     }
   }
 
   public void reset() {
-    if (usageTrackerManager.isUsageTrackingAvailable()) {
-      enableUsageTrackerBox.setSelected(usageTrackerManager.hasUserOptedIn());
+    if (usageTrackingManagementService.isUsageTrackingAvailable()) {
+      enableUsageTrackerBox.setSelected(usageTrackingManagementService.hasUserOptedIn());
     }
   }
 

--- a/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackingManagementService.java
+++ b/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackingManagementService.java
@@ -19,14 +19,10 @@ package com.google.cloud.tools.intellij.analytics;
 import com.intellij.openapi.components.ServiceManager;
 import org.jetbrains.annotations.Nullable;
 
-/**
- * This service provides management APIs for the analytics UI and tracking components.
- */
+/** This service provides management APIs for the analytics UI and tracking components. */
 public interface UsageTrackingManagementService {
 
-  /**
-   * Returns the service bound to this interface in the plugin.xml
-   */
+  /** Returns the service bound to this interface in the plugin.xml */
   static UsageTrackingManagementService getInstance() {
     return ServiceManager.getService(UsageTrackingManagementService.class);
   }
@@ -38,9 +34,7 @@ public interface UsageTrackingManagementService {
    */
   void setTrackingPreference(boolean optIn);
 
-  /**
-   * Returns whether the user is opted in to anonymous usage monitoring or not.
-   */
+  /** Returns whether the user is opted in to anonymous usage monitoring or not. */
   boolean hasUserOptedIn();
 
   /**
@@ -48,7 +42,7 @@ public interface UsageTrackingManagementService {
    * whether the user has set a preference for providing anonymous usage data.
    *
    * @return {@code true} if the user has either consented or declined to provide anonymous usage
-   *        data, and {@code false} if the user has never indicated a preference.
+   *     data, and {@code false} if the user has never indicated a preference.
    */
   boolean hasUserRecordedTrackingPreference();
 
@@ -62,14 +56,12 @@ public interface UsageTrackingManagementService {
    */
   boolean isUsageTrackingAvailable();
 
-  /**
-   * Returns the plugin's analytics ID.
-   */
+  /** Returns the plugin's analytics ID. */
   @Nullable
   String getAnalyticsProperty();
 
   /**
-   * Returns whether tracking is turned on.  This means that the user has explicitly consented to
+   * Returns whether tracking is turned on. This means that the user has explicitly consented to
    * anonymous usage tracking and the plugin is configured with analytics turned on so that usage
    * tracking is possible.
    */

--- a/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackingManagementService.java
+++ b/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackingManagementService.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.analytics;
+
+import com.intellij.openapi.components.ServiceManager;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ *
+ */
+public interface UsageTrackingManagementService {
+
+  /**
+   * Returns the service bound to this interface in the plugin.xml
+   */
+  static UsageTrackingManagementService getInstance() {
+    return ServiceManager.getService(UsageTrackingManagementService.class);
+  }
+
+  /**
+   * Sets the user's preference for whether anonymous usage data should be collected or not.
+   *
+   * @param optIn {@code true} to turn on usage collection or {@code false} otherwise
+   */
+  void setTrackingPreference(boolean optIn);
+
+  /**
+   * Returns whether the user is opted in to anonymous usage monitoring or not.
+   */
+  boolean hasUserOptedIn();
+
+  /**
+   * This method is not to be confused with {@link #hasUserOptedIn()} because it only indicates
+   * whether the user has set a preference for providing anonymous usage data.
+   *
+   * @return {@code true} if the user has either consented or declined to provide anonymous usage
+   *        data, and {@code false} if the user has never indicated a preference.
+   */
+  boolean hasUserRecordedTrackingPreference();
+
+  /**
+   * Indicates whether usage tracking is configured for this plugin's release and platform. This is
+   * independent of whether the user is opted in to usage tracking.
+   *
+   * <p>{@code isUsageTrackingAvailable()} and {@link #hasUserOptedIn()} both need to return {@code
+   * true} for tracking to be enabled. Call {@link #isTrackingEnabled()} to determine whether to do
+   * user tracking.
+   */
+  boolean isUsageTrackingAvailable();
+
+  /**
+   * Returns the plugin's analytics ID.
+   */
+  @Nullable
+  String getAnalyticsProperty();
+
+  /**
+   * Returns whether tracking is turned on.  This means that the user has explicitly consented to
+   * anonymous usage tracking and the plugin is configured with analytics turned on so that usage
+   * tracking is possible.
+   */
+  boolean isTrackingEnabled();
+}

--- a/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackingManagementService.java
+++ b/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackingManagementService.java
@@ -20,7 +20,7 @@ import com.intellij.openapi.components.ServiceManager;
 import org.jetbrains.annotations.Nullable;
 
 /**
- *
+ * This service provides management APIs for the analytics UI and tracking components.
  */
 public interface UsageTrackingManagementService {
 

--- a/google-cloud-tools-plugin/google-cloud-core/testSrc/com/google/cloud/tools/intellij/analytics/UsageTrackerManagerTest.java
+++ b/google-cloud-tools-plugin/google-cloud-core/testSrc/com/google/cloud/tools/intellij/analytics/UsageTrackerManagerTest.java
@@ -30,18 +30,18 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-/** Tests for {@link UsageTrackerManager}. */
+/** Tests for {@link DefaultUsageTrackingManagementService}. */
 @RunWith(MockitoJUnitRunner.class)
 public class UsageTrackerManagerTest {
 
   @Mock private PropertiesComponent mockComponent;
   @Mock private PluginFlags mockFlags;
 
-  private UsageTrackerManager manager;
+  private DefaultUsageTrackingManagementService manager;
 
   @Before
   public void setUp() {
-    manager = new UsageTrackerManager(mockComponent, mockFlags);
+    manager = new DefaultUsageTrackingManagementService(mockComponent, mockFlags);
   }
 
   @Test
@@ -51,13 +51,15 @@ public class UsageTrackerManagerTest {
 
   @Test
   public void testHasUserRecordedTrackingPreference_prefSetToTrue() {
-    when(mockComponent.getValue(UsageTrackerManager.USAGE_TRACKER_KEY)).thenReturn("true");
+    when(mockComponent.getValue(DefaultUsageTrackingManagementService.USAGE_TRACKER_KEY))
+        .thenReturn("true");
     assertTrue(manager.hasUserRecordedTrackingPreference());
   }
 
   @Test
   public void testHasUserRecordedTrackingPreference_prefSetToFalse() {
-    when(mockComponent.getValue(UsageTrackerManager.USAGE_TRACKER_KEY)).thenReturn("false");
+    when(mockComponent.getValue(DefaultUsageTrackingManagementService.USAGE_TRACKER_KEY))
+        .thenReturn("false");
 
     assertTrue(manager.hasUserRecordedTrackingPreference());
   }
@@ -71,7 +73,7 @@ public class UsageTrackerManagerTest {
   @Test
   public void testGetAnalyticsProperty_placeHolderShouldResultInNull() {
     when(mockFlags.getAnalyticsId())
-        .thenReturn(UsageTrackerManager.USAGE_TRACKER_PROPERTY_PLACEHOLDER);
+        .thenReturn(DefaultUsageTrackingManagementService.USAGE_TRACKER_PROPERTY_PLACEHOLDER);
     assertNull(manager.getAnalyticsProperty());
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponent.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponent.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.tools.intellij.startup;
 
-import com.google.cloud.tools.intellij.analytics.UsageTrackingManagementService;
 import com.google.cloud.tools.intellij.analytics.UsageTrackerNotification;
+import com.google.cloud.tools.intellij.analytics.UsageTrackingManagementService;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceManager;
 import com.google.cloud.tools.intellij.login.Services;
 import com.google.cloud.tools.intellij.login.util.TrackerMessageBundle;

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponent.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponent.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.intellij.startup;
 
-import com.google.cloud.tools.intellij.analytics.UsageTrackerManager;
+import com.google.cloud.tools.intellij.analytics.UsageTrackingManagementService;
 import com.google.cloud.tools.intellij.analytics.UsageTrackerNotification;
 import com.google.cloud.tools.intellij.appengine.sdk.CloudSdkServiceManager;
 import com.google.cloud.tools.intellij.login.Services;
@@ -77,9 +77,10 @@ public class CloudToolsPluginInitializationComponent implements ApplicationCompo
    */
   @VisibleForTesting
   void configureUsageTracking() {
-    UsageTrackerManager usageTrackerManager = UsageTrackerManager.getInstance();
-    if (usageTrackerManager.isUsageTrackingAvailable()
-        && !usageTrackerManager.hasUserRecordedTrackingPreference()) {
+    UsageTrackingManagementService usageTrackingManagementService =
+        UsageTrackingManagementService.getInstance();
+    if (usageTrackingManagementService.isUsageTrackingAvailable()
+        && !usageTrackingManagementService.hasUserRecordedTrackingPreference()) {
       NotificationsManager.getNotificationsManager();
       NotificationsConfiguration.getNotificationsConfiguration()
           .register(


### PR DESCRIPTION
Implementing an old to-do to improve testability/mockability of usage tracking.

Will help to fix a few breaking tests in my GCS module refactor.