### PR TITLE
Only return the real UsageTrack impl if not in unit test mode

### DIFF
--- a/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/KeyedExtensionUsageTrackerProvider.java
+++ b/google-cloud-tools-plugin/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/KeyedExtensionUsageTrackerProvider.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.intellij.analytics;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.util.KeyedExtensionCollector;
 import com.intellij.util.PlatformUtils;
 import java.util.Map;
@@ -38,6 +39,10 @@ public final class KeyedExtensionUsageTrackerProvider extends UsageTrackerProvid
   @NotNull
   @Override
   protected UsageTracker getTracker() {
+    if (ApplicationManager.getApplication().isUnitTestMode()) {
+      return new NoOpUsageTracker();
+    }
+
     String key = PlatformUtils.getPlatformPrefix();
     return getTracker(key);
   }


### PR DESCRIPTION
addresses #2031 

Always return the Noop usage tracker in unit test mode.

The previous CI build was failing due to a thread leak caused by the call to `PermanentInstallationId.get()` in `GoogleUsageTracker` (which apparently was fixed in 2018.1). This workaround prevents that call from ever executing in unit test mode.