### PR TITLE
Pin objectify to version 5.1.22

### DIFF
--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/standard/AppEngineStandardMavenLibrary.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/standard/AppEngineStandardMavenLibrary.java
@@ -52,7 +52,7 @@ public enum AppEngineStandardMavenLibrary {
       AppEngineMessageBundle.message("appengine.library.objectify.api.name"),
       "com.googlecode.objectify",
       "objectify",
-      AppEngineStandardMavenLibrary.RELEASE_VERSION_ID,
+      "5.1.22",
       DependencyScope.COMPILE);
 
   private final String displayName;


### PR DESCRIPTION
addresses the IJ equivalent issue detailed here https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/3111