### PR TITLE
Don't exclude metrics from other IDEs

### DIFF
--- a/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/DefaultUsageTrackingManagementService.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/DefaultUsageTrackingManagementService.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.intellij.analytics;
 import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
 import com.google.cloud.tools.intellij.login.PluginFlagsService;
 import com.intellij.ide.util.PropertiesComponent;
-import com.intellij.util.PlatformUtils;
 import org.jetbrains.annotations.Nullable;
 
 /** Stores the user's choice to opt in/out of sending usage metrics via the Google Usage Tracker. */
@@ -62,7 +61,7 @@ public final class DefaultUsageTrackingManagementService implements UsageTrackin
 
   @Override
   public boolean isUsageTrackingAvailable() {
-    return PlatformUtils.isIntelliJ() && (getAnalyticsProperty() != null);
+    return getAnalyticsProperty() != null;
   }
 
   @Override

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerConfigurableProvider.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerConfigurableProvider.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.intellij.analytics;
 
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurableProvider;
-import com.intellij.util.PlatformUtils;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -38,8 +37,7 @@ public class UsageTrackerConfigurableProvider extends ConfigurableProvider {
   public boolean canCreateConfigurable() {
     // For now we can hide Google entirely if usage tracking isn't available as there are no
     // other Google related account settings in the IJ UI.
-    // Create a sub-menu item for the cloud SDK and hide the usage tracker if not avaible
-    return PlatformUtils.isIntelliJ()
-        && UsageTrackingManagementService.getInstance().isUsageTrackingAvailable();
+    // Create a sub-menu item for the cloud SDK and hide the usage tracker if not available
+    return UsageTrackingManagementService.getInstance().isUsageTrackingAvailable();
   }
 }


### PR DESCRIPTION
the last piece towards fixing #2133 

Don't exclude other IJ platforms from metrics and enable the opt-in panel for these other IDEs.