### PR TITLE
Proper application service interface override

### DIFF
--- a/google-cloud-apis/resources/META-INF/google-cloud-apis.xml
+++ b/google-cloud-apis/resources/META-INF/google-cloud-apis.xml
@@ -29,7 +29,8 @@
     <applicationService
         serviceImplementation="com.google.cloud.tools.intellij.cloudapis.CloudApiMavenService"/>
     <applicationService
-            serviceImplementation="com.google.cloud.tools.intellij.cloudapis.ServiceAccountKeyDialogService"/>
+            serviceInterface="com.google.cloud.tools.intellij.cloudapis.ServiceAccountKeyDialogService"
+            serviceImplementation="com.google.cloud.tools.intellij.cloudapis.ServiceAccountKeyCommunityDialogService"/>
 
     <localInspection language="XML" shortName="DependencyVersionWithBom"
         bundle="messages.CloudApisBundle"

--- a/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/ServiceAccountKeyCommunityDialogService.java
+++ b/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/ServiceAccountKeyCommunityDialogService.java
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij.appengine.java.ultimate.cloudapis;
+package com.google.cloud.tools.intellij.cloudapis;
 
-import com.google.cloud.tools.intellij.cloudapis.ServiceAccountKeyDialogService;
 import com.google.cloud.tools.intellij.project.CloudProject;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import org.jetbrains.annotations.Nullable;
 
-/** Application service that provides a handle to the IU's Service Account Key Created dialog */
-public class ServiceAccountKeyUltimateDialogService implements ServiceAccountKeyDialogService {
+/** IDEA Community implementation of the {@link ServiceAccountKeyDialogService} service. */
+public class ServiceAccountKeyCommunityDialogService implements ServiceAccountKeyDialogService {
+
   @Override
   public DialogWrapper getDialog(
       @Nullable Project project, CloudProject cloudProject, String downloadPath) {
-    return new ServiceAccountKeyUltimateDisplayDialog(project, cloudProject, downloadPath);
+    return new ServiceAccountKeyDisplayDialog(project, cloudProject, downloadPath);
   }
 }

--- a/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/ServiceAccountKeyDialogService.java
+++ b/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/ServiceAccountKeyDialogService.java
@@ -22,9 +22,7 @@ import com.intellij.openapi.ui.DialogWrapper;
 import org.jetbrains.annotations.Nullable;
 
 /** Application service that provides the handle to the IC's Service Account Key Created dialog */
-public class ServiceAccountKeyDialogService {
-  public DialogWrapper getDialog(
-      @Nullable Project project, CloudProject cloudProject, String downloadPath) {
-    return new ServiceAccountKeyDisplayDialog(project, cloudProject, downloadPath);
-  }
+public interface ServiceAccountKeyDialogService {
+  DialogWrapper getDialog(
+      @Nullable Project project, CloudProject cloudProject, String downloadPath);
 }


### PR DESCRIPTION
fixes #2125 

The UE service definition in plugin.xml uses an override to inject a different impl for UE. Previously, it was overriding a concrete class (which for some reason was working, but now we get the error in #2125).

This updates the base service to an interface with a CE, and UE implementation.