### PR TITLE
Adds EAP version support for tests to pass.

### DIFF
--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -31,9 +31,9 @@
     </html>]]>
   </description>
   <vendor>Google</vendor>
-  <!-- "idea-version since-build" set to cover 2017.1 - 2017.3 -->
+  <!-- "idea-version since-build" set to cover 2017.1 - 2018.2 -->
   <!-- Set manually because the gradle-intellij-plugin cannot span across major release versions -->
-  <idea-version since-build="171.3780" until-build="181.*"/>
+  <idea-version since-build="171.3780" until-build="182.*"/>
 
   <change-notes>
     <![CDATA[


### PR DESCRIPTION
Fixes #2030.

After hours of debugging and inital attempt to rewrite all the tests I  figured out our plugin was simply disabled by `PluginManager` since latest EAP version (182.1) doesn't match our version brackets. This fixed it. You can try on your machine changing `ideaVersion = LATEST-EAP-SNAPSHOT` in gradle props.