### PR TITLE
Remove duplicate registration of sdk module in test roots

### DIFF
--- a/app-engine/java/gradle/testResources/META-INF/plugin.xml
+++ b/app-engine/java/gradle/testResources/META-INF/plugin.xml
@@ -20,7 +20,6 @@
 
     <xi:include href="/META-INF/google-cloud-core.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/app-engine-java.xml" xpointer="xpointer(/idea-plugin/*)"/>
-    <xi:include href="/META-INF/google-cloud-sdk.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/gwt-integration.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/javaee-integration.xml" xpointer="xpointer(/idea-plugin/*)"/>
 </idea-plugin>

--- a/app-engine/java/maven/testResources/META-INF/plugin.xml
+++ b/app-engine/java/maven/testResources/META-INF/plugin.xml
@@ -21,5 +21,4 @@
     <xi:include href="/META-INF/google-cloud-core.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/app-engine-java.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/app-engine-java-maven.xml" xpointer="xpointer(/idea-plugin/*)"/>
-    <xi:include href="/META-INF/google-cloud-sdk.xml" xpointer="xpointer(/idea-plugin/*)"/>
 </idea-plugin>

--- a/app-engine/java/testResources/META-INF/plugin.xml
+++ b/app-engine/java/testResources/META-INF/plugin.xml
@@ -20,7 +20,6 @@
 
     <xi:include href="/META-INF/google-cloud-core.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/app-engine-java.xml" xpointer="xpointer(/idea-plugin/*)"/>
-    <xi:include href="/META-INF/google-cloud-sdk.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/gwt-integration.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/javaee-integration.xml" xpointer="xpointer(/idea-plugin/*)"/>
 </idea-plugin>


### PR DESCRIPTION
fixes #2186 

`google-cloud-sdk` is xi:include'd from the `app-engine-java`. Including it again on its own resulted in duplicate key exceptions caused by multiple service registration.