### PR TITLE
Refactor deployment source collection into extension point based providers

### DIFF
--- a/app-engine/java/resources/META-INF/app-engine-java.xml
+++ b/app-engine/java/resources/META-INF/app-engine-java.xml
@@ -27,6 +27,8 @@
     <extensionPoints>
         <extensionPoint name="forbiddenCodeHandler"
                         interface="com.google.cloud.tools.intellij.appengine.java.inspections.AppEngineForbiddenCodeHandler"/>
+        <extensionPoint name="appEngineDeploymentSourceProvider"
+                        interface="com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineDeploymentSourceProvider"/>
     </extensionPoints>
 
     <actions>
@@ -53,6 +55,16 @@
             <implementation-class>com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardGradleModuleComponent</implementation-class>
         </component>
     </module-components>
+
+
+    <extensions defaultExtensionNs="com.google.gct.core">
+        <appEngineDeploymentSourceProvider
+                implementation="com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineModuleDeploymentSourceProvider"/>
+        <appEngineDeploymentSourceProvider
+                implementation="com.google.cloud.tools.intellij.appengine.java.AppEngineArtifactDeploymentSourceProvider"/>
+        <appEngineDeploymentSourceProvider
+                implementation="com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineGradleDeploymentSourceProvider"/>
+    </extensions>
 
     <extensions defaultExtensionNs="com.intellij">
         <!--<configurationType implementation="com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineServerCommunityConfigurationType"/>-->

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/AppEngineArtifactDeploymentSourceProvider.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/AppEngineArtifactDeploymentSourceProvider.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.java;
+
+import static java.util.stream.Collectors.toList;
+
+import com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineArtifactDeploymentSource;
+import com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineDeploymentSourceProvider;
+import com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineEnvironment;
+import com.google.cloud.tools.intellij.appengine.java.facet.flexible.AppEngineFlexibleFacetType;
+import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardFacetType;
+import com.google.cloud.tools.intellij.appengine.java.project.AppEngineProjectService;
+import com.google.common.collect.Lists;
+import com.intellij.facet.FacetManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.packaging.artifacts.Artifact;
+import com.intellij.packaging.artifacts.ArtifactPointerManager;
+import com.intellij.packaging.impl.artifacts.ArtifactUtil;
+import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
+import java.util.Collection;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/** An {@link AppEngineDeploymentSourceProvider} that collects artifact-based deployment sources. */
+public class AppEngineArtifactDeploymentSourceProvider
+    implements AppEngineDeploymentSourceProvider {
+
+  /**
+   * Collects a list of artifact deployment sources available for deployment to App Engine.
+   *
+   * <p>Artifacts either target the standard or the flexible environment. All standard artifacts are
+   * added. Flexible artifacts are only added if there are no other standard artifacts associated
+   * with the same module.
+   *
+   * @return a list of {@link AppEngineArtifactDeploymentSource}
+   */
+  @Override
+  public List<DeploymentSource> getDeploymentSources(@NotNull Project project) {
+    List<DeploymentSource> sources = Lists.newArrayList();
+    AppEngineProjectService projectService = AppEngineProjectService.getInstance();
+
+    for (Module module : ModuleManager.getInstance(project).getModules()) {
+      FacetManager facetManager = FacetManager.getInstance(module);
+      if (facetManager.getFacetByType(AppEngineStandardFacetType.ID) != null
+          || facetManager.getFacetByType(AppEngineFlexibleFacetType.ID) != null) {
+        final AppEngineEnvironment environment =
+            projectService
+                .getModuleAppEngineEnvironment(module)
+                .orElseThrow(() -> new RuntimeException("No environment."));
+
+        Collection<Artifact> artifacts = ArtifactUtil.getArtifactsContainingModuleOutput(module);
+        sources.addAll(
+            artifacts
+                .stream()
+                .filter(artifact -> doesArtifactMatchEnvironment(artifact, environment))
+                .map(artifact -> createArtifactDeploymentSource(project, artifact, environment))
+                .collect(toList()));
+      }
+    }
+
+    return sources;
+  }
+
+  /** Instantiates a new {@link AppEngineArtifactDeploymentSource}. */
+  private static AppEngineArtifactDeploymentSource createArtifactDeploymentSource(
+      @NotNull Project project,
+      @NotNull Artifact artifact,
+      @NotNull AppEngineEnvironment environment) {
+    ArtifactPointerManager pointerManager = ArtifactPointerManager.getInstance(project);
+
+    return new AppEngineArtifactDeploymentSource(
+        environment, pointerManager.createPointer(artifact));
+  }
+
+  /**
+   * Returns {@code true} if the supplied {@link Artifact} is compatible with the supplied {@link
+   * AppEngineEnvironment}. Returns {@code false} otherwise.
+   */
+  private static boolean doesArtifactMatchEnvironment(
+      Artifact artifact, AppEngineEnvironment environment) {
+    AppEngineProjectService projectService = AppEngineProjectService.getInstance();
+
+    return ((environment.isStandard() || environment.isFlexCompat())
+            && projectService.isAppEngineStandardArtifactType(artifact))
+        || (environment.isFlexible() && projectService.isAppEngineFlexArtifactType(artifact));
+  }
+}

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineDeploymentSourceProvider.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineDeploymentSourceProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.java.cloud;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.project.Project;
+import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An extension point for collecting {@link DeploymentSource deploymentSources}. Implementing
+ * extensions can hook into this to provide custom deployment source collection logic.
+ */
+public interface AppEngineDeploymentSourceProvider {
+  ExtensionPointName<AppEngineDeploymentSourceProvider> EP_NAME =
+      ExtensionPointName.create("com.google.gct.core.appEngineDeploymentSourceProvider");
+
+  List<DeploymentSource> getDeploymentSources(@NotNull Project project);
+}

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineGradleDeploymentSourceProvider.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineGradleDeploymentSourceProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.java.cloud;
+
+import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardFacet;
+import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardGradleModuleComponent;
+import com.google.cloud.tools.intellij.appengine.java.project.AppEngineProjectService;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModulePointerManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
+import com.intellij.util.PlatformUtils;
+import java.util.List;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+
+/** An {@link AppEngineDeploymentSourceProvider} that collects Gradle-based deployment sources. */
+public class AppEngineGradleDeploymentSourceProvider implements AppEngineDeploymentSourceProvider {
+
+  /**
+   * Assembles a list of {@link GradlePluginDeploymentSource} for each module.
+   *
+   * <p>Will create a Gradle plugin deployment source if the module has both the App Engine standard
+   * the App Engine Gradle plugin facet.
+   *
+   * <p>Will only collect deployment sources if the environment is IDEA Community.
+   *
+   * @param project the current {@link Project}
+   * @return a list of {@link GradlePluginDeploymentSource} containing the app-gradle-plugin based
+   *     deployment sources.
+   */
+  @Override
+  public List<DeploymentSource> getDeploymentSources(@NotNull Project project) {
+    if (!PlatformUtils.isIdeaCommunity()) {
+      return ImmutableList.of();
+    }
+
+    AppEngineProjectService projectService = AppEngineProjectService.getInstance();
+    List<DeploymentSource> moduleDeploymentSources = Lists.newArrayList();
+
+    Stream.of(ModuleManager.getInstance(project).getModules())
+        .forEach(
+            module -> {
+              if (projectService.isGradleModule(module)
+                  && AppEngineStandardFacet.hasFacet(module)
+                  && AppEngineStandardGradleModuleComponent.getInstance(module)
+                      .getGradleBuildDir()
+                      .isPresent()) {
+                moduleDeploymentSources.add(
+                    new GradlePluginDeploymentSource(
+                        ModulePointerManager.getInstance(project).create(module)));
+              }
+            });
+
+    return moduleDeploymentSources;
+  }
+}

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineModuleDeploymentSourceProvider.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineModuleDeploymentSourceProvider.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.java.cloud;
+
+import com.google.cloud.tools.intellij.appengine.java.cloud.flexible.UserSpecifiedPathDeploymentSource;
+import com.google.cloud.tools.intellij.appengine.java.facet.flexible.AppEngineFlexibleFacetType;
+import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardFacetType;
+import com.google.cloud.tools.intellij.appengine.java.project.AppEngineProjectService;
+import com.google.common.collect.Lists;
+import com.intellij.facet.FacetManager;
+import com.intellij.openapi.module.JavaModuleType;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModulePointer;
+import com.intellij.openapi.module.ModulePointerManager;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.project.Project;
+import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
+import com.intellij.remoteServer.configuration.deployment.ModuleDeploymentSource;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/** An {@link AppEngineDeploymentSourceProvider} that collects module-based deployment sources. */
+public class AppEngineModuleDeploymentSourceProvider implements AppEngineDeploymentSourceProvider {
+
+  /**
+   * Collects a list of module deployment sources available for deployment to App Engine:
+   *
+   * <p>Maven based deployment sources are included for both flexible and standard projects if
+   * applicable.
+   *
+   * <p>User browsable jar/war deployment sources are included only if there are no App Engine
+   * standard modules.
+   *
+   * @return a list of {@link ModuleDeploymentSource}
+   */
+  @Override
+  public List<DeploymentSource> getDeploymentSources(@NotNull Project project) {
+    AppEngineProjectService projectService = AppEngineProjectService.getInstance();
+
+    List<DeploymentSource> moduleDeploymentSources = Lists.newArrayList();
+
+    boolean hasStandardModules = false;
+
+    for (Module module : ModuleManager.getInstance(project).getModules()) {
+      FacetManager facetManager = FacetManager.getInstance(module);
+      if (facetManager.getFacetByType(AppEngineStandardFacetType.ID) != null
+          || facetManager.getFacetByType(AppEngineFlexibleFacetType.ID) != null) {
+        AppEngineEnvironment environment =
+            projectService
+                .getModuleAppEngineEnvironment(module)
+                .orElseThrow(() -> new RuntimeException("No environment."));
+
+        if (ModuleType.is(module, JavaModuleType.getModuleType())
+            && projectService.isJarOrWarMavenBuild(module)) {
+          moduleDeploymentSources.add(
+              createMavenBuildDeploymentSource(project, module, environment));
+        }
+
+        if (environment.isStandard() || environment.isFlexCompat()) {
+          hasStandardModules = true;
+        }
+      }
+    }
+
+    if (!hasStandardModules) {
+      moduleDeploymentSources.add(createUserSpecifiedPathDeploymentSource(project));
+    }
+
+    return moduleDeploymentSources;
+  }
+
+  private static MavenBuildDeploymentSource createMavenBuildDeploymentSource(
+      @NotNull Project project, @NotNull Module module, @NotNull AppEngineEnvironment environment) {
+    return new MavenBuildDeploymentSource(
+        ModulePointerManager.getInstance(project).create(module), project, environment);
+  }
+
+  private static UserSpecifiedPathDeploymentSource createUserSpecifiedPathDeploymentSource(
+      @NotNull Project project) {
+    ModulePointer modulePointer =
+        ModulePointerManager.getInstance(project)
+            .create(UserSpecifiedPathDeploymentSource.moduleName);
+
+    return new UserSpecifiedPathDeploymentSource(modulePointer);
+  }
+}

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineUtil.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineUtil.java
@@ -18,32 +18,12 @@ package com.google.cloud.tools.intellij.appengine.java.util;
 
 import static java.util.stream.Collectors.toList;
 
