### PR TITLE
Fix cloud tools action ordering

### DIFF
--- a/app-engine/java/resources/META-INF/app-engine-java.xml
+++ b/app-engine/java/resources/META-INF/app-engine-java.xml
@@ -41,7 +41,9 @@
             <action id="GoogleCloudTools.AppEngineDeploy"
                     class="com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineDeployToolsMenuAction"/>
             <separator/>
-            <add-to-group group-id="GoogleCloudTools"/>
+            <add-to-group group-id="GoogleCloudTools"
+                          relative-to-action="GoogleCloudTools.stackdriver.debugger"
+                          anchor="before"/>
         </group>
     </actions>
 

--- a/google-cloud-apis/resources/META-INF/google-cloud-apis.xml
+++ b/google-cloud-apis/resources/META-INF/google-cloud-apis.xml
@@ -49,7 +49,7 @@
       <action id="GoogleCloudTools.AddCloudLibraries"
           class="com.google.cloud.tools.intellij.cloudapis.AddCloudLibrariesAction"/>
       <separator/>
-      <add-to-group group-id="GoogleCloudTools"/>
+      <add-to-group group-id="GoogleCloudTools" anchor="first"/>
     </group>
   </actions>
 

--- a/google-cloud-storage/resources/META-INF/google-cloud-storage.xml
+++ b/google-cloud-storage/resources/META-INF/google-cloud-storage.xml
@@ -24,7 +24,7 @@
     </extensions>
 
     <actions>
-        <group id="GoogleCloudTools.csr">
+        <group id="GoogleCloudTools.gcs">
             <action id="GoogleCloudTools.CloudStorage"
                     class="com.google.cloud.tools.intellij.gcs.GcsToolWindowAction"/>
             <separator/>

--- a/stackdriver-debugger/resources/META-INF/stackdriver-debugger.xml
+++ b/stackdriver-debugger/resources/META-INF/stackdriver-debugger.xml
@@ -38,7 +38,8 @@
             <action id="GoogleCloudTools.CloudDebugger"
                     class="com.google.cloud.tools.intellij.stackdriver.debugger.CloudDebuggerToolsMenuAction"/>
             <separator/>
-            <add-to-group group-id="GoogleCloudTools"/>
+            <add-to-group group-id="GoogleCloudTools" relative-to-action="GoogleCloudTools.csr"
+                          anchor="before"/>
         </group>
 
         <group id="EditorGutterCloudDebuggerMenu">


### PR DESCRIPTION
fixes #2123 

![image](https://user-images.githubusercontent.com/1735744/40438530-523a95f0-5e86-11e8-8cc8-1f27a5f641fc.png)

This is somewhat brittle still and care will be needed when adding more actions, but the key idea is that the actions defined in modules included optionally (via `depends optional`) are loaded out of band (not in the order they are declared in the plugin.xml). Therefore, those actions need to be defined relative to other actions.