### PR TITLE
Use separate failure / cancel metrics for Managed SDK

### DIFF
--- a/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/GctTracking.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/GctTracking.java
@@ -98,6 +98,8 @@ public class GctTracking {
 
   public static final String MANAGED_SDK_SUCCESSFUL_INSTALL = "managed.sdk.successful.install";
   public static final String MANAGED_SDK_FAILED_INSTALL = "managed.sdk.failed.install";
+  public static final String MANAGED_SDK_CANCELLED_INSTALL = "managed.sdk.cancelled.install";
   public static final String MANAGED_SDK_SUCCESSFUL_UPDATE = "managed.sdk.successful.update";
   public static final String MANAGED_SDK_FAILED_UPDATE = "managed.sdk.failed.update";
+  public static final String MANAGED_SDK_CANCELLED_UPDATE = "managed.sdk.cancelled.install";
 }

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/GctTracking.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/GctTracking.java
@@ -101,5 +101,5 @@ public class GctTracking {
   public static final String MANAGED_SDK_CANCELLED_INSTALL = "managed.sdk.cancelled.install";
   public static final String MANAGED_SDK_SUCCESSFUL_UPDATE = "managed.sdk.successful.update";
   public static final String MANAGED_SDK_FAILED_UPDATE = "managed.sdk.failed.update";
-  public static final String MANAGED_SDK_CANCELLED_UPDATE = "managed.sdk.cancelled.install";
+  public static final String MANAGED_SDK_CANCELLED_UPDATE = "managed.sdk.cancelled.update";
 }


### PR DESCRIPTION
Fixes #2096.

Current Managed SDK implementation reports all install and updates cancellations as generic failures instead of a separate cancel event type which could be deceiving. This PR adds separate metrics for user cancelled installs and updates, and also adds additional information (exception string) in case of a real failure.