### PR TITLE
remove <module> declarations from our plugin xml files.

### DIFF
--- a/app-engine/java/gradle/resources/META-INF/app-engine-java-gradle.xml
+++ b/app-engine/java/gradle/resources/META-INF/app-engine-java-gradle.xml
@@ -14,7 +14,6 @@
   ~ limitations under the License.
   -->
 <idea-plugin>
-    <module value="com.google.cloud.tools.intellij.appengine-java-gradle"/>
     <depends>org.jetbrains.plugins.gradle</depends>
 
     <extensions defaultExtensionNs="org.jetbrains.plugins.gradle">

--- a/app-engine/java/resources/META-INF/app-engine-java.xml
+++ b/app-engine/java/resources/META-INF/app-engine-java.xml
@@ -14,7 +14,6 @@
   ~ limitations under the License.
   -->
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
-    <module value="com.google.cloud.tools.intellij.appengine-java"/>
     <depends>com.intellij.modules.java</depends>
 
     <xi:include href="/META-INF/stackdriver-debugger.xml" xpointer="xpointer(/idea-plugin/*)"/>

--- a/google-cloud-apis/resources/META-INF/google-cloud-apis.xml
+++ b/google-cloud-apis/resources/META-INF/google-cloud-apis.xml
@@ -15,7 +15,6 @@
   -->
 
 <idea-plugin>
-  <module value="com.google.cloud.tools.intellij.google-cloud-apis"/>
   <depends>org.jetbrains.idea.maven</depends>
 
   <project-components>

--- a/google-cloud-repos/resources/META-INF/google-cloud-repos.xml
+++ b/google-cloud-repos/resources/META-INF/google-cloud-repos.xml
@@ -15,7 +15,6 @@
   -->
 
 <idea-plugin>
-    <module value="com.google.cloud.tools.intellij.google-cloud-repos"/>
 
     <depends>com.intellij.modules.vcs</depends>
     <depends>Git4Idea</depends>

--- a/google-cloud-storage/resources/META-INF/google-cloud-storage.xml
+++ b/google-cloud-storage/resources/META-INF/google-cloud-storage.xml
@@ -15,7 +15,6 @@
   -->
 
 <idea-plugin>
-    <module value="com.google.cloud.tools.intellij.google-cloud-storage"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow id="Google Cloud Storage" anchor="right"

--- a/stackdriver-debugger/resources/META-INF/stackdriver-debugger.xml
+++ b/stackdriver-debugger/resources/META-INF/stackdriver-debugger.xml
@@ -15,7 +15,6 @@
   -->
 
 <idea-plugin>
-    <module value="com.google.cloud.tools.intellij.stackdriver-debugger"/>
     <depends>Git4Idea</depends>
     <depends>com.intellij.modules.vcs</depends>
     <depends>com.intellij.modules.xdebugger</depends>


### PR DESCRIPTION
Based off of [this thread](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000563584-What-is-the-module-element-in-the-plugin-xml-for-?page=1#community_comment_360000188510) ,
it appears that they serve no purpose for custom plugins.