### PR TITLE
Do not attempt update sooner than next update period after failed attempt.

### DIFF
--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkServiceUserSettings.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkServiceUserSettings.java
@@ -50,6 +50,10 @@ public class CloudSdkServiceUserSettings {
     return instance;
   }
 
+  /**
+   * The values for these properties persist between unit tests and if set, must be cleaned up
+   * between tests to avoid intermediate state and failures.
+   */
   @VisibleForTesting
   static void reset() {
     getInstance().propertiesComponent.unsetValue(SDK_TYPE_PROPERTY_NAME);

--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkService.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkService.java
@@ -349,7 +349,7 @@ public class ManagedCloudSdkService implements CloudSdkService {
       updateStatus(SdkStatus.READY);
 
       if (result == ManagedSdkJobResult.PROCESSED) {
-        ManagedCloudSdkUpdateService.getInstance().notifySdkUpdate();
+        ManagedCloudSdkUpdateService.getInstance().notifySdkUpdateCompleted();
 
         String trackingEventAction;
         switch (jobType) {
@@ -398,6 +398,9 @@ public class ManagedCloudSdkService implements CloudSdkService {
         case UPDATE:
           // failed or interrupted update might still keep SDK itself installed.
           checkSdkStatusAfterFailedUpdate();
+          // notify updater we've attempted update and schedule next one for the next period to
+          // avoid frequently repeating same errors
+          ManagedCloudSdkUpdateService.getInstance().notifySdkUpdateCompleted();
 
           sendManagedSdkTrackingEvent(
               jobCancelled

--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkUpdateService.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkUpdateService.java
@@ -68,8 +68,11 @@ public class ManagedCloudSdkUpdateService {
     schedule(sdkUpdateTask, getDelayBeforeFirstUpdate(), SDK_UPDATE_INTERVAL_MS);
   }
 
-  /** Called when managed SDK update operation (update or install) successfully completes. */
-  void notifySdkUpdate() {
+  /**
+   * Called when managed SDK update operation (update or install) completes, either with success or
+   * failure.
+   */
+  void notifySdkUpdateCompleted() {
     CloudSdkServiceUserSettings.getInstance().setLastAutomaticUpdateTimestamp(getClock().millis());
   }
 


### PR DESCRIPTION
Fixes #2170.

As of now, update time is not changed if an update failed, only when update succeeds. In this case, when users restart their IDE, Managed SDK updated will attempt to update again, and if the core reason has not been solved (in our case, most of the failures are on Windows and failures cannot be fixed without path changes), the failures will repeat rather frequently.

Update is now scheduled to only run next period (in 7 days) after both failure and success. This should reduce amount of metrics noise and error messages for Windows users who are having troubles updating their Managed Cloud SDK and for other users if they have any issue preventing successful update.