-import com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineArtifactDeploymentSource;
-import com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineEnvironment;
-import com.google.cloud.tools.intellij.appengine.java.cloud.GradlePluginDeploymentSource;
-import com.google.cloud.tools.intellij.appengine.java.cloud.MavenBuildDeploymentSource;
-import com.google.cloud.tools.intellij.appengine.java.cloud.flexible.UserSpecifiedPathDeploymentSource;
-import com.google.cloud.tools.intellij.appengine.java.facet.flexible.AppEngineFlexibleFacetType;
-import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardFacet;
-import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardFacetType;
-import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardGradleModuleComponent;
 import com.google.cloud.tools.intellij.appengine.java.project.AppEngineProjectService;
 import com.google.common.collect.Lists;
-import com.intellij.facet.FacetManager;
-import com.intellij.openapi.module.JavaModuleType;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.module.ModulePointer;
-import com.intellij.openapi.module.ModulePointerManager;
-import com.intellij.openapi.module.ModuleType;
-import com.intellij.openapi.project.Project;
 import com.intellij.packaging.artifacts.Artifact;
-import com.intellij.packaging.artifacts.ArtifactPointerManager;
 import com.intellij.packaging.impl.artifacts.ArtifactUtil;
-import com.intellij.remoteServer.configuration.deployment.ModuleDeploymentSource;
 import java.util.Collection;
