### PR TITLE
Allow multiple projects with the same name in project selector.

### DIFF
--- a/google-cloud-core/src/com/google/cloud/tools/intellij/project/ProjectLoader.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/project/ProjectLoader.java
@@ -29,8 +29,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 /** Loads list of {@link Project} for a {@link CredentialedUser}. */
 class ProjectLoader {
@@ -54,11 +52,7 @@ class ProjectLoader {
         cloudResourceManagerClient.projects().list().setPageSize(PROJECTS_MAX_PAGE_SIZE).execute();
 
     if (response != null && response.getProjects() != null) {
-      // Create a sorted set to sort the projects list by project name.
-      Set<Project> allProjects =
-          new TreeSet<>(Comparator.comparing(project -> project.getName().toLowerCase()));
-
-      allProjects.addAll(response.getProjects());
+      List<Project> allProjects = new ArrayList<>(response.getProjects());
 
       while (!Strings.isNullOrEmpty(response.getNextPageToken())) {
         response =
@@ -78,6 +72,9 @@ class ProjectLoader {
           .filter((project) -> !Strings.isNullOrEmpty(project.getProjectId()))
           // Add remaining projects to the set.
           .forEach(result::add);
+
+      // sort the projects list by project name. project names are not unique.
+      result.sort(Comparator.comparing(project -> project.getName().toLowerCase()));
     }
 
     return result;

--- a/google-cloud-core/testSrc/com/google/cloud/tools/intellij/project/ProjectLoaderTest.java
+++ b/google-cloud-core/testSrc/com/google/cloud/tools/intellij/project/ProjectLoaderTest.java
@@ -112,6 +112,23 @@ public class ProjectLoaderTest {
   }
 
   @Test
+  public void loadUserProjects_keeps_projectsWithSameName() {
+    // two projects with the same name, different IDs.
+    Project project1 = new Project();
+    String sameProjectName = "project";
+    project1.setName(sameProjectName);
+    project1.setProjectId("GCP ID 1");
+    Project project2 = new Project();
+    project2.setName(sameProjectName);
+    project2.setProjectId("GCP ID 2");
+    mockListProjectsResponse(Arrays.asList(project1, project2));
+
+    projectLoader.loadUserProjectsInBackground(mockUser);
+
+    verify(mockFutureCallback).onSuccess(Arrays.asList(project1, project2));
+  }
+
+  @Test
   public void deletedProjects_filteredFromResult() {
     List<Project> projects = Arrays.asList(testProject1, testProject2);
     testProject1.setLifecycleState("DELETE_REQUESTED");


### PR DESCRIPTION
Fixes #2221.

We incorrectly used a sorted set based on project names when preparing list of projects for the project selector, thus allowing only one project with a same name although names are not unique. Set is replaced with a list which is sorted at the end instead.