### PR TITLE
Increase border spacing for IDEA 2018.2 look and feel update.

### DIFF
--- a/google-cloud-core/src/com/google/cloud/tools/intellij/project/ProjectSelector.form
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/project/ProjectSelector.form
@@ -2,7 +2,7 @@
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.cloud.tools.intellij.project.ProjectSelector">
   <grid id="27dc6" binding="rootPanel" layout-manager="BorderLayout" hgap="1" vgap="0">
     <constraints>
-      <xy x="20" y="20" width="500" height="24"/>
+      <xy x="20" y="20" width="500" height="30"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -12,7 +12,7 @@
         <properties/>
       </component>
       <grid id="60529" binding="wrapperBorderPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
+        <margin top="2" left="1" bottom="2" right="1"/>
         <constraints border-constraint="Center"/>
         <properties/>
         <border type="none"/>


### PR DESCRIPTION
Fixes #2168.

IDEA 2018.2 introduces slightly more compact and "flat" default look and feel while hyperlinks now take a couple pixels more space. This fix adds a small margin to accomodate for that and ensure hyperlink is not clipped.

Mac (2018.2):

<img width="546" alt="screen shot 2018-08-17 at 12 07 29 pm" src="https://user-images.githubusercontent.com/11686100/44276830-c1405880-a216-11e8-876c-fc7f3d1750ec.png">

Unix (2018.2):
![selector-2018-2-idea](https://user-images.githubusercontent.com/11686100/44276859-d6b58280-a216-11e8-9d47-9445fd99d05d.png)

Older versions with a new design:
![selector-margin-old-version](https://user-images.githubusercontent.com/11686100/44276979-3c097380-a217-11e8-8578-6a047882c71a.png)

