### PR TITLE
Explicitly bring in proto 2.5 to fix feedback reporting

### DIFF
--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     compile(project(':app-engine:java:ultimate'))
     compile(project(':stackdriver-debugger'))
 
+    compile 'com.google.protobuf:protobuf-java:2.5.0'
     compile 'com.google.apis:google-api-services-clouddebugger:v2-rev7-1.21.0'
     compile 'com.google.apis:google-api-services-cloudresourcemanager:v1beta1-rev12-1.21.0'
     compile 'com.google.apis:google-api-services-iam:v1-rev225-1.22.0'


### PR DESCRIPTION
similar to the problem we had with #1842 

Idea 2018.1 started providing proto 3 which breaks our GoogleFeedback.jar (it made a method overriden there final).

