### PR TITLE
Fixes appengine-web.xml generation in Ultimate when the web resource dir does not exist

### DIFF
--- a/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
+++ b/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
@@ -96,23 +96,27 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
     }
 
     for (WebRoot webRoot : webRoots) {
-      VirtualFile parent = webRoot.getFile();
-      if (parent != null) {
-        if (WEB_INF.equals(parent.getName())) {
-          return parent;
+      VirtualFile webRootDir = webRoot.getFile();
+      if (webRootDir != null) {
+        if (WEB_INF.equals(webRootDir.getName())) {
+          return webRootDir;
         }
 
-        VirtualFile child = parent.findChild(WEB_INF);
-        if (child != null) {
-          return child;
+        VirtualFile webInfDir = webRootDir.findChild(WEB_INF);
+        if (webInfDir != null) {
+          return webInfDir;
         }
       }
     }
 
     try {
-      VirtualFile webRootFile = webRoots.get(0).getFile();
-      if (webRootFile != null) {
-        return VfsUtil.createDirectoryIfMissing(webRootFile, WEB_INF);
+      VirtualFile webRootDir = webRoots.get(0).getFile();
+      if (webRootDir != null) {
+        return VfsUtil.createDirectoryIfMissing(webRootDir, WEB_INF);
+      } else {
+        // There is a webroot, but the directory does not exist
+        VirtualFile dir = VfsUtil.createDirectories(webRoots.get(0).getDirectoryUrl().substring(7));
+        return VfsUtil.createDirectoryIfMissing(dir, WEB_INF);
       }
     } catch (IOException ioe) {
       LOG.info(ioe);

--- a/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
+++ b/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
@@ -125,6 +125,7 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
           webRoots.stream().map(WebRoot::getFile).filter(Objects::nonNull).findFirst();
 
       if (!webRootDir.isPresent()) {
+        // There is at least one web-root path, but none that exist, select the first and create it
         String presentableUrl = webRoots.get(0).getPresentableUrl();
         if (presentableUrl != null) {
           webRootDir = Optional.ofNullable(VfsUtil.createDirectories(presentableUrl));

--- a/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
+++ b/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
@@ -124,18 +124,15 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
       Optional<VirtualFile> webRootDir =
           webRoots.stream().map(WebRoot::getFile).filter(Objects::nonNull).findFirst();
 
-      if (webRootDir.isPresent()) {
-        return VfsUtil.createDirectoryIfMissing(webRootDir.get(), WEB_INF);
-      } else {
-        // There is at least one web-root path, but none that exist, select the first and create it
+      if (!webRootDir.isPresent()) {
         String presentableUrl = webRoots.get(0).getPresentableUrl();
         if (presentableUrl != null) {
-          VirtualFile newWebRoot = VfsUtil.createDirectories(presentableUrl);
-
-          if (newWebRoot != null) {
-            return VfsUtil.createDirectoryIfMissing(newWebRoot, WEB_INF);
-          }
+          webRootDir = Optional.ofNullable(VfsUtil.createDirectories(presentableUrl));
         }
+      }
+
+      if (webRootDir.isPresent()) {
+        return VfsUtil.createDirectoryIfMissing(webRootDir.get(), WEB_INF);
       }
     } catch (IOException ioe) {
       LOG.warn(ioe);

--- a/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
+++ b/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
@@ -114,9 +114,9 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
       if (webRootDir != null) {
         return VfsUtil.createDirectoryIfMissing(webRootDir, WEB_INF);
       } else {
-        // There is a webroot, but the directory does not exist
-        VirtualFile dir = VfsUtil.createDirectories(webRoots.get(0).getDirectoryUrl().substring(7));
-        return VfsUtil.createDirectoryIfMissing(dir, WEB_INF);
+        // There is a webroot, but the directory does not exist, so create it
+        webRootDir = VfsUtil.createDirectories(webRoots.get(0).getPresentableUrl());
+        return VfsUtil.createDirectoryIfMissing(webRootDir, WEB_INF);
       }
     } catch (IOException ioe) {
       LOG.info(ioe);

--- a/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
+++ b/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
@@ -77,11 +77,17 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
   }
 
   /**
-   * Returns the first WEB-INF folder determined in this order or null if none can be found. 1. If a
-   * WEB-INF folder exists as one of {@code module}'s web resource directories, returns the first
-   * one 2. If a WEB-INF folder is a child of one or more of the web resource directories, returns
-   * the first one 3. Creates a WEB-INF folder in the first web resource directory
+   * Locates a parent directory for placing the generated appengine-web.xml according to the
+   * following strategy:
+   *
+   * <p>Returns the first WEB-INF folder determined in this order or null if none can be found. 1.
+   * If a WEB-INF folder exists as one of {@code module}'s web resource directories, returns the
+   * first one 2. If a WEB-INF folder is a child of one or more of the web resource directories,
+   * returns the first one 3. Creates a WEB-INF folder in the first web resource directory 4. If the
+   * web resource directory is specified but does not exist, create it with a WEB-INF child and
+   * return it
    */
+  // todo refactor this logic
   @Override
   public VirtualFile suggestParentDirectoryForAppEngineWebXml(
       @NotNull Module module, @NotNull ModifiableRootModel rootModel) {
@@ -94,6 +100,7 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
     if (webRoots.isEmpty()) {
       return null;
     }
+
 
     for (WebRoot webRoot : webRoots) {
       VirtualFile webRootDir = webRoot.getFile();
@@ -110,6 +117,7 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
     }
 
     try {
+      // todo this is technically incorrect - it shouldn't just get the first, it should get the first that isn't null
       VirtualFile webRootDir = webRoots.get(0).getFile();
       if (webRootDir != null) {
         return VfsUtil.createDirectoryIfMissing(webRootDir, WEB_INF);

--- a/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegrationTest.java
+++ b/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegrationTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
+import com.google.cloud.tools.intellij.testing.TestDirectory;
 import com.intellij.facet.FacetManager;
 import com.intellij.javaee.web.WebRoot;
 import com.intellij.javaee.web.facet.WebFacet;
@@ -27,6 +28,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +52,8 @@ public class AppEngineStandardUltimateWebIntegrationTest {
   @Mock private VirtualFile mockExistingWebInfDir;
   @Mock private VirtualFile mockNewWebInfDir;
 
-  private static final String WEB_ROOT_PATH = "/path/to/web/root";
+  @TestDirectory(name = "WEB-INF")
+  File testWebInf;
 
   private List<WebRoot> webRoots = new ArrayList<>();
 
@@ -115,13 +118,15 @@ public class AppEngineStandardUltimateWebIntegrationTest {
   @Test
   public void testSuggestParentDirectory_withInvalidWebRoot_andWebRootPath_returnsNewWebInf() {
     when(mockWebRoot.getFile()).thenReturn(null);
-    when(mockWebRoot.getPresentableUrl()).thenReturn(WEB_ROOT_PATH);
+
+    String testWebInfParentDir = testWebInf.getParent();
+    when(mockWebRoot.getPresentableUrl()).thenReturn(testWebInfParentDir);
 
     VirtualFile suggestedDirectory =
         webIntegration.suggestParentDirectoryForAppEngineWebXml(
             mockModule, mockModifiableRootModel);
 
-    assertThat(suggestedDirectory.getPath().endsWith(WEB_ROOT_PATH + "/WEB-INF")).isTrue();
+    assertThat(suggestedDirectory.getPath().endsWith(testWebInf.getAbsolutePath())).isTrue();
   }
 
   @Test

--- a/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegrationTest.java
+++ b/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegrationTest.java
@@ -17,8 +17,6 @@
 package com.google.cloud.tools.intellij.appengine.java.ultimate.impl;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
@@ -39,6 +37,7 @@ import org.mockito.Mock;
 
 /** Tests for {@link AppEngineStandardUltimateWebIntegration}. */
 public class AppEngineStandardUltimateWebIntegrationTest {
+
   @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
 
   private AppEngineStandardUltimateWebIntegration webIntegration;
@@ -47,9 +46,12 @@ public class AppEngineStandardUltimateWebIntegrationTest {
   @Mock private WebFacet mockWebFacet;
   @Mock private FacetManager mockFacetManager;
   @Mock private WebRoot mockWebRoot;
-  @Mock private VirtualFile mockVirtualFile1;
-  @Mock private VirtualFile mockVirtualFile2;
-  @Mock private VirtualFile mockVirtualFile3;
+  @Mock private VirtualFile mockWebRootDir;
+  @Mock private VirtualFile mockExistingWebInfDir;
+  @Mock private VirtualFile mockNewWebInfDir;
+
+  private static final String WEB_ROOT_PATH = "/path/to/web/root";
+
   private List<WebRoot> webRoots = new ArrayList<>();
 
   @Before
@@ -57,14 +59,14 @@ public class AppEngineStandardUltimateWebIntegrationTest {
     webIntegration = new AppEngineStandardUltimateWebIntegration();
     webRoots.add(mockWebRoot);
 
-    when(mockVirtualFile1.getFileSystem()).thenReturn(LocalFileSystem.getInstance());
-    when(mockVirtualFile1.createChildDirectory(
+    when(mockWebRootDir.getFileSystem()).thenReturn(LocalFileSystem.getInstance());
+    when(mockWebRootDir.createChildDirectory(
             LocalFileSystem.getInstance(), AppEngineStandardUltimateWebIntegration.WEB_INF))
-        .thenReturn(mockVirtualFile3);
-    when(mockVirtualFile1.findChild(AppEngineStandardUltimateWebIntegration.WEB_INF))
-        .thenReturn(mockVirtualFile2);
-    when(mockVirtualFile1.getName()).thenReturn("someName");
-    when(mockWebRoot.getFile()).thenReturn(mockVirtualFile1);
+        .thenReturn(mockNewWebInfDir);
+    when(mockWebRootDir.findChild(AppEngineStandardUltimateWebIntegration.WEB_INF))
+        .thenReturn(mockExistingWebInfDir);
+    when(mockWebRootDir.getName()).thenReturn("someName");
+    when(mockWebRoot.getFile()).thenReturn(mockWebRootDir);
     when(mockWebFacet.getWebRoots()).thenReturn(webRoots);
     when(mockFacetManager.getFacetsByType(WebFacet.ID))
         .thenReturn(Collections.singletonList(mockWebFacet));
@@ -72,47 +74,60 @@ public class AppEngineStandardUltimateWebIntegrationTest {
   }
 
   @Test
-  public void testSuggestParentDirectoryForAppEngineWebXml_noWebResourceDir() {
+  public void testSuggestParentDirectory_withNoWebRoot_returnsNull() {
     webRoots.clear();
 
     VirtualFile suggestedDirectory =
         webIntegration.suggestParentDirectoryForAppEngineWebXml(
             mockModule, mockModifiableRootModel);
-    assertNull(suggestedDirectory);
+    assertThat(suggestedDirectory).isNull();
   }
 
   @Test
-  public void testSuggestParentDirectoryForAppEngineWebXml_noWebInfFolderInResourceDir() {
-    when(mockVirtualFile1.findChild(AppEngineStandardUltimateWebIntegration.WEB_INF))
+  public void testSuggestParentDirectory_withNoWebInfInWebRoot_returnsNewWebInfDir() {
+    when(mockWebRootDir.findChild(AppEngineStandardUltimateWebIntegration.WEB_INF))
         .thenReturn(null);
 
     VirtualFile suggestedDirectory =
         webIntegration.suggestParentDirectoryForAppEngineWebXml(
             mockModule, mockModifiableRootModel);
-    assertEquals(mockVirtualFile3, suggestedDirectory);
+    assertThat(suggestedDirectory).isEqualTo(mockNewWebInfDir);
   }
 
   @Test
-  public void testSuggestParentDirectoryForAppEngineWebXml_withWebInfFolderInResourceDir() {
+  public void testSuggestParentDirectory_withWebInfFolderInWebRoot_returnsExistingWebInfDir() {
     VirtualFile suggestedDirectory =
         webIntegration.suggestParentDirectoryForAppEngineWebXml(
             mockModule, mockModifiableRootModel);
-    assertEquals(mockVirtualFile2, suggestedDirectory);
+    assertThat(suggestedDirectory).isEqualTo(mockExistingWebInfDir);
   }
 
   @Test
-  public void testSuggestParentDirectoryForAppEngineWebXml_withWebInfFolderAsResourceDir() {
-    when(mockVirtualFile1.getName()).thenReturn(AppEngineStandardUltimateWebIntegration.WEB_INF);
+  public void testSuggestParentDirectory_withWebInfFolderAsResourceDir_returnsWebRootDir() {
+    when(mockWebRootDir.getName()).thenReturn(AppEngineStandardUltimateWebIntegration.WEB_INF);
 
     VirtualFile suggestedDirectory =
         webIntegration.suggestParentDirectoryForAppEngineWebXml(
             mockModule, mockModifiableRootModel);
-    assertEquals(mockVirtualFile1, suggestedDirectory);
+    assertThat(suggestedDirectory).isEqualTo(mockWebRootDir);
   }
 
   @Test
-  public void malformedWebRoot_noFile_suggestsNullDirectory() {
+  public void testSuggestParentDirectory_withInvalidWebRoot_andWebRootPath_returnsNewWebInf() {
     when(mockWebRoot.getFile()).thenReturn(null);
+    when(mockWebRoot.getPresentableUrl()).thenReturn(WEB_ROOT_PATH);
+
+    VirtualFile suggestedDirectory =
+        webIntegration.suggestParentDirectoryForAppEngineWebXml(
+            mockModule, mockModifiableRootModel);
+
+    assertThat(suggestedDirectory.getPath().endsWith(WEB_ROOT_PATH + "/WEB-INF")).isTrue();
+  }
+
+  @Test
+  public void testSuggestParentDirectory_withInvalidWebRoot_andNoWebRootPath_returnsNull() {
+    when(mockWebRoot.getFile()).thenReturn(null);
+    when(mockWebRoot.getPresentableUrl()).thenReturn(null);
 
     VirtualFile suggestedDirectory =
         webIntegration.suggestParentDirectoryForAppEngineWebXml(

--- a/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegrationTest.java
+++ b/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegrationTest.java
@@ -37,31 +37,20 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 
-/**
- * Tests for {@link AppEngineStandardUltimateWebIntegration}.
- */
+/** Tests for {@link AppEngineStandardUltimateWebIntegration}. */
 public class AppEngineStandardUltimateWebIntegrationTest {
 
-  @Rule
-  public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
+  @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
 
   private AppEngineStandardUltimateWebIntegration webIntegration;
-  @Mock
-  private Module mockModule;
-  @Mock
-  private ModifiableRootModel mockModifiableRootModel;
-  @Mock
-  private WebFacet mockWebFacet;
-  @Mock
-  private FacetManager mockFacetManager;
-  @Mock
-  private WebRoot mockWebRoot;
-  @Mock
-  private VirtualFile mockWebRootDir;
-  @Mock
-  private VirtualFile mockExistingWebInfDir;
-  @Mock
-  private VirtualFile mockNewWebInfDir;
+  @Mock private Module mockModule;
+  @Mock private ModifiableRootModel mockModifiableRootModel;
+  @Mock private WebFacet mockWebFacet;
+  @Mock private FacetManager mockFacetManager;
+  @Mock private WebRoot mockWebRoot;
+  @Mock private VirtualFile mockWebRootDir;
+  @Mock private VirtualFile mockExistingWebInfDir;
+  @Mock private VirtualFile mockNewWebInfDir;
 
   @TestDirectory(name = "WEB-INF")
   File testWebInf;
@@ -75,7 +64,7 @@ public class AppEngineStandardUltimateWebIntegrationTest {
 
     when(mockWebRootDir.getFileSystem()).thenReturn(LocalFileSystem.getInstance());
     when(mockWebRootDir.createChildDirectory(
-        LocalFileSystem.getInstance(), AppEngineStandardUltimateWebIntegration.WEB_INF))
+            LocalFileSystem.getInstance(), AppEngineStandardUltimateWebIntegration.WEB_INF))
         .thenReturn(mockNewWebInfDir);
     when(mockWebRootDir.findChild(AppEngineStandardUltimateWebIntegration.WEB_INF))
         .thenReturn(mockExistingWebInfDir);
@@ -137,8 +126,11 @@ public class AppEngineStandardUltimateWebIntegrationTest {
         webIntegration.suggestParentDirectoryForAppEngineWebXml(
             mockModule, mockModifiableRootModel);
 
-    assertThat(new File(suggestedDirectory.getPath()).getAbsolutePath()
-        .endsWith(testWebInf.getAbsolutePath())).isTrue();
+    assertThat(
+            new File(suggestedDirectory.getPath())
+                .getAbsolutePath()
+                .endsWith(testWebInf.getAbsolutePath()))
+        .isTrue();
   }
 
   @Test

--- a/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegrationTest.java
+++ b/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegrationTest.java
@@ -37,20 +37,31 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 
-/** Tests for {@link AppEngineStandardUltimateWebIntegration}. */
+/**
+ * Tests for {@link AppEngineStandardUltimateWebIntegration}.
+ */
 public class AppEngineStandardUltimateWebIntegrationTest {
 
-  @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
+  @Rule
+  public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
 
   private AppEngineStandardUltimateWebIntegration webIntegration;
-  @Mock private Module mockModule;
-  @Mock private ModifiableRootModel mockModifiableRootModel;
-  @Mock private WebFacet mockWebFacet;
-  @Mock private FacetManager mockFacetManager;
-  @Mock private WebRoot mockWebRoot;
-  @Mock private VirtualFile mockWebRootDir;
-  @Mock private VirtualFile mockExistingWebInfDir;
-  @Mock private VirtualFile mockNewWebInfDir;
+  @Mock
+  private Module mockModule;
+  @Mock
+  private ModifiableRootModel mockModifiableRootModel;
+  @Mock
+  private WebFacet mockWebFacet;
+  @Mock
+  private FacetManager mockFacetManager;
+  @Mock
+  private WebRoot mockWebRoot;
+  @Mock
+  private VirtualFile mockWebRootDir;
+  @Mock
+  private VirtualFile mockExistingWebInfDir;
+  @Mock
+  private VirtualFile mockNewWebInfDir;
 
   @TestDirectory(name = "WEB-INF")
   File testWebInf;
@@ -64,7 +75,7 @@ public class AppEngineStandardUltimateWebIntegrationTest {
 
     when(mockWebRootDir.getFileSystem()).thenReturn(LocalFileSystem.getInstance());
     when(mockWebRootDir.createChildDirectory(
-            LocalFileSystem.getInstance(), AppEngineStandardUltimateWebIntegration.WEB_INF))
+        LocalFileSystem.getInstance(), AppEngineStandardUltimateWebIntegration.WEB_INF))
         .thenReturn(mockNewWebInfDir);
     when(mockWebRootDir.findChild(AppEngineStandardUltimateWebIntegration.WEB_INF))
         .thenReturn(mockExistingWebInfDir);
@@ -126,7 +137,8 @@ public class AppEngineStandardUltimateWebIntegrationTest {
         webIntegration.suggestParentDirectoryForAppEngineWebXml(
             mockModule, mockModifiableRootModel);
 
-    assertThat(suggestedDirectory.getPath().endsWith(testWebInf.getAbsolutePath())).isTrue();
+    assertThat(new File(suggestedDirectory.getPath()).getAbsolutePath()
+        .endsWith(testWebInf.getAbsolutePath())).isTrue();
   }
 
   @Test

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponentTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/startup/CloudToolsPluginInitializationComponentTest.java
@@ -16,9 +16,8 @@
 
 package com.google.cloud.tools.intellij.startup;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -28,39 +27,41 @@ import com.google.cloud.tools.intellij.login.IntegratedGoogleLoginService;
 import com.google.cloud.tools.intellij.service.ApplicationPluginInfoService;
 import com.google.cloud.tools.intellij.service.PluginConfigurationService;
 import com.google.cloud.tools.intellij.service.PluginInfoService;
-import com.google.cloud.tools.intellij.testing.BasePluginTestCase;
+import com.google.cloud.tools.intellij.testing.CloudToolsRule;
+import com.google.cloud.tools.intellij.testing.TestService;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 /** Tests to validate initialization on supported platforms */
-@RunWith(MockitoJUnitRunner.class)
-public class CloudToolsPluginInitializationComponentTest extends BasePluginTestCase {
+public class CloudToolsPluginInitializationComponentTest {
+
+  @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
 
   private static final String PLUGIN_ID_STRING = "com.google.gct.core";
-  @Mock PluginInfoService pluginInfoService;
-  @Mock PluginConfigurationService pluginConfigurationService;
-  @Mock ActionManager actionManager;
-  @Mock ApplicationPluginInfoService applicationInfoService;
-  @Mock IntegratedGoogleLoginService googleLoginService;
+  @Mock Disposable disposable;
+  @Mock @TestService PluginInfoService pluginInfoService;
+  @Mock @TestService PluginConfigurationService pluginConfigurationService;
+  @Mock @TestService ApplicationPluginInfoService applicationInfoService;
+  @Mock @TestService IntegratedGoogleLoginService googleLoginService;
 
+  private Application application;
   CloudToolsPluginInitializationComponent testComponent;
 
   @Before
   public void registerMockServices() {
-    registerService(PluginInfoService.class, pluginInfoService);
-    registerService(PluginConfigurationService.class, pluginConfigurationService);
-    registerService(ActionManager.class, actionManager);
-    registerService(ApplicationPluginInfoService.class, applicationInfoService);
-    registerService(IntegratedGoogleLoginService.class, googleLoginService);
-
     testComponent = new CloudToolsPluginInitializationComponent();
+    application = ApplicationManager.getApplication();
+  }
+
+  @After
+  public void tearDown() {
+    ApplicationManager.setApplication(application, disposable);
   }
 
   @Test
@@ -82,7 +83,7 @@ public class CloudToolsPluginInitializationComponentTest extends BasePluginTestC
   public void testInitComponent_usageTrackingIsEnabled() {
     Application mockApplication = spy(ApplicationManager.getApplication());
     when(mockApplication.isUnitTestMode()).thenReturn(false);
-    ApplicationManager.setApplication(mockApplication, mock(Disposable.class));
+    ApplicationManager.setApplication(mockApplication, disposable);
     testComponent = spy(new CloudToolsPluginInitializationComponent());
     doNothing().when(testComponent).configureUsageTracking();
     testComponent.initComponent();
@@ -93,7 +94,7 @@ public class CloudToolsPluginInitializationComponentTest extends BasePluginTestC
   public void testInitComponent_usageTrackingIsDisabled() {
     Application mockApplication = spy(ApplicationManager.getApplication());
     when(mockApplication.isUnitTestMode()).thenReturn(true);
-    ApplicationManager.setApplication(mockApplication, mock(Disposable.class));
+    ApplicationManager.setApplication(mockApplication, disposable);
     testComponent = spy(new CloudToolsPluginInitializationComponent());
     testComponent.initComponent();
     verify(testComponent, never()).configureUsageTracking();


### PR DESCRIPTION
Progress towards #1948 and #2191 

Updates the `appengine-web.xml` parent directory discovery logic for Ultimate Edition as follows:
- Added: If the web resource directory has a path specified, but that path does not map to a valid directory (which is the case when you import a vanilla Maven or Gradle Spring boot project), it will create that directory recursively (including all of the parent directories, under the project)
- Fixed: If there are no WEB-INF folders found within the available web-roots, instead of just choosing the first one to try and create a WEB-INF, now it will first try and find one that is a valid directory

In addition to new tests, I also cleaned up existing ones as they were pretty hard to follow before.

Example of what happens when importing Spring Boot Maven project now:


1) create a plain Maven WAR Spring Boot project (I used the initializr):
<img width="745" alt="screen shot 2018-06-27 at 9 10 43 pm" src="https://user-images.githubusercontent.com/1735744/42007511-9561cb58-7a4e-11e8-8bd7-15fb7bbf918e.png">

2) project is created. it is not yet an app-engine project:
<img width="356" alt="screen shot 2018-06-27 at 9 11 40 pm" src="https://user-images.githubusercontent.com/1735744/42007534-b6132356-7a4e-11e8-9f3f-486c27229515.png">

3) Notice the defaulted web resource directory on the web facet. This directory does not yet exist:
<img width="754" alt="screen shot 2018-06-27 at 9 12 43 pm" src="https://user-images.githubusercontent.com/1735744/42007575-e7975d98-7a4e-11e8-91af-4669912ffdac.png">

4) Add appengine-standard support via the cloud tools menu. Notice that the appengine-web.xml is created in the correct location (previously it was not created at all):
<img width="334" alt="screen shot 2018-06-27 at 9 14 01 pm" src="https://user-images.githubusercontent.com/1735744/42007600-0a9634ae-7a4f-11e8-9df2-73a4feef861e.png">

Now deploy and local run work right away, avoiding the error in #2191