### PR TITLE
Create stable copy of DOM element prior to returning it

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryProjectState.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/apis/CloudLibraryProjectState.java
@@ -209,7 +209,12 @@ public class CloudLibraryProjectState implements ProjectComponent {
                       MavenDomUtil.getMavenDomProjectModel(project, mavenProject.getFile());
 
                   return model != null
-                      ? model.getDependencies().getDependencies()
+                      ? model
+                          .getDependencies()
+                          .getDependencies()
+                          .stream()
+                          .map(dependency -> (MavenDomDependency) dependency.createStableCopy())
+                          .collect(Collectors.toList())
                       : ImmutableList.of();
                 });
   }


### PR DESCRIPTION
Small fix for error (shown below) that I occasionally get. This happens when a DOM element that has been invalidated is queried. The solution is to instead return a stable copy of the DOM element. See https://youtrack.jetbrains.com/issue/IDEA-189982 for more info on this.

```
lement: class com.intellij.psi.impl.source.xml.XmlTagImpl because: different providers: SingleRootFileViewProvider{myVirtualFile=file:///usr/local/google/home/eshaul/IdeaProjects/demo-test/pom.xml, content=VirtualFileContent{size=3525}}(161a75ba); SingleRootFileViewProvider{myVirtualFile=file:///usr/local/google/home/eshaul/IdeaProjects/demo-test/pom.xml, content=VirtualFileContent{size=3525}}(864f7d7)
invalidated at: see attachment
com.intellij.psi.PsiInvalidElementAccessException: Element: class com.intellij.psi.impl.source.xml.XmlTagImpl because: different providers: SingleRootFileViewProvider{myVirtualFile=file:///usr/local/google/home/eshaul/IdeaProjects/demo-test/pom.xml, content=VirtualFileContent{size=3525}}(161a75ba); SingleRootFileViewProvider{myVirtualFile=file:///usr/local/google/home/eshaul/IdeaProjects/demo-test/pom.xml, content=VirtualFileContent{size=3525}}(864f7d7)
invalidated at: see attachment
	at com.intellij.util.xml.impl.DomInvocationHandler.getFixedChild(DomInvocationHandler.java:623)
	at com.intellij.util.xml.impl.GetFixedChildInvocation.invoke(GetFixedChildInvocation.java:32)
	at com.intellij.util.xml.impl.DomInvocationHandler.invoke(DomInvocationHandler.java:681)
	at org.jetbrains.idea.maven.dom.model.MavenDomDependency$$EnhancerByJetBrainsMainCglib$$1aa89cdc.getGroupId(<generated>)
	at com.google.cloud.tools.intellij.apis.MavenUtils.lambda$isMavenIdInDependencyList$0(MavenUtils.java:47)
	at java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)
```