### PR TITLE
Disable legacy appengine plugin automatically for dev

### DIFF
--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -32,6 +32,13 @@ intellij {
     }
 }
 
+prepareSandbox {
+    copy {
+        from project(":google-cloud-tools-plugin").file("disabled_plugins.txt")
+        into new File(project(":google-cloud-tools-plugin").buildDir, "idea-sandbox/config")
+    }
+}
+
 publishPlugin {
     username System.getenv('IJ_REPO_USERNAME')
     password System.getenv('IJ_REPO_PASSWORD')

--- a/google-cloud-tools-plugin/disabled_plugins.txt
+++ b/google-cloud-tools-plugin/disabled_plugins.txt
@@ -1,0 +1,1 @@
+com.intellij.appengine


### PR DESCRIPTION
fixes #1827 

With this we no longer have to manually disable the legacy plugin (then restart the IDE) after performing a clean. This patches in the necessary file with the exclude into the sandbox directory.