### PR TITLE
Update appengine-plugins-core to the latest 0.6.3

### DIFF
--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/standard/AppEngineStandardStage.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/standard/AppEngineStandardStage.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.intellij.appengine.java.cloud.standard;
 
 import com.google.cloud.tools.appengine.api.AppEngineException;
 import com.google.cloud.tools.appengine.api.deploy.DefaultStageStandardConfiguration;
+import com.google.cloud.tools.appengine.api.deploy.StageStandardConfiguration;
 import com.google.cloud.tools.appengine.cloudsdk.process.LegacyProcessHandler;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessExitListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessHandler;
@@ -60,11 +61,13 @@ public class AppEngineStandardStage {
     ProcessOutputLineListener outputListener = line -> loggingHandler.print(line + "\n");
 
     // TODO determine the default set of flags we want to set for AE standard staging
-    DefaultStageStandardConfiguration stageConfig = new DefaultStageStandardConfiguration();
-    stageConfig.setEnableJarSplitting(true);
     // TODO(joaomartins): Change File to Path on library configs.
-    stageConfig.setStagingDirectory(stagingDirectory.toFile());
-    stageConfig.setSourceDirectory(deploymentArtifactPath.toFile());
+    StageStandardConfiguration stageConfig =
+        new DefaultStageStandardConfiguration.Builder()
+            .setEnableJarSplitting(true)
+            .setStagingDirectory(stagingDirectory.toFile())
+            .setSourceDirectory(deploymentArtifactPath.toFile())
+            .build();
 
     ProcessHandler processHandler =
         LegacyProcessHandler.builder()

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,5 +20,5 @@ intellijRepoUrl = https://www.jetbrains.com/intellij-repository
 javaVersion = 1.8
 ijPluginRepoChannel = alpha
 version = 18.4.2-SNAPSHOT
-toolsLibVersion = 0.6.0
+toolsLibVersion = 0.6.3
 systemProp.idea.log.leaked.projects.in.tests=false


### PR DESCRIPTION
This upgrade should fix the latest critical Cloud SDK installation failure issue (with downgrading the versions and the wrong directory to start the script, see `appengine-plugins-core`). Converted staging attributes to use the new builder pattern.