### PR TITLE
Choose from available web-roots more intelligently during appengine-web.xml generation

### DIFF
--- a/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
+++ b/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
@@ -121,19 +121,27 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
     }
 
     try {
-      Optional<VirtualFile> webRootDir =
+      Optional<VirtualFile> webRootDirOptional =
           webRoots.stream().map(WebRoot::getFile).filter(Objects::nonNull).findFirst();
 
-      if (!webRootDir.isPresent()) {
-        // There is at least one web-root path, but none that exist, select the first and create it
-        String presentableUrl = webRoots.get(0).getPresentableUrl();
+      if (!webRootDirOptional.isPresent()) {
+        // There is at least one web-root path, but none that exist, find a suitable one and create
+        // it
+        String presentableUrl = findWebRootPath(webRoots);
         if (presentableUrl != null) {
-          webRootDir = Optional.ofNullable(VfsUtil.createDirectories(presentableUrl));
+          webRootDirOptional = Optional.ofNullable(VfsUtil.createDirectories(presentableUrl));
         }
       }
 
-      if (webRootDir.isPresent()) {
-        return VfsUtil.createDirectoryIfMissing(webRootDir.get(), WEB_INF);
+      if (webRootDirOptional.isPresent()) {
+        VirtualFile webRootDir = webRootDirOptional.get();
+
+        // If the webroot's leaf directory is already WEB-INF, no need to create it
+        if (WEB_INF.equals(webRootDir.getName())) {
+          return webRootDir;
+        }
+
+        return VfsUtil.createDirectoryIfMissing(webRootDir, WEB_INF);
       }
     } catch (IOException ioe) {
       LOG.warn(ioe);
@@ -218,6 +226,34 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
   @Override
   public void setupDevServer() {
     getOrCreateAppServer();
+  }
+
+  /**
+   * Given a non-empty list of {@link WebRoot} tries to locate a "suitable" one and returns its
+   * path.
+   *
+   * <p>First attempts to find a web root with a root relative path to the deployment root, i.e.
+   * "/".
+   *
+   * <p>If none exist with a root relative path, simply grab the first web root and return its path.
+   */
+  @Nullable
+  private String findWebRootPath(List<WebRoot> webRoots) {
+    if (webRoots.isEmpty()) {
+      return null;
+    }
+
+    // TODO test that "/" check works in Windows
+    Optional<String> rootPath =
+        webRoots
+            .stream()
+            .filter(
+                webRoot ->
+                    webRoot.getRelativePath() == null || "/".equals(webRoot.getRelativePath()))
+            .findAny()
+            .map(WebRoot::getPresentableUrl);
+
+    return rootPath.orElseGet(() -> webRoots.get(0).getPresentableUrl());
   }
 
   private static ApplicationServer getOrCreateAppServer() {

--- a/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
+++ b/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
@@ -243,7 +243,6 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
       return null;
     }
 
-    // TODO test that "/" check works in Windows
     Optional<String> rootPath =
         webRoots
             .stream()

--- a/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegrationTest.java
+++ b/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegrationTest.java
@@ -134,6 +134,22 @@ public class AppEngineStandardUltimateWebIntegrationTest {
   }
 
   @Test
+  public void testSuggestParentDirectory_withWebRootEndingWithWebInf_returnsWebInfDir() {
+    when(mockWebRoot.getFile()).thenReturn(null);
+    when(mockWebRoot.getPresentableUrl()).thenReturn(testWebInf.getAbsolutePath());
+
+    VirtualFile suggestedDirectory =
+        webIntegration.suggestParentDirectoryForAppEngineWebXml(
+            mockModule, mockModifiableRootModel);
+
+    assertThat(
+            new File(suggestedDirectory.getPath())
+                .getAbsolutePath()
+                .endsWith(testWebInf.getAbsolutePath()))
+        .isTrue();
+  }
+
+  @Test
   public void testSuggestParentDirectory_withInvalidWebRoot_andNoWebRootPath_returnsNull() {
     when(mockWebRoot.getFile()).thenReturn(null);
     when(mockWebRoot.getPresentableUrl()).thenReturn(null);


### PR DESCRIPTION
Fixes #2223 

See the bug for more details of what was happening.

Previously, when no web root physically existed on the filesystem (but were defined in the IDE), then the 1st one was always chosen. In this case, the web root was:

`../webapp/WEB-INF`

The code was always generating a WEB-INF in the web root causing the double WEB-INF bug.

The fix here does 2 things:
1) Chooses from the available web roots slightly more intelligently: it attempts to find the web root that has a root relative path to the deployment root directory, i.e "/". See the second table entry in this screenshot for an idea of what I mean:
![image](https://user-images.githubusercontent.com/1735744/42965364-c6776fb6-8b67-11e8-8367-b82a481412e9.png)
If none is available, then just take the first web root as before**
2) Given the webroot path, only generate a `WEB-INF` folder if the leaf folder of the webroot isn't already `WEB-INF` (imagine that in the screenshot above, the first entry in the table was all that existed: in this case, the WEB-INF will not be created after the web root is created since it already exists in the web root.).

** I didn't go farther than this on purpose. The user can enter arbitrary values for the web root and the relative path to the deployment root so it becomes messy (and unreliable) to do any deduction beyond what I described in step 1.