### PR TITLE
Disable cloud api continue button if GCP project not selected and no client library support

### DIFF
--- a/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/AddCloudLibrariesDialog.java
+++ b/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/AddCloudLibrariesDialog.java
@@ -50,9 +50,11 @@ final class AddCloudLibrariesDialog extends DialogWrapper {
 
     cloudApiSelectorPanel = new GoogleCloudApiSelectorPanel(libraries, project);
     cloudApiSelectorPanel.addModuleSelectionListener(
-        listener -> setOKActionEnabled(isReadyToSubmit()));
+        listener -> setOKActionEnabled(isReadyToContinue()));
     cloudApiSelectorPanel.addTableModelListener(
-        cloudProject -> setOKActionEnabled(isReadyToSubmit()));
+        cloudProject -> setOKActionEnabled(isReadyToContinue()));
+    cloudApiSelectorPanel.addCloudProjectSelectionListener(
+        cloudProject -> setOKActionEnabled(isReadyToContinue()));
 
     init();
 
@@ -68,7 +70,7 @@ final class AddCloudLibrariesDialog extends DialogWrapper {
     super.init();
     setTitle(GoogleCloudApisMessageBundle.message("cloud.libraries.dialog.title"));
     updateOKButtonText(GoogleCloudApisMessageBundle.message("cloud.libraries.ok.button.text"));
-    setOKActionEnabled(isReadyToSubmit());
+    setOKActionEnabled(isReadyToContinue());
   }
 
   /** Exposes OK button text setter for use by UI extensions via {@link CloudApiUiPresenter} */
@@ -204,7 +206,17 @@ final class AddCloudLibrariesDialog extends DialogWrapper {
     return cloudApiSelectorPanel.getPanel();
   }
 
-  private boolean isReadyToSubmit() {
-    return getSelectedModule() != null && !getSelectedLibraries().isEmpty();
+  /**
+   * Returns {@code true} if the dialog is ready to continue to the next state, and {@code false}
+   * otherwise.
+   *
+   * <p>The dialog is considered ready if a module is selected and at least one library has been
+   * selected. Also, a Cloud Project selection is required if the client library functionality is
+   * disabled (tested by checking if the module combobox is hidden).
+   */
+  private boolean isReadyToContinue() {
+    return getSelectedModule() != null
+        && (cloudApiSelectorPanel.getModulesComboBox().isVisible() || getCloudProject() != null)
+        && !getSelectedLibraries().isEmpty();
   }
 }

--- a/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/GoogleCloudApiSelectorPanel.java
+++ b/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/GoogleCloudApiSelectorPanel.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.intellij.cloudapis;
 
 import com.google.cloud.tools.intellij.cloudapis.CloudApiUiExtension.EXTENSION_UI_COMPONENT_LOCATION;
 import com.google.cloud.tools.intellij.project.CloudProject;
+import com.google.cloud.tools.intellij.project.ProjectSelectionListener;
 import com.google.cloud.tools.intellij.project.ProjectSelector;
 import com.google.cloud.tools.libraries.json.CloudLibrary;
 import com.google.common.annotations.VisibleForTesting;
@@ -126,6 +127,11 @@ public final class GoogleCloudApiSelectorPanel {
   /** Adds the given {@link TableModelListener} to the {@link TableModel}. */
   void addTableModelListener(TableModelListener listener) {
     cloudLibrariesTable.getModel().addTableModelListener(listener);
+  }
+
+  /** Adds the given {@link ProjectSelectionListener} to the {@link ProjectSelector}. */
+  void addCloudProjectSelectionListener(ProjectSelectionListener listener) {
+    projectSelector.addProjectSelectionListener(listener);
   }
 
   /** Returns the selected {@link Module}. */


### PR DESCRIPTION
fixes #2248 

@ivanporty ptal. This PR disables the "continue" action in the API dialog if:

1) There is no client library functionality (tested by checking if the module selector is hidden -> this is less then ideal, so I'm open to suggestions to improve this)
**&&**
2) There is no GCP project

In other words, if the only functionality of the dialog is to manage APIs, then the user _must_ select a GCP project before continuing. Before, the user could continue and the dialog would just close and do nothing (which is strange behavior).