### PR TITLE
Allow users to cancel Managed SDK installation once.

### DIFF
--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkServiceUserSettings.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkServiceUserSettings.java
@@ -39,6 +39,7 @@ public class CloudSdkServiceUserSettings {
       "GCT_CLOUD_SDK_AUTOMATIC_UPDATES";
   private static final String SDK_LAST_AUTOMATIC_UPDATE_TMESTAMP_PROPERTY_NAME =
       "GCT_CLOUD_SDK_LAST_AUTOMATIC_UPDATE_TMESTAMP";
+  private static final String SDK_USER_CANCELLED_INSTALLATION = "SDK_USER_CANCELLED_INSTALLATION";
 
   private PropertiesComponent propertiesComponent = PropertiesComponent.getInstance();
 
@@ -55,6 +56,7 @@ public class CloudSdkServiceUserSettings {
     getInstance().propertiesComponent.unsetValue(CUSTOM_CLOUD_SDK_PATH_PROPERTY_NAME);
     getInstance().propertiesComponent.unsetValue(SDK_AUTOMATIC_UPDATES_PROPERTY_NAME);
     getInstance().propertiesComponent.unsetValue(SDK_LAST_AUTOMATIC_UPDATE_TMESTAMP_PROPERTY_NAME);
+    getInstance().propertiesComponent.unsetValue(SDK_USER_CANCELLED_INSTALLATION);
   }
 
   @NotNull
@@ -108,6 +110,19 @@ public class CloudSdkServiceUserSettings {
         SDK_LAST_AUTOMATIC_UPDATE_TMESTAMP_PROPERTY_NAME,
         Long.toString(timestamp),
         null /* null default not to remove property value. */);
+  }
+
+  boolean isUserCancelledInstallation() {
+    return propertiesComponent.getBoolean(
+        SDK_AUTOMATIC_UPDATES_PROPERTY_NAME,
+        false /* default - user hasn't cancelled SDK installs.*/);
+  }
+
+  void setUserCancelledInstallation(boolean userCancelledInstallation) {
+    propertiesComponent.setValue(
+        SDK_USER_CANCELLED_INSTALLATION,
+        userCancelledInstallation,
+        false /* default - user hasn't cancelled SDK installs.*/);
   }
 
   @VisibleForTesting

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkServiceUserSettings.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkServiceUserSettings.java
@@ -114,8 +114,7 @@ public class CloudSdkServiceUserSettings {
 
   boolean isUserCancelledInstallation() {
     return propertiesComponent.getBoolean(
-        SDK_AUTOMATIC_UPDATES_PROPERTY_NAME,
-        false /* default - user hasn't cancelled SDK installs.*/);
+        SDK_USER_CANCELLED_INSTALLATION, false /* default - user hasn't cancelled SDK installs.*/);
   }
 
   void setUserCancelledInstallation(boolean userCancelledInstallation) {

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkService.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkService.java
@@ -152,7 +152,10 @@ public class ManagedCloudSdkService implements CloudSdkService {
   void initManagedSdk() {
     try {
       managedCloudSdk = createManagedSdk();
-      install();
+      // do not install SDK on activation if user cancelled installation once.
+      if (!CloudSdkServiceUserSettings.getInstance().isUserCancelledInstallation()) {
+        install();
+      }
     } catch (UnsupportedOsException ex) {
       logger.warn("Unsupported OS for Managed Cloud SDK", ex);
       updateStatus(SdkStatus.NOT_AVAILABLE);
@@ -362,6 +365,7 @@ public class ManagedCloudSdkService implements CloudSdkService {
       if (throwable instanceof InterruptedException || throwable instanceof CancellationException) {
         logger.info("Managed Google Cloud SDK install/update cancelled.");
         jobCancelled = true;
+        CloudSdkServiceUserSettings.getInstance().setUserCancelledInstallation(true);
 
         ManagedCloudSdkServiceUiPresenter.getInstance().notifyManagedSdkJobCancellation(jobType);
       } else {

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkService.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkService.java
@@ -357,6 +357,8 @@ public class ManagedCloudSdkService implements CloudSdkService {
       }
 
       ManagedCloudSdkServiceUiPresenter.getInstance().notifyManagedSdkJobSuccess(jobType, result);
+      // no need to abstain from checking install status anymore after success.
+      CloudSdkServiceUserSettings.getInstance().setUserCancelledInstallation(false);
     }
 
     @Override

--- a/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkServiceTest.java
+++ b/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkServiceTest.java
@@ -287,6 +287,22 @@ public class ManagedCloudSdkServiceTest {
   }
 
   @Test
+  public void cancelledInstall_stops_installing_onActivation() throws Exception {
+    emulateMockSdkInstallationProcess(MOCK_SDK_PATH);
+    SdkInstaller sdkInstaller = mockManagedCloudSdk.newInstaller();
+    when(sdkInstaller.install(any(), any())).thenThrow(new CancellationException());
+    when(mockManagedCloudSdk.newInstaller()).thenReturn(sdkInstaller);
+
+    sdkService.install();
+    // cancelled, now attempt to do clean install process and activation.
+    emulateMockSdkInstallationProcess(MOCK_SDK_PATH);
+    sdkService.activate();
+
+    // install is not supposed to run on activation anymore.
+    assertThat(sdkService.getStatus()).isEqualTo(SdkStatus.NOT_AVAILABLE);
+  }
+
+  @Test
   public void successful_update_changesSdkStatus_inProgress() {
     makeMockSdkInstalled(MOCK_SDK_PATH);
     emulateMockSdkUpdateProcess();

--- a/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkServiceTest.java
+++ b/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkServiceTest.java
@@ -56,6 +56,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -107,6 +108,12 @@ public class ManagedCloudSdkServiceTest {
     when(mockUiPresenter.createProgressListener(any())).thenReturn(mockProgressListener);
     // init SDK, most tests require initialized state.
     sdkService.initManagedSdk();
+  }
+
+  @After
+  public void tearDown() {
+    // reset user cancelled flags.
+    CloudSdkServiceUserSettings.reset();
   }
 
   @Test


### PR DESCRIPTION
Fixes #2113.

Improves cancellation process - persists if a user cancelled managed SDK installation and does not attempt it anymore until actual local run or deployment is requested. Users who do not cancel will still have Managed SDK installed at the point of plugin installation. See the issue for more details.