### PR TITLE
Move Gradle dependencies out of app-engine

### DIFF
--- a/app-engine/java/build.gradle
+++ b/app-engine/java/build.gradle
@@ -20,7 +20,7 @@ sourceSets.test.java.srcDirs = ['testSrc']
 sourceSets.test.resources.srcDirs = ['testResources', 'testData']
 
 intellij {
-    plugins 'Groovy', 'gradle', 'git4idea', 'properties', 'junit', 'yaml'
+    plugins 'Groovy', 'git4idea', 'properties', 'junit', 'yaml'
 }
 
 dependencies {

--- a/app-engine/java/gradle/resources/META-INF/app-engine-java-gradle.xml
+++ b/app-engine/java/gradle/resources/META-INF/app-engine-java-gradle.xml
@@ -22,7 +22,21 @@
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">
+        <applicationService
+                serviceImplementation="com.google.cloud.tools.intellij.appengine.java.gradle.project.GradleProjectService"/>
+
         <externalProjectDataService
                 implementation="com.google.cloud.tools.intellij.appengine.java.gradle.AppEngineGradleProjectDataService"/>
+
+        <remoteServer.deploymentSource.type
+                implementation="com.google.cloud.tools.intellij.appengine.java.gradle.GradlePluginDeploymentSourceType"/>
+    </extensions>
+
+    <extensions defaultExtensionNs="com.google.gct.core">
+        <appEngineDeploymentSourceProvider
+                implementation="com.google.cloud.tools.intellij.appengine.java.gradle.AppEngineGradleDeploymentSourceProvider"/>
+
+        <appEngineStandardLibraryManager
+                implementation="com.google.cloud.tools.intellij.appengine.java.gradle.AppEngineStandardGradleLibraryManager"/>
     </extensions>
 </idea-plugin>

--- a/app-engine/java/gradle/src/com/google/cloud/tools/intellij/appengine/java/gradle/AppEngineGradleDeploymentSourceProvider.java
+++ b/app-engine/java/gradle/src/com/google/cloud/tools/intellij/appengine/java/gradle/AppEngineGradleDeploymentSourceProvider.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij.appengine.java.cloud;
+package com.google.cloud.tools.intellij.appengine.java.gradle;
 
+import com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineDeploymentSourceProvider;
 import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardFacet;
 import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardGradleModuleComponent;
-import com.google.cloud.tools.intellij.appengine.java.project.AppEngineProjectService;
+import com.google.cloud.tools.intellij.appengine.java.gradle.project.GradleProjectService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.intellij.openapi.module.ModuleManager;
@@ -53,7 +54,7 @@ public class AppEngineGradleDeploymentSourceProvider implements AppEngineDeploym
       return ImmutableList.of();
     }
 
-    AppEngineProjectService projectService = AppEngineProjectService.getInstance();
+    GradleProjectService projectService = GradleProjectService.getInstance();
     List<DeploymentSource> moduleDeploymentSources = Lists.newArrayList();
 
     Stream.of(ModuleManager.getInstance(project).getModules())

--- a/app-engine/java/gradle/src/com/google/cloud/tools/intellij/appengine/java/gradle/AppEngineStandardGradleLibraryManager.java
+++ b/app-engine/java/gradle/src/com/google/cloud/tools/intellij/appengine/java/gradle/AppEngineStandardGradleLibraryManager.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij.appengine.java.facet.standard;
+package com.google.cloud.tools.intellij.appengine.java.gradle;
 
-import com.google.cloud.tools.intellij.appengine.java.project.AppEngineProjectService;
+import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardLibraryManager;
+import com.google.cloud.tools.intellij.appengine.java.gradle.project.GradleProjectService;
 import com.intellij.openapi.module.Module;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,6 +31,6 @@ public class AppEngineStandardGradleLibraryManager implements AppEngineStandardL
    */
   @Override
   public boolean isSupported(@NotNull Module module) {
-    return !AppEngineProjectService.getInstance().isGradleModule(module);
+    return !GradleProjectService.getInstance().isGradleModule(module);
   }
 }

--- a/app-engine/java/gradle/src/com/google/cloud/tools/intellij/appengine/java/gradle/GradlePluginDeploymentSource.java
+++ b/app-engine/java/gradle/src/com/google/cloud/tools/intellij/appengine/java/gradle/GradlePluginDeploymentSource.java
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij.appengine.java.cloud;
+package com.google.cloud.tools.intellij.appengine.java.gradle;
 
+import com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineDeployable;
+import com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineEnvironment;
 import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardGradleModuleComponent;
 import com.intellij.openapi.module.ModulePointer;
 import com.intellij.remoteServer.configuration.deployment.DeploymentSourceType;

--- a/app-engine/java/gradle/src/com/google/cloud/tools/intellij/appengine/java/gradle/GradlePluginDeploymentSourceType.java
+++ b/app-engine/java/gradle/src/com/google/cloud/tools/intellij/appengine/java/gradle/GradlePluginDeploymentSourceType.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij.appengine.java.cloud;
+package com.google.cloud.tools.intellij.appengine.java.gradle;
 
+import com.google.cloud.tools.intellij.appengine.java.cloud.BuildDeploymentSourceType;
 import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardGradleModuleComponent;
 import com.google.common.collect.ImmutableList;
 import com.intellij.execution.BeforeRunTask;

