### PR TITLE
Deflake tests

### DIFF
--- a/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/CloudToolsRule.java
+++ b/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/CloudToolsRule.java
@@ -96,12 +96,12 @@ public final class CloudToolsRule implements TestRule {
 
   /** Sets up utilities before the test runs. */
   private void setUp(Description description) throws Exception {
-    MockitoAnnotations.initMocks(testInstance);
     testFixture =
         IdeaTestFixtureFactory.getFixtureFactory()
             .createFixtureBuilder(description.getMethodName())
             .getFixture();
     testFixture.setUp();
+    MockitoAnnotations.initMocks(testInstance);
 
     populateTestFixture();
     replaceServices();

--- a/google-cloud-tools-plugin/google-cloud-core/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
+++ b/google-cloud-tools-plugin/google-cloud-core/testSrc/com/google/cloud/tools/intellij/project/ProjectSelectionDialogTest.java
@@ -79,7 +79,6 @@ public class ProjectSelectionDialogTest {
     doNothing().when(projectSelectionDialog).installTableSpeedSearch(any());
     doNothing().when(projectSelectionDialog).setLoading(anyBoolean());
 
-    projectSelectionDialog.createUIComponents();
     projectSelectionDialog.loadAllProjects();
 
     testUiProject = CloudProject.create(TEST_PROJECT_NAME, TEST_PROJECT_ID, TEST_USER_EMAIL);


### PR DESCRIPTION
The flake was in ProjectSelectionDialogTest.  @Spy initializes before fixtures are reinitialized and throws errors due to use of disposed elements from previous runs.