-import java.util.List;
-import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -54,133 +34,6 @@ public class AppEngineUtil {
 
   private AppEngineUtil() {
     // Not designed for instantiation
-  }
-
-  /**
-   * Creates a list of artifact deployment sources available for deployment to App Engine.
-   *
-   * <p>Artifacts either target the standard or the flexible environment. All standard artifacts are
-   * added. Flexible artifacts are only added if there are no other standard artifacts associated
-   * with the same module.
-   *
-   * @return a list of {@link AppEngineArtifactDeploymentSource}
-   */
-  public static List<AppEngineArtifactDeploymentSource> createArtifactDeploymentSources(
-      @NotNull final Project project) {
-    List<AppEngineArtifactDeploymentSource> sources = Lists.newArrayList();
-    AppEngineProjectService projectService = AppEngineProjectService.getInstance();
-
-    for (Module module : ModuleManager.getInstance(project).getModules()) {
-      FacetManager facetManager = FacetManager.getInstance(module);
-      if (facetManager.getFacetByType(AppEngineStandardFacetType.ID) != null
-          || facetManager.getFacetByType(AppEngineFlexibleFacetType.ID) != null) {
-        final AppEngineEnvironment environment =
-            projectService
-                .getModuleAppEngineEnvironment(module)
-                .orElseThrow(() -> new RuntimeException("No environment."));
-
-        Collection<Artifact> artifacts = ArtifactUtil.getArtifactsContainingModuleOutput(module);
-        sources.addAll(
-            artifacts
-                .stream()
-                .filter(artifact -> doesArtifactMatchEnvironment(artifact, environment))
-                .map(
-                    artifact ->
-                        AppEngineUtil.createArtifactDeploymentSource(
-                            project, artifact, environment))
-                .collect(toList()));
-      }
-    }
-
-    return sources;
-  }
-
-  private static boolean doesArtifactMatchEnvironment(
-      Artifact artifact, AppEngineEnvironment environment) {
-    AppEngineProjectService projectService = AppEngineProjectService.getInstance();
-
-    return ((environment.isStandard() || environment.isFlexCompat())
-            && projectService.isAppEngineStandardArtifactType(artifact))
-        || (environment.isFlexible() && projectService.isAppEngineFlexArtifactType(artifact));
-  }
-
-  /**
-   * Creates a list of module deployment sources available for deployment to App Engine:
-   *
-   * <p>Maven based deployment sources are included for both flexible and standard projects if
-   * applicable.
-   *
-   * <p>User browsable jar/war deployment sources are included only if there are no App Engine
-   * standard modules.
-   *
-   * @return a list of {@link ModuleDeploymentSource}'s
-   */
-  public static List<ModuleDeploymentSource> createModuleDeploymentSources(
-      @NotNull Project project) {
-    AppEngineProjectService projectService = AppEngineProjectService.getInstance();
-
-    List<ModuleDeploymentSource> moduleDeploymentSources = Lists.newArrayList();
-
-    boolean hasStandardModules = false;
-
-    for (Module module : ModuleManager.getInstance(project).getModules()) {
-      FacetManager facetManager = FacetManager.getInstance(module);
-      if (facetManager.getFacetByType(AppEngineStandardFacetType.ID) != null
-          || facetManager.getFacetByType(AppEngineFlexibleFacetType.ID) != null) {
-        AppEngineEnvironment environment =
-            projectService
-                .getModuleAppEngineEnvironment(module)
-                .orElseThrow(() -> new RuntimeException("No environment."));
-
-        if (ModuleType.is(module, JavaModuleType.getModuleType())
-            && projectService.isJarOrWarMavenBuild(module)) {
-          moduleDeploymentSources.add(
-              createMavenBuildDeploymentSource(project, module, environment));
-        }
-
-        if (environment.isStandard() || environment.isFlexCompat()) {
-          hasStandardModules = true;
-        }
-      }
-    }
-
-    if (!hasStandardModules) {
-      moduleDeploymentSources.add(createUserSpecifiedPathDeploymentSource(project));
-    }
-
-    return moduleDeploymentSources;
-  }
-
-  /**
-   * Assembles a list of {@link GradlePluginDeploymentSource} for each module.
-   *
-   * <p>Will create a Gradle plugin deployment source if the module has both the App Engine standard
-   * the App Engine Gradle plugin facet.
-   *
-   * @param project the current {@link Project}
-   * @return a list of {@link ModuleDeploymentSource} containing the app-gradle-plugin based
-   *     deployment sources.
-   */
-  public static List<ModuleDeploymentSource> createGradlePluginDeploymentSources(
-      @NotNull Project project) {
-    AppEngineProjectService projectService = AppEngineProjectService.getInstance();
-    List<ModuleDeploymentSource> moduleDeploymentSources = Lists.newArrayList();
-
-    Stream.of(ModuleManager.getInstance(project).getModules())
-        .forEach(
-            module -> {
-              if (projectService.isGradleModule(module)
-                  && AppEngineStandardFacet.hasFacet(module)
-                  && AppEngineStandardGradleModuleComponent.getInstance(module)
-                      .getGradleBuildDir()
-                      .isPresent()) {
-                moduleDeploymentSources.add(
-                    new GradlePluginDeploymentSource(
-                        ModulePointerManager.getInstance(project).create(module)));
-              }
-            });
-
-    return moduleDeploymentSources;
   }
 
   /**
@@ -202,30 +55,5 @@ public class AppEngineUtil {
     return appEngineStandardArtifacts.size() == 1
         ? appEngineStandardArtifacts.iterator().next()
         : null;
-  }
-
-  private static AppEngineArtifactDeploymentSource createArtifactDeploymentSource(
-      @NotNull Project project,
-      @NotNull Artifact artifact,
-      @NotNull AppEngineEnvironment environment) {
-    ArtifactPointerManager pointerManager = ArtifactPointerManager.getInstance(project);
-
-    return new AppEngineArtifactDeploymentSource(
-        environment, pointerManager.createPointer(artifact));
-  }
-
-  private static MavenBuildDeploymentSource createMavenBuildDeploymentSource(
-      @NotNull Project project, @NotNull Module module, @NotNull AppEngineEnvironment environment) {
-    return new MavenBuildDeploymentSource(
-        ModulePointerManager.getInstance(project).create(module), project, environment);
-  }
-
-  private static UserSpecifiedPathDeploymentSource createUserSpecifiedPathDeploymentSource(
-      @NotNull Project project) {
-    ModulePointer modulePointer =
-        ModulePointerManager.getInstance(project)
-            .create(UserSpecifiedPathDeploymentSource.moduleName);
-
-    return new UserSpecifiedPathDeploymentSource(modulePointer);
   }
 }

--- a/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineDeploymentConfiguratorTest.java
+++ b/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineDeploymentConfiguratorTest.java
@@ -23,24 +23,15 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.intellij.appengine.java.cloud.flexible.AppEngineFlexibleDeploymentEditor;
 import com.google.cloud.tools.intellij.appengine.java.cloud.standard.AppEngineStandardDeploymentEditor;
-import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardFacetType;
-import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardGradleModuleComponent;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
-import com.google.cloud.tools.intellij.testing.ModuleTestUtils;
 import com.google.cloud.tools.intellij.testing.TestFixture;
 import com.google.cloud.tools.intellij.testing.TestModule;
-import com.google.cloud.tools.intellij.testing.TestScopedSystemPropertyRule;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.externalSystem.ExternalSystemModulePropertyManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.remoteServer.configuration.RemoteServer;
 import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
 import com.intellij.testFramework.UsefulTestCase;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
-import com.intellij.util.PlatformUtils;
-import java.util.List;
-import org.jetbrains.plugins.gradle.util.GradleConstants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,10 +46,6 @@ public final class AppEngineDeploymentConfiguratorTest {
 
   @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
   @TestFixture private IdeaProjectTestFixture testFixture;
-
-  @Rule
-  public final TestScopedSystemPropertyRule systemPropertyRule =
-      new TestScopedSystemPropertyRule(PlatformUtils.PLATFORM_PREFIX_KEY);
 
   @Mock private AppEngineDeployable mockAppEngineDeployable;
   @Mock private DeploymentSource mockDeploymentSource;
@@ -115,62 +102,5 @@ public final class AppEngineDeploymentConfiguratorTest {
         configurator.createEditor(mockAppEngineDeployable, mockRemoteServer);
 
     assertThat(editor).isInstanceOf(AppEngineStandardDeploymentEditor.class);
-  }
-
-  @Test
-  public void getDeploymentSources_withCommunityEdition_andGradle_returnsSource() {
-    System.setProperty(PlatformUtils.PLATFORM_PREFIX_KEY, PlatformUtils.IDEA_CE_PREFIX);
-    addAppEngineFacetWithGradleBuildDir();
-
-    assertGradleDeploymentSourceExists();
-  }
-
-  @Test
-  public void getDeploymentSources_withPyCharm_andGradle_returnsEmpty() {
-    System.setProperty(PlatformUtils.PLATFORM_PREFIX_KEY, PlatformUtils.PYCHARM_CE_PREFIX);
-    addAppEngineFacetWithGradleBuildDir();
-
-    assertGradleDeploymentSourcesEmpty();
-  }
-
-  @Test
-  public void getDeploymentSources_withUltimateEdition_andGradle_returnsEmpty() {
-    System.setProperty(PlatformUtils.PLATFORM_PREFIX_KEY, PlatformUtils.IDEA_PREFIX);
-    addAppEngineFacetWithGradleBuildDir();
-
-    assertGradleDeploymentSourcesEmpty();
-  }
-
-  private void assertGradleDeploymentSourceExists() {
-    ApplicationManager.getApplication()
-        .invokeAndWait(
-            () -> {
-              List<DeploymentSource> availableDeploymentSources =
-                  configurator.getAvailableDeploymentSources();
-
-              assertThat(availableDeploymentSources).hasSize(1);
-              assertThat(availableDeploymentSources.get(0))
-                  .isInstanceOf(GradlePluginDeploymentSource.class);
-            });
-  }
-
-  private void assertGradleDeploymentSourcesEmpty() {
-    ApplicationManager.getApplication()
-        .invokeAndWait(
-            () -> {
-              List<DeploymentSource> availableDeploymentSources =
-                  configurator.getAvailableDeploymentSources();
-
-              assertThat(availableDeploymentSources).isEmpty();
-            });
-  }
-
-  private void addAppEngineFacetWithGradleBuildDir() {
-    ModuleTestUtils.addFacet(gradleModule, AppEngineStandardFacetType.ID);
-    ExternalSystemModulePropertyManager.getInstance(gradleModule)
-        .setExternalId(GradleConstants.SYSTEM_ID);
-
-    AppEngineStandardGradleModuleComponent.getInstance(gradleModule)
-        .setGradleBuildDir("/path/to/gradle/build");
   }
 }

--- a/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineGradleDeploymentProviderSourceTest.java
+++ b/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineGradleDeploymentProviderSourceTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij.appengine.java.util;
+package com.google.cloud.tools.intellij.appengine.java.cloud;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -24,65 +24,115 @@ import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.ModuleTestUtils;
 import com.google.cloud.tools.intellij.testing.TestFixture;
 import com.google.cloud.tools.intellij.testing.TestModule;
+import com.google.cloud.tools.intellij.testing.TestScopedSystemPropertyRule;
 import com.intellij.openapi.externalSystem.ExternalSystemModulePropertyManager;
 import com.intellij.openapi.module.Module;
-import com.intellij.remoteServer.configuration.deployment.ModuleDeploymentSource;
+import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
+import com.intellij.util.PlatformUtils;
 import java.util.List;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-/** Tests for {@link AppEngineUtil}. */
-public class AppEngineUtilTest {
+/** Tests for {@link AppEngineGradleDeploymentSourceProvider}. */
+public class AppEngineGradleDeploymentProviderSourceTest {
   @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
+
+  @Rule
+  public final TestScopedSystemPropertyRule systemPropertyRule =
+      new TestScopedSystemPropertyRule(PlatformUtils.PLATFORM_PREFIX_KEY);
+
   @TestFixture private IdeaProjectTestFixture testFixture;
 
   @TestModule private Module module;
 
+  private AppEngineGradleDeploymentSourceProvider gradleDeploymentSourceProvider;
+
+  @Before
+  public void setUp() {
+    gradleDeploymentSourceProvider = new AppEngineGradleDeploymentSourceProvider();
+  }
+
   @Test
   public void createGradleSource_withAppEngineFacet_andGradleBuildDir_returnsGradleSource() {
-    addGradleBuildDir();
-    addAppEngineStandardFacet();
-    enableGradle();
+    System.setProperty(PlatformUtils.PLATFORM_PREFIX_KEY, PlatformUtils.IDEA_CE_PREFIX);
+    initForGradleSources();
 
-    List<ModuleDeploymentSource> sources =
-        AppEngineUtil.createGradlePluginDeploymentSources(testFixture.getProject());
+    List<DeploymentSource> sources =
+        gradleDeploymentSourceProvider.getDeploymentSources(testFixture.getProject());
 
     assertThat(sources).hasSize(1);
+    assertThat(sources.get(0) instanceof GradlePluginDeploymentSource).isTrue();
   }
 
   @Test
   public void createGradleSource_withAppEngineFacet_andGradleBuildDir_withNoGradle_returnsEmpty() {
+    System.setProperty(PlatformUtils.PLATFORM_PREFIX_KEY, PlatformUtils.IDEA_CE_PREFIX);
     addGradleBuildDir();
     addAppEngineStandardFacet();
 
-    List<ModuleDeploymentSource> sources =
-        AppEngineUtil.createGradlePluginDeploymentSources(testFixture.getProject());
+    List<DeploymentSource> sources =
+        gradleDeploymentSourceProvider.getDeploymentSources(testFixture.getProject());
 
     assertThat(sources).isEmpty();
   }
 
   @Test
   public void createGradleSource_withNoAppEngineFacet_returnsEmpty() {
+    System.setProperty(PlatformUtils.PLATFORM_PREFIX_KEY, PlatformUtils.IDEA_CE_PREFIX);
     addGradleBuildDir();
     enableGradle();
 
-    List<ModuleDeploymentSource> sources =
-        AppEngineUtil.createGradlePluginDeploymentSources(testFixture.getProject());
+    List<DeploymentSource> sources =
+        gradleDeploymentSourceProvider.getDeploymentSources(testFixture.getProject());
 
     assertThat(sources).isEmpty();
   }
 
   @Test
   public void createGradleSource_withAppEngineFacet_andNoGradleBuildDir_returnsEmpty() {
+    System.setProperty(PlatformUtils.PLATFORM_PREFIX_KEY, PlatformUtils.IDEA_CE_PREFIX);
     addAppEngineStandardFacet();
     enableGradle();
 
-    List<ModuleDeploymentSource> sources =
-        AppEngineUtil.createGradlePluginDeploymentSources(testFixture.getProject());
+    List<DeploymentSource> sources =
+        gradleDeploymentSourceProvider.getDeploymentSources(testFixture.getProject());
 
     assertThat(sources).isEmpty();
+  }
+
+  @Test
+  public void getDeploymentSources_withPyCharm_returnsEmpty() {
+    System.setProperty(PlatformUtils.PLATFORM_PREFIX_KEY, PlatformUtils.PYCHARM_CE_PREFIX);
+    initForGradleSources();
+
+    List<DeploymentSource> sources =
+        gradleDeploymentSourceProvider.getDeploymentSources(testFixture.getProject());
+
+    assertThat(sources).isEmpty();
+  }
+
+  @Test
+  public void getDeploymentSources_withUltimateEdition_returnsEmpty() {
+    System.setProperty(PlatformUtils.PLATFORM_PREFIX_KEY, PlatformUtils.IDEA_PREFIX);
+    initForGradleSources();
+
+    List<DeploymentSource> sources =
+        gradleDeploymentSourceProvider.getDeploymentSources(testFixture.getProject());
+
+    assertThat(sources).isEmpty();
+  }
+
+  /**
+   * Sets up everything needed for Gradle sources to be collected: adds a gradle build directory,
+   * adds the App Engine standard facet, and enables the Gradle external build system.
+   */
+  private void initForGradleSources() {
+    addGradleBuildDir();
+    addAppEngineStandardFacet();
+    enableGradle();
   }
 
   private void addGradleBuildDir() {


### PR DESCRIPTION
first step towards #2183

In order to extract Maven from the App Engine module, one of the things we need to do is refactor the deployment source collection into extensions which can plug in their own deployment source collection logic. This way, once a maven module is extracted (in subsequent PRs), it can inject its logic for collecting maven sources, thus isolating maven dependencies out of the app engine module.

This PR is a one-to-one refactoring of the previous logic, just with the extension point mechanism. All of the extensions are still in the App Engine module. Also, the Maven deployment source collection is still part of the module deployment source provider. This is to keep things easier to review. The next set of PRs will continue the extraction.

Extension Point: `AppEngineDeploymentSourceProvider`
Extensions:
- `AppEngineArtifactDeploymentSourceProvider` - collects artifact deployment sources
- `AppEngineModuleDeploymentSourceProvider` - collects module deployment sources (including Maven sources, for now)
- `AppEngineGradleDeploymentSourceProvider` - collects gradle plugin based deployment sources