### PR TITLE
Hide module selection UI for generic Cloud API dialog by default

### DIFF
--- a/google-cloud-apis/java-apis/maven-apis/testSrc/com/google/cloud/tools/intellij/cloudapis/maven/MavenCloudApiUiExtensionTest.java
+++ b/google-cloud-apis/java-apis/maven-apis/testSrc/com/google/cloud/tools/intellij/cloudapis/maven/MavenCloudApiUiExtensionTest.java
@@ -38,7 +38,6 @@ import com.google.cloud.tools.libraries.json.CloudLibrary;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.intellij.icons.AllIcons.General;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.Result;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.module.Module;
@@ -201,9 +200,10 @@ public class MavenCloudApiUiExtensionTest {
   public void noAvailableBomVersions_hidesBomUi() {
     when(mavenService.getAllBomVersions()).thenReturn(ImmutableList.of());
 
-    ApplicationManager.getApplication()
-        .invokeAndWait(
-            () -> {
+    MavenTestUtils.getInstance()
+        .runWithMavenModule(
+            testFixture.getProject(),
+            module -> {
               mavenCloudApiUiExtension.createCustomUiComponents();
               BomComboBox bomComboBox = mavenCloudApiUiExtension.getBomComboBox();
               bomComboBox.populateBomVersions(testFixture.getProject(), module1);
@@ -259,6 +259,13 @@ public class MavenCloudApiUiExtensionTest {
 
               assertThat(bomComboBox.getSelectedItem()).isEqualTo(preconfigureBomVersion);
             });
+  }
+
+  @Test
+  public void nonMaven_ideProject_extensionUi_notCreated() {
+    // not setting up any Maven modules should result in extension components not created at all.
+    assertThat(mavenCloudApiUiExtension.createCustomUiComponents().size()).isEqualTo(0);
+    assertThat(mavenCloudApiUiExtension.getBomComboBox()).isNull();
   }
 
   private void writeBomDependency(Module module, String bomVersion) {

--- a/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/CloudApiUiPresenter.java
+++ b/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/CloudApiUiPresenter.java
@@ -45,6 +45,11 @@ public interface CloudApiUiPresenter {
   /** Obtains currently selected module for current IDE project. */
   Module getSelectedModule();
 
+  /**
+   * Enables module selection UI. Makes module selector combo box and its label available to a user.
+   */
+  void enableModuleSelection();
+
   /** Changes Cloud API dialog title. */
   void setCloudApiDialogTitle(@NotNull String title);
 

--- a/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/DefaultCloudApiUiPresenter.java
+++ b/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/DefaultCloudApiUiPresenter.java
@@ -35,7 +35,6 @@ import org.jetbrains.annotations.Nullable;
  * extension points.
  */
 public class DefaultCloudApiUiPresenter implements CloudApiUiPresenter {
-
   private Project project;
   private AddCloudLibrariesDialog addCloudLibrariesDialog;
   private GoogleCloudApiSelectorPanel cloudApiSelectorPanel;
@@ -50,6 +49,11 @@ public class DefaultCloudApiUiPresenter implements CloudApiUiPresenter {
   @Override
   public Module getSelectedModule() {
     return cloudApiSelectorPanel.getSelectedModule();
+  }
+
+  @Override
+  public void enableModuleSelection() {
+    cloudApiSelectorPanel.enableModuleSelection();
   }
 
   @Override

--- a/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/GoogleCloudApiSelectorPanel.java
+++ b/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/GoogleCloudApiSelectorPanel.java
@@ -107,6 +107,10 @@ public final class GoogleCloudApiSelectorPanel {
     panel.setPreferredSize(new Dimension(800, 600));
 
     projectSelector.loadActiveCloudProject();
+
+    // by default for all IDEs module selection is hidden since the action is module-independent.
+    modulesLabel.setVisible(false);
+    modulesComboBox.setVisible(false);
   }
 
   /** Returns the {@link JPanel} that holds the UI elements in this panel. */
@@ -200,6 +204,14 @@ public final class GoogleCloudApiSelectorPanel {
         extensionComponentPanels.get(nextLocation).add(extensionComponents.get(nextLocation));
       }
     }
+  }
+
+  /**
+   * Enables module selection UI. Makes module selector combo box and its label available to a user.
+   */
+  void enableModuleSelection() {
+    modulesLabel.setVisible(true);
+    modulesComboBox.setVisible(true);
   }
 
   /**


### PR DESCRIPTION
Fixes #2241.

Hides module selection by default for all IDEs Cloud API selection dialog since a module is not relevant for service accounts / API enablement. Only Maven project will expose both module selection and BOM selection.

Generic version, GoLand (and any other IDE):
![cloud-api-final-go](https://user-images.githubusercontent.com/11686100/44423759-eacdec80-a554-11e8-94f4-c8b05a124e5f.png)

Java version, non-Maven project:
![cloudapi-final-java](https://user-images.githubusercontent.com/11686100/44423669-b4906d00-a554-11e8-8613-431880218167.png)

Java version, Maven project:
![cloud-api-final-maven](https://user-images.githubusercontent.com/11686100/44423685-bce8a800-a554-11e8-994a-4e3b2fc65833.png)

