### PR TITLE
update target build version to latest IDE GA version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 ideaEdition = IU
-ideaVersion = 2018.1
+ideaVersion = 2018.2
 intellijRepoUrl = https://www.jetbrains.com/intellij-repository
 javaVersion = 1.8
 ijPluginRepoChannel = alpha


### PR DESCRIPTION
fixes #2227 

I left the "previous version" CI to 2017.3 since that CI is meant to target the previous _major_ (this is loosely defined anyway, but I take to mean each yearly release) version.