### PR TITLE
Enable gradle sync for gradle deployment source support in CE

### DIFF
--- a/google-cloud-core/resources/config.properties
+++ b/google-cloud-core/resources/config.properties
@@ -19,7 +19,7 @@ feature.appengine.flex=true
 feature.managed.sdk=true
 feature.managed.sdk.update=true
 feature.bom=true
-feature.gradle.sync.ce=false
+feature.gradle.sync.ce=true
 
 # Should be used in any Notifications explicitly produced by the plugin.
 notifications.plugin.groupdisplayid=Google App Engine plugin


### PR DESCRIPTION
now that #2120 is merged, we can enable this