### PR TITLE
Add --stacktrace to nightly build for debugging

### DIFF
--- a/kokoro/ubuntu/nightly.sh
+++ b/kokoro/ubuntu/nightly.sh
@@ -46,4 +46,4 @@ nightly_release_date=`date "+%Y%m%d"`
 ./gradlew :google-cloud-tools-plugin:publishPlugin \
     -PijPluginRepoChannel=nightly \
     -PintellijRepoUrl=https://storage.googleapis.com/cloud-tools-for-java-team-kokoro-build-cache/idea-distributions \
-    -Pversion=${nightly_release_date} --info
+    -Pversion=${nightly_release_date} --stacktrace


### PR DESCRIPTION
The nightly release is failing during publish. No useful error is printed. Adding this to debug.