--- a/app-engine/java/gradle/src/com/google/cloud/tools/intellij/appengine/java/gradle/project/GradleProjectService.java
+++ b/app-engine/java/gradle/src/com/google/cloud/tools/intellij/appengine/java/gradle/project/GradleProjectService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.java.gradle.project;
+
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
+import com.intellij.openapi.module.Module;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.gradle.util.GradleConstants;
+
+/** A set of helper methods for dealing with Gradle-based projects * */
+public class GradleProjectService {
+
+  public static GradleProjectService getInstance() {
+    return ServiceManager.getService(GradleProjectService.class);
+  }
+
+  /** Determines if the module is backed by Gradle. */
+  public boolean isGradleModule(@NotNull Module module) {
+    return ExternalSystemApiUtil.isExternalSystemAwareModule(GradleConstants.SYSTEM_ID, module);
+  }
+}

--- a/app-engine/java/gradle/testResources/META-INF/plugin.xml
+++ b/app-engine/java/gradle/testResources/META-INF/plugin.xml
@@ -20,6 +20,5 @@
 
     <xi:include href="/META-INF/google-cloud-core.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/app-engine-java.xml" xpointer="xpointer(/idea-plugin/*)"/>
-    <xi:include href="/META-INF/gwt-integration.xml" xpointer="xpointer(/idea-plugin/*)"/>
-    <xi:include href="/META-INF/javaee-integration.xml" xpointer="xpointer(/idea-plugin/*)"/>
+    <xi:include href="/META-INF/app-engine-java-gradle.xml" xpointer="xpointer(/idea-plugin/*)"/>
 </idea-plugin>

--- a/app-engine/java/gradle/testSrc/com/google/cloud/tools/intellij/appengine/java/gradle/AppEngineGradleDeploymentSourceProviderTest.java
+++ b/app-engine/java/gradle/testSrc/com/google/cloud/tools/intellij/appengine/java/gradle/AppEngineGradleDeploymentSourceProviderTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij.appengine.java.cloud;
+package com.google.cloud.tools.intellij.appengine.java.gradle;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/app-engine/java/gradle/testSrc/com/google/cloud/tools/intellij/appengine/java/gradle/AppEngineStandardGradleLibraryManagerTest.java
+++ b/app-engine/java/gradle/testSrc/com/google/cloud/tools/intellij/appengine/java/gradle/AppEngineStandardGradleLibraryManagerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij.appengine.java.facet.standard;
+package com.google.cloud.tools.intellij.appengine.java.gradle;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/app-engine/java/resources/META-INF/app-engine-java.xml
+++ b/app-engine/java/resources/META-INF/app-engine-java.xml
@@ -64,11 +64,6 @@
                 implementation="com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineArtifactDeploymentSourceProvider"/>
         <appEngineDeploymentSourceProvider
                 implementation="com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineUserSpecifiedPathDeploymentSourceProvider"/>
-        <appEngineDeploymentSourceProvider
-                implementation="com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineGradleDeploymentSourceProvider"/>
-
-        <appEngineStandardLibraryManager
-                implementation="com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardGradleLibraryManager"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">
@@ -99,10 +94,9 @@
         <!-- App Engine Cloud and Deployment Sources Configuration-->
         <remoteServer.type
                 implementation="com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineCloudType"/>
+
         <remoteServer.deploymentSource.type
                 implementation="com.google.cloud.tools.intellij.appengine.java.cloud.flexible.UserSpecifiedPathDeploymentSourceType"/>
-        <remoteServer.deploymentSource.type
-                implementation="com.google.cloud.tools.intellij.appengine.java.cloud.GradlePluginDeploymentSourceType"/>
         <remoteServer.deploymentSource.type
                 implementation="com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineArtifactDeploymentSourceType"/>
 

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/project/AppEngineProjectService.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/project/AppEngineProjectService.java
@@ -95,9 +95,6 @@ public abstract class AppEngineProjectService {
 
   public abstract boolean hasAppEngineFlexFacet(@NotNull Module module);
 
-  /** Determines if the module is backed by gradle. */
-  public abstract boolean isGradleModule(@NotNull Module module);
-
   public abstract Optional<String> getServiceNameFromAppYaml(@NotNull String appYamlPath)
       throws MalformedYamlFileException;
 

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/project/DefaultAppEngineProjectService.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/project/DefaultAppEngineProjectService.java
@@ -30,7 +30,6 @@ import com.intellij.ide.fileTemplates.FileTemplateManager;
 import com.intellij.ide.fileTemplates.FileTemplateUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -60,7 +59,6 @@ import java.util.Optional;
 import java.util.Properties;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.plugins.gradle.util.GradleConstants;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.scanner.ScannerException;
 
@@ -150,11 +148,6 @@ public class DefaultAppEngineProjectService extends AppEngineProjectService {
   @Override
   public boolean hasAppEngineFlexFacet(@NotNull Module module) {
     return FacetManager.getInstance(module).getFacetByType(AppEngineFlexibleFacetType.ID) != null;
-  }
-
-  @Override
-  public boolean isGradleModule(@NotNull Module module) {
-    return ExternalSystemApiUtil.isExternalSystemAwareModule(GradleConstants.SYSTEM_ID, module);
   }
 
   @Nullable


### PR DESCRIPTION
This is the same thing that was done for Maven.

Moves remaining Gradle dependencies out of the app-engine module and into the app-engine gradle module.