### PR TITLE
move cloud sdk specific plugin initialization into appengine module

### DIFF
--- a/app-engine/java/resources/META-INF/app-engine-java.xml
+++ b/app-engine/java/resources/META-INF/app-engine-java.xml
@@ -18,6 +18,8 @@
     <depends>org.jetbrains.plugins.gradle</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
 
+    <xi:include href="/META-INF/app-engine-java-ultimate.xml" xpointer="xpointer(/idea-plugin/*)"/>
+
     <application-components>
         <component>
             <implementation-class>com.google.cloud.tools.intellij.appengine.java.startup.AppEngineInitializationComponent</implementation-class>

--- a/app-engine/java/resources/META-INF/app-engine-java.xml
+++ b/app-engine/java/resources/META-INF/app-engine-java.xml
@@ -18,8 +18,11 @@
     <depends>org.jetbrains.plugins.gradle</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
 
-    <xi:include href="/META-INF/app-engine-java-ultimate.xml" xpointer="xpointer(/idea-plugin/*)"/>
-
+    <application-components>
+        <component>
+            <implementation-class>com.google.cloud.tools.intellij.appengine.java.startup.AppEngineInitializationComponent</implementation-class>
+        </component>
+    </application-components>
     <extensionPoints>
         <extensionPoint name="forbiddenCodeHandler"
                         interface="com.google.cloud.tools.intellij.appengine.java.inspections.AppEngineForbiddenCodeHandler"/>

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/startup/AppEngineInitializationComponent.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/startup/AppEngineInitializationComponent.java
@@ -21,9 +21,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ApplicationComponent;
 import com.intellij.openapi.components.ServiceManager;
 
-/**
- * Run at plugin startup to do App Engine specific plugin initialization.
- */
+/** Run at plugin startup to do App Engine specific plugin initialization. */
 public class AppEngineInitializationComponent implements ApplicationComponent {
 
   @Override

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/startup/AppEngineInitializationComponent.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/startup/AppEngineInitializationComponent.java
@@ -21,6 +21,9 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ApplicationComponent;
 import com.intellij.openapi.components.ServiceManager;
 
+/**
+ * Run at plugin startup to do App Engine specific plugin initialization.
+ */
 public class AppEngineInitializationComponent implements ApplicationComponent {
 
   @Override

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/startup/AppEngineInitializationComponent.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/startup/AppEngineInitializationComponent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.java.startup;
+
+import com.google.cloud.tools.intellij.appengine.java.sdk.CloudSdkServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.ApplicationComponent;
+import com.intellij.openapi.components.ServiceManager;
+
+public class AppEngineInitializationComponent implements ApplicationComponent {
+
+  @Override
+  public void initComponent() {
+    if (!ApplicationManager.getApplication().isUnitTestMode()) {
+      ServiceManager.getService(CloudSdkServiceManager.class).getCloudSdkService().activate();
+    }
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponent.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponent.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.intellij.startup;
 
 import com.google.cloud.tools.intellij.analytics.UsageTrackerNotification;
 import com.google.cloud.tools.intellij.analytics.UsageTrackingManagementService;
-import com.google.cloud.tools.intellij.appengine.java.sdk.CloudSdkServiceManager;
 import com.google.cloud.tools.intellij.appengine.java.startup.ConflictingAppEnginePluginCheck;
 import com.google.cloud.tools.intellij.login.Services;
 import com.google.cloud.tools.intellij.login.util.TrackerMessageBundle;

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponent.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponent.java
@@ -64,10 +64,6 @@ public class CloudToolsPluginInitializationComponent implements ApplicationCompo
 
     new ConflictingAppEnginePluginCheck().notifyIfConflicting();
     new GoogleAccountPluginUninstaller().uninstallIfPresent();
-
-    if (!ApplicationManager.getApplication().isUnitTestMode()) {
-      ServiceManager.getService(CloudSdkServiceManager.class).getCloudSdkService().activate();
-    }
   }
 
   /**

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponentTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponentTest.java
@@ -24,8 +24,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.tools.intellij.appengine.java.sdk.CloudSdkService;
-import com.google.cloud.tools.intellij.appengine.java.sdk.CloudSdkServiceManager;
 import com.google.cloud.tools.intellij.login.IntegratedGoogleLoginService;
 import com.google.cloud.tools.intellij.service.ApplicationPluginInfoService;
 import com.google.cloud.tools.intellij.service.PluginConfigurationService;
@@ -51,7 +49,6 @@ public class CloudToolsPluginInitializationComponentTest extends BasePluginTestC
   @Mock ActionManager actionManager;
   @Mock ApplicationPluginInfoService applicationInfoService;
   @Mock IntegratedGoogleLoginService googleLoginService;
-  @Mock CloudSdkServiceManager cloudSdkServiceManager;
 
   CloudToolsPluginInitializationComponent testComponent;
 
@@ -62,8 +59,6 @@ public class CloudToolsPluginInitializationComponentTest extends BasePluginTestC
     registerService(ActionManager.class, actionManager);
     registerService(ApplicationPluginInfoService.class, applicationInfoService);
     registerService(IntegratedGoogleLoginService.class, googleLoginService);
-    registerService(CloudSdkServiceManager.class, cloudSdkServiceManager);
-    when(cloudSdkServiceManager.getCloudSdkService()).thenReturn(mock(CloudSdkService.class));
 
     testComponent = new CloudToolsPluginInitializationComponent();
   }


### PR DESCRIPTION
this initialization doesn't make sense in environment where the
app engine module isn't available.

related to #1896 