### PR TITLE
Fix NPE when no GCP project is selected and user types in repository selector.

### DIFF
--- a/google-cloud-core/src/com/google/cloud/tools/intellij/ui/CustomizableComboBox.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/ui/CustomizableComboBox.java
@@ -156,6 +156,12 @@ public abstract class CustomizableComboBox extends JPanel {
     }
   }
 
+  @Override
+  public void setEnabled(boolean enabled) {
+    textField.setEnabled(enabled);
+    themedCombo.setEnabled(enabled);
+  }
+
   protected abstract CustomizableComboBoxPopup getPopup();
 
   protected abstract int getPreferredPopupHeight();

--- a/google-cloud-repos/src/com/google/cloud/tools/intellij/csr/SetupCloudRepositoryDialog.java
+++ b/google-cloud-repos/src/com/google/cloud/tools/intellij/csr/SetupCloudRepositoryDialog.java
@@ -65,6 +65,10 @@ public class SetupCloudRepositoryDialog extends DialogWrapper {
     setOKActionEnabled(false);
 
     projectSelector.loadActiveCloudProject();
+
+    if (projectSelector.getSelectedProject() == null) {
+      repositorySelector.setEnabled(false);
+    }
   }
 
   /** Return the project ID selected by the user. */
@@ -129,10 +133,15 @@ public class SetupCloudRepositoryDialog extends DialogWrapper {
   }
 
   private void updateRepositorySelector(CloudProject cloudProject) {
-    repositorySelector.setCloudProject(cloudProject);
-    repositorySelector.setText("");
-    repositorySelector.loadRepositories();
-    updateButtons();
+    if (cloudProject != null) {
+      repositorySelector.setEnabled(true);
+      repositorySelector.setCloudProject(cloudProject);
+      repositorySelector.setText("");
+      repositorySelector.loadRepositories();
+      updateButtons();
+    } else {
+      repositorySelector.setEnabled(false);
+    }
   }
 
   private void updateButtons() {

--- a/google-cloud-repos/src/com/google/cloud/tools/intellij/csr/SetupCloudRepositoryDialog.java
+++ b/google-cloud-repos/src/com/google/cloud/tools/intellij/csr/SetupCloudRepositoryDialog.java
@@ -137,6 +137,13 @@ public class SetupCloudRepositoryDialog extends DialogWrapper {
 
   private void updateButtons() {
     CloudProject selectedProject = projectSelector.getSelectedProject();
+    if (selectedProject == null) {
+      setErrorText(
+          CloudReposMessageBundle.message("cloud.repository.selector.missing.project.error"));
+      setOKActionEnabled(false);
+      return;
+    }
+
     Optional<CredentialedUser> user =
         Services.getLoginService().getLoggedInUser(selectedProject.googleUsername());
 


### PR DESCRIPTION
Fixes #2212.

`updateButtons()` is called when user types in repository selector and that led to NPE when no GCP project was pre-selected.