### PR TITLE
CloudSdkServiceManager is null for non IDEA IDEs. Adds null safety.

### DIFF
--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkService.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkService.java
@@ -26,6 +26,9 @@ public interface CloudSdkService {
   /** Shortcut for getting currently active implementation of {@link CloudSdkService}. */
   static CloudSdkService getInstance() {
     CloudSdkServiceManager service = ServiceManager.getService(CloudSdkServiceManager.class);
+
+    // The service itself may be null if used from IDEs where the App Engine integration is not
+    // loaded (due to optional depends).
     return service != null ? service.getCloudSdkService() : null;
   }
 

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkService.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkService.java
@@ -25,7 +25,8 @@ public interface CloudSdkService {
 
   /** Shortcut for getting currently active implementation of {@link CloudSdkService}. */
   static CloudSdkService getInstance() {
-    return ServiceManager.getService(CloudSdkServiceManager.class).getCloudSdkService();
+    CloudSdkServiceManager service = ServiceManager.getService(CloudSdkServiceManager.class);
+    return service != null ? service.getCloudSdkService() : null;
   }
 
   /** Called when this service becomes primary choice for serving Cloud SDK. */


### PR DESCRIPTION
fixes #2138 