### PR TITLE
Reduce log level for a common exception to avoid plugin crash reporting.

### DIFF
--- a/stackdriver-debugger/src/com/google/cloud/tools/intellij/stackdriver/debugger/CloudDebugProcessStateController.java
+++ b/stackdriver-debugger/src/com/google/cloud/tools/intellij/stackdriver/debugger/CloudDebugProcessStateController.java
@@ -273,7 +273,7 @@ public class CloudDebugProcessStateController {
                   handler.onError(StackdriverDebuggerBundle.getString("clouddebug.no.response"));
                 }
               } catch (IOException ex) {
-                LOG.error("exception setting a breakpoint", ex);
+                LOG.warn("exception setting a breakpoint", ex);
                 handler.onError(ex.toString());
               }
             });


### PR DESCRIPTION
Fixes #2233.

IDE's `error()` reports an error as a fatal one, causing this error report to be created. Network exceptions are expected and should be handled properly with a simple warning.