### PR TITLE
Better handling of Cloud SDK version parse error

### DIFF
--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineDeploy.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineDeploy.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.intellij.appengine.java.cloud;
 import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
 import com.google.cloud.tools.appengine.api.AppEngineException;
 import com.google.cloud.tools.appengine.api.deploy.DefaultDeployConfiguration;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkOutOfDateException;
 import com.google.cloud.tools.appengine.cloudsdk.process.LegacyProcessHandler;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessExitListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessHandler;
@@ -147,9 +148,14 @@ public class AppEngineDeploy {
             .build();
 
     // show a warning notification if the cloud sdk version is not supported
-    CloudSdkVersionNotifier.getInstance().notifyIfUnsupportedVersion();
+    CloudSdkVersionNotifier.getInstance().notifyIfVersionOutOfDate();
+    CloudSdkVersionNotifier.getInstance().notifyIfVersionParseError();
 
-    helper.createGcloud(loggingHandler).newDeployment(processHandler).deploy(configuration);
+    try {
+      helper.createGcloud(loggingHandler).newDeployment(processHandler).deploy(configuration);
+    } catch (CloudSdkOutOfDateException ex) {
+      logger.warn("Error during deployment because because Cloud SDK version out of date");
+    }
   }
 
   public AppEngineHelper getHelper() {

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/executor/AppEngineStandardRunTask.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/executor/AppEngineStandardRunTask.java
@@ -79,6 +79,7 @@ public class AppEngineStandardRunTask extends AppEngineTask {
   public void execute(ProcessStartListener startListener) {
     // show a warning notification if the cloud sdk version is not supported
     CloudSdkVersionNotifier.getInstance().notifyIfVersionOutOfDate();
+    CloudSdkVersionNotifier.getInstance().notifyIfVersionParseError();
 
     CloudSdkService instance = CloudSdkService.getInstance();
     CloudSdk.Builder sdkBuilder =

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/executor/AppEngineStandardRunTask.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/executor/AppEngineStandardRunTask.java
@@ -78,7 +78,7 @@ public class AppEngineStandardRunTask extends AppEngineTask {
   @Override
   public void execute(ProcessStartListener startListener) {
     // show a warning notification if the cloud sdk version is not supported
-    CloudSdkVersionNotifier.getInstance().notifyIfUnsupportedVersion();
+    CloudSdkVersionNotifier.getInstance().notifyIfVersionOutOfDate();
 
     CloudSdkService instance = CloudSdkService.getInstance();
     CloudSdk.Builder sdkBuilder =

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/startup/CloudSdkVersionStartupCheck.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/startup/CloudSdkVersionStartupCheck.java
@@ -31,5 +31,6 @@ public class CloudSdkVersionStartupCheck implements StartupActivity {
   public void runActivity(@NotNull Project project) {
     // If there is a configured Cloud SDK at this time, check that it is supported.
     CloudSdkVersionNotifier.getInstance().notifyIfVersionOutOfDate();
+    CloudSdkVersionNotifier.getInstance().notifyIfVersionParseError();
   }
 }

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/startup/CloudSdkVersionStartupCheck.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/startup/CloudSdkVersionStartupCheck.java
@@ -30,6 +30,6 @@ public class CloudSdkVersionStartupCheck implements StartupActivity {
   @Override
   public void runActivity(@NotNull Project project) {
     // If there is a configured Cloud SDK at this time, check that it is supported.
-    CloudSdkVersionNotifier.getInstance().notifyIfUnsupportedVersion();
+    CloudSdkVersionNotifier.getInstance().notifyIfVersionOutOfDate();
   }
 }

--- a/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineDeploymentConfigurationTest.java
+++ b/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/cloud/AppEngineDeploymentConfigurationTest.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.intellij.appengine.java.cloud;
 
 import static com.google.cloud.tools.intellij.appengine.java.sdk.CloudSdkValidationResult.CLOUD_SDK_NOT_FOUND;
-import static com.google.cloud.tools.intellij.appengine.java.sdk.CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED;
+import static com.google.cloud.tools.intellij.appengine.java.sdk.CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION;
 import static com.google.cloud.tools.intellij.appengine.java.sdk.CloudSdkValidationResult.NO_APP_ENGINE_COMPONENT;
 import static com.google.cloud.tools.intellij.testing.TestUtils.expectThrows;
 import static com.google.common.truth.Truth.assertThat;
@@ -195,7 +195,7 @@ public final class AppEngineDeploymentConfigurationTest {
   public void checkConfiguration_withOutdatedCloudSdkVersion_throwsException() {
     setUpValidFlexConfiguration();
     when(mockSdkValidator.validateCloudSdk())
-        .thenReturn(ImmutableSet.of(CLOUD_SDK_VERSION_NOT_SUPPORTED));
+        .thenReturn(ImmutableSet.of(CLOUD_SDK_NOT_MINIMUM_VERSION));
 
     RuntimeConfigurationError error =
         expectThrows(

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/GctTracking.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/GctTracking.java
@@ -105,5 +105,5 @@ public class GctTracking {
   public static final String MANAGED_SDK_SUCCESSFUL_UPDATE = "managed.sdk.successful.update";
   public static final String MANAGED_SDK_FAILED_UPDATE = "managed.sdk.failed.update";
   public static final String MANAGED_SDK_CANCELLED_UPDATE = "managed.sdk.cancelled.update";
-  public static final String MANAGED_SDK_VERSION_PARSE_ERROR = "managed.sdk.version.parse.error";
+  public static final String SDK_VERSION_PARSE_ERROR = "sdk.version.parse.error";
 }

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/GctTracking.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/GctTracking.java
@@ -105,4 +105,5 @@ public class GctTracking {
   public static final String MANAGED_SDK_SUCCESSFUL_UPDATE = "managed.sdk.successful.update";
   public static final String MANAGED_SDK_FAILED_UPDATE = "managed.sdk.failed.update";
   public static final String MANAGED_SDK_CANCELLED_UPDATE = "managed.sdk.cancelled.update";
+  public static final String MANAGED_SDK_VERSION_PARSE_ERROR = "managed.sdk.version.parse.error";
 }

--- a/google-cloud-sdk/resources/messages/CloudSdkBundle.properties
+++ b/google-cloud-sdk/resources/messages/CloudSdkBundle.properties
@@ -50,4 +50,5 @@ appengine.cloudsdk.location.invalid.message=No Cloud SDK was found in the specif
 appengine.cloudsdk.version.support.message=The Cloud SDK is out of date. Version {0} is the minimum required version for use with the Google Cloud Tools Plugin. To update, run "gcloud components update".
 appengine.deployment.error.sdk.settings.action=Open Google Cloud SDK Settings...
 appengine.cloudsdk.version.support.title=Google Cloud SDK Update Required
-appengine.cloudsdk.version.file.error=The Cloud SDK version file could not be read
+appengine.cloudsdk.version.file.error=The Cloud SDK version file could not be read. Operations may have unintended results. You can install the Cloud SDK manually and set the path via:<p><p>Settings -> Google -> Cloud Sdk -> Use a custom local installation
+appengine.cloudsdk.version.file.error.title=Error Reading Cloud SDK Version

--- a/google-cloud-sdk/resources/messages/CloudSdkBundle.properties
+++ b/google-cloud-sdk/resources/messages/CloudSdkBundle.properties
@@ -50,5 +50,5 @@ appengine.cloudsdk.location.invalid.message=No Cloud SDK was found in the specif
 appengine.cloudsdk.version.support.message=The Cloud SDK is out of date. Version {0} is the minimum required version for use with the Google Cloud Tools Plugin. To update, run "gcloud components update".
 appengine.deployment.error.sdk.settings.action=Open Google Cloud SDK Settings...
 appengine.cloudsdk.version.support.title=Google Cloud SDK Update Required
-appengine.cloudsdk.version.file.error=The Cloud SDK version file could not be read. Operations may have unintended results. You can install the Cloud SDK manually and set the path via:<p><p>Settings -> Google -> Cloud Sdk -> Use a custom local installation
-appengine.cloudsdk.version.file.error.title=Error Reading Cloud SDK Version
+appengine.cloudsdk.version.file.error=Operations may have unintended results. You can install the Cloud SDK manually and set the path via:<p><p>Settings -> Google -> Cloud Sdk -> Use a custom local installation
+appengine.cloudsdk.version.file.error.title=Unrecognized Cloud SDK Version

--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkValidationResult.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkValidationResult.java
@@ -22,7 +22,7 @@ import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 public enum CloudSdkValidationResult {
   CLOUD_SDK_NOT_FOUND(
       CloudSdkMessageBundle.message("appengine.cloudsdk.location.invalid.message"), true),
-  CLOUD_SDK_VERSION_NOT_SUPPORTED(
+  CLOUD_SDK_NOT_MINIMUM_VERSION(
       CloudSdkMessageBundle.message(
           "appengine.cloudsdk.version.support.message", CloudSdk.MINIMUM_VERSION),
       false),

--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkValidator.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkValidator.java
@@ -60,9 +60,7 @@ public class CloudSdkValidator {
     } catch (CloudSdkOutOfDateException exception) {
       validationResults.add(CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION);
     } catch (CloudSdkVersionFileException exception) {
-      // TODO once appengine-plugins core change is merge in, this exception will not be thrown
-      // instead, we validate the version parsing separately
-      //      validationResults.add(CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR);
+      // Use CloudSdk#getVersion to validate the SDK version
     }
 
     try {

--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkValidator.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkValidator.java
@@ -125,6 +125,14 @@ public class CloudSdkValidator {
     return false;
   }
 
+  CloudSdk buildCloudSdk() throws CloudSdkNotFoundException {
+    CloudSdkService instance = CloudSdkService.getInstance();
+
+    return new CloudSdk.Builder()
+        .sdkPath(instance != null ? instance.getSdkHomePath() : null)
+        .build();
+  }
+
   @VisibleForTesting
   CloudSdk buildCloudSdkWithPath(@NotNull Path path) throws CloudSdkNotFoundException {
     return new CloudSdk.Builder().sdkPath(path).build();

--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkValidator.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkValidator.java
@@ -58,8 +58,16 @@ public class CloudSdkValidator {
       // If the Cloud SDK is not found, don't bother checking anything else
       return validationResults;
     } catch (CloudSdkOutOfDateException exception) {
-      validationResults.add(CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED);
-    } catch (CloudSdkVersionFileException e) {
+      validationResults.add(CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION);
+    } catch (CloudSdkVersionFileException exception) {
+      // TODO once appengine-plugins core change is merge in, this exception will not be thrown
+      // instead, we validate the version parsing separately
+//      validationResults.add(CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR);
+    }
+
+    try {
+      sdk.getVersion();
+    } catch (CloudSdkVersionFileException exception) {
       validationResults.add(CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR);
     }
 

--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkValidator.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkValidator.java
@@ -62,7 +62,7 @@ public class CloudSdkValidator {
     } catch (CloudSdkVersionFileException exception) {
       // TODO once appengine-plugins core change is merge in, this exception will not be thrown
       // instead, we validate the version parsing separately
-//      validationResults.add(CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR);
+      //      validationResults.add(CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR);
     }
 
     try {

--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkVersionNotifier.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkVersionNotifier.java
@@ -28,6 +28,12 @@ public abstract class CloudSdkVersionNotifier {
     return ServiceManager.getService(CloudSdkVersionNotifier.class);
   }
 
-  /** Notifies the user if the saved Cloud SDK is not supported. */
-  public abstract void notifyIfUnsupportedVersion();
+  /**
+   * Notifies the user if the saved Cloud SDK is not at least updated to the minimum supported
+   * version.
+   */
+  public abstract void notifyIfVersionOutOfDate();
+
+  /** Notifies the user if the saved Cloud SDK version cannot be read. */
+  public abstract void notifyIfVersionParseError();
 }

--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifier.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifier.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.intellij.appengine.java.sdk;
 
+import com.google.cloud.tools.intellij.analytics.GctTracking;
+import com.google.cloud.tools.intellij.analytics.UsageTrackerService;
 import com.google.common.annotations.VisibleForTesting;
 import com.intellij.notification.NotificationDisplayType;
 import com.intellij.notification.NotificationGroup;
@@ -51,6 +53,10 @@ public class DefaultCloudSdkVersionNotifier extends CloudSdkVersionNotifier {
 
       showNotification(
           CloudSdkMessageBundle.message("appengine.cloudsdk.version.file.error.title"), message);
+
+      UsageTrackerService.getInstance()
+          .trackEvent(GctTracking.MANAGED_SDK_VERSION_PARSE_ERROR)
+          .ping();
     }
   }
 

--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifier.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifier.java
@@ -25,32 +25,43 @@ import com.intellij.notification.NotificationType;
 public class DefaultCloudSdkVersionNotifier extends CloudSdkVersionNotifier {
 
   @Override
-  public void notifyIfUnsupportedVersion() {
+  public void notifyIfVersionOutOfDate() {
     CloudSdkValidator sdkValidator = CloudSdkValidator.getInstance();
+
     if (sdkValidator
         .validateCloudSdk()
-        .contains(CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED)) {
-      showNotification();
+        .contains(CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION)) {
+      String message =
+          "<p>" + CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION.getMessage() + "</p>";
+
+      showNotification(
+          CloudSdkMessageBundle.message("appengine.cloudsdk.version.support.title"), message);
+    }
+  }
+
+  @Override
+  public void notifyIfVersionParseError() {
+    CloudSdkValidator sdkValidator = CloudSdkValidator.getInstance();
+
+    if (sdkValidator
+        .validateCloudSdk()
+        .contains(CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR)) {
+      String message =
+          "<p>" + CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR.getMessage() + "</p>";
+
+      showNotification(
+          CloudSdkMessageBundle.message("appengine.cloudsdk.version.file.error.title"), message);
     }
   }
 
   @VisibleForTesting
-  void showNotification() {
+  void showNotification(String title, String message) {
     NotificationGroup notification =
-        new NotificationGroup(
-            CloudSdkMessageBundle.message("appengine.cloudsdk.version.support.title"),
-            NotificationDisplayType.BALLOON,
-            true);
-
-    String message =
-        "<p>" + CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED.getMessage() + "</p>";
+        new NotificationGroup(title, NotificationDisplayType.BALLOON, true);
 
     notification
         .createNotification(
-            CloudSdkMessageBundle.message("appengine.cloudsdk.version.support.title"),
-            message,
-            NotificationType.WARNING,
-            null /* notificationListener */)
+            title, message, NotificationType.WARNING, null /* notificationListener */)
         .notify(null /*project*/);
   }
 }

--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifier.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifier.java
@@ -55,7 +55,7 @@ public class DefaultCloudSdkVersionNotifier extends CloudSdkVersionNotifier {
           CloudSdkMessageBundle.message("appengine.cloudsdk.version.file.error.title"), message);
 
       UsageTrackerService.getInstance()
-          .trackEvent(GctTracking.MANAGED_SDK_VERSION_PARSE_ERROR)
+          .trackEvent(GctTracking.SDK_VERSION_PARSE_ERROR)
           .ping();
     }
   }

--- a/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkPanelTest.java
+++ b/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/CloudSdkPanelTest.java
@@ -102,25 +102,25 @@ public class CloudSdkPanelTest {
 
   @Test
   public void testCheckSdk_unsupportedSdk() {
-    setValidateCloudSdkResponse(CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED);
+    setValidateCloudSdkResponse(CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION);
     when(cloudSdkValidator.isValidCloudSdk("/non/empty/path")).thenReturn(false);
     panel.checkSdk("/non/empty/path");
     verify(panel, times(1))
-        .showWarning(eq(CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED.getMessage()));
+        .showWarning(eq(CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION.getMessage()));
     verify(panel, times(0)).hideWarning();
   }
 
   @Test
   public void testCheckSdk_multipleValidationResults() {
     setValidateCloudSdkResponse(
-        CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED,
+        CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION,
         CloudSdkValidationResult.CLOUD_SDK_NOT_FOUND);
     when(cloudSdkValidator.isValidCloudSdk("/non/empty/path")).thenReturn(false);
 
     String expectedMessage =
         INVALID_SDK_DIR_WARNING
             + "<p>"
-            + CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED.getMessage()
+            + CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION.getMessage()
             + "</p>";
 
     panel.checkSdk("/non/empty/path");

--- a/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkServiceTest.java
+++ b/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkServiceTest.java
@@ -70,13 +70,22 @@ public class DefaultCloudSdkServiceTest {
   }
 
   @Test
-  public void testValidateCloudSdk_versionUnsupported()
+  public void testValidateCloudSdk_versionOutOfDate()
       throws CloudSdkNotFoundException, CloudSdkOutOfDateException, CloudSdkVersionFileException {
     doThrow(CloudSdkOutOfDateException.class).when(mockSdk).validateCloudSdk();
     Set<CloudSdkValidationResult> results = sdkValidator.validateCloudSdk();
     assertEquals(1, results.size());
-    assertEquals(
-        CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED, results.iterator().next());
+    assertEquals(CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION, results.iterator().next());
+    assertFalse(sdkValidator.isValidCloudSdk());
+  }
+
+  @Test
+  public void testValidateCloudSdk_versionParseError()
+      throws CloudSdkNotFoundException, CloudSdkOutOfDateException, CloudSdkVersionFileException {
+    doThrow(CloudSdkVersionFileException.class).when(mockSdk).validateCloudSdk();
+    Set<CloudSdkValidationResult> results = sdkValidator.validateCloudSdk();
+    assertEquals(1, results.size());
+    assertEquals(CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR, results.iterator().next());
     assertFalse(sdkValidator.isValidCloudSdk());
   }
 
@@ -148,6 +157,6 @@ public class DefaultCloudSdkServiceTest {
     Set<CloudSdkValidationResult> results = sdkValidator.validateCloudSdk("/good/path");
     assertEquals(2, results.size());
     assertTrue(results.contains(CloudSdkValidationResult.NO_APP_ENGINE_COMPONENT));
-    assertTrue(results.contains(CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED));
+    assertTrue(results.contains(CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION));
   }
 }

--- a/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkServiceTest.java
+++ b/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkServiceTest.java
@@ -80,9 +80,8 @@ public class DefaultCloudSdkServiceTest {
   }
 
   @Test
-  public void testValidateCloudSdk_versionParseError()
-      throws CloudSdkNotFoundException, CloudSdkOutOfDateException, CloudSdkVersionFileException {
-    doThrow(CloudSdkVersionFileException.class).when(mockSdk).validateCloudSdk();
+  public void testValidateCloudSdk_versionParseError() throws CloudSdkVersionFileException {
+    doThrow(CloudSdkVersionFileException.class).when(mockSdk).getVersion();
     Set<CloudSdkValidationResult> results = sdkValidator.validateCloudSdk();
     assertEquals(1, results.size());
     assertEquals(CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR, results.iterator().next());

--- a/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifierTest.java
+++ b/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifierTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.intellij.appengine.java.sdk;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,7 +24,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.TestService;
 import com.google.common.collect.Sets;
-import com.intellij.util.containers.HashSet;
+import java.util.HashSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -44,18 +45,27 @@ public class DefaultCloudSdkVersionNotifierTest {
   @Test
   public void testNotifyIfCloudSdkNotSupported_isSupported() {
     when(cloudSdkValidator.validateCloudSdk()).thenReturn(new HashSet<>());
-    checker.notifyIfUnsupportedVersion();
+    checker.notifyIfVersionOutOfDate();
 
-    verify(checker, times(0)).showNotification();
+    verify(checker, times(0)).showNotification(anyString(), anyString());
   }
 
   @Test
-  public void testNotifyIfCloudSdkNotSupported_notSupported() {
+  public void testNotifyIfCloudSdkNotSupported_versionOutOfDateError() {
     when(cloudSdkValidator.validateCloudSdk())
-        .thenReturn(Sets.newHashSet(CloudSdkValidationResult.CLOUD_SDK_VERSION_NOT_SUPPORTED));
+        .thenReturn(Sets.newHashSet(CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION));
 
-    checker.notifyIfUnsupportedVersion();
-    verify(checker, times(1)).showNotification();
+    checker.notifyIfVersionOutOfDate();
+    verify(checker, times(1)).showNotification(anyString(), anyString());
+  }
+
+  @Test
+  public void testNotifyIfCloudSdkNotSupported_versionParseError() {
+    when(cloudSdkValidator.validateCloudSdk())
+        .thenReturn(Sets.newHashSet(CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR));
+
+    checker.notifyIfVersionParseError();
+    verify(checker, times(1)).showNotification(anyString(), anyString());
   }
 
   @Test
@@ -63,13 +73,13 @@ public class DefaultCloudSdkVersionNotifierTest {
     when(cloudSdkValidator.validateCloudSdk())
         .thenReturn(Sets.newHashSet(CloudSdkValidationResult.CLOUD_SDK_NOT_FOUND));
 
-    checker.notifyIfUnsupportedVersion();
-    verify(checker, times(0)).showNotification();
+    checker.notifyIfVersionOutOfDate();
+    verify(checker, times(0)).showNotification(anyString(), anyString());
   }
 
   @Test
   public void testNotifyIfCloudSdkNotSupported_nullSdkPath() {
-    checker.notifyIfUnsupportedVersion();
-    verify(checker, times(0)).showNotification();
+    checker.notifyIfVersionOutOfDate();
+    verify(checker, times(0)).showNotification(anyString(), anyString());
   }
 }

--- a/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifierTest.java
+++ b/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifierTest.java
@@ -79,8 +79,8 @@ public class DefaultCloudSdkVersionNotifierTest {
     checker.notifyIfVersionParseError();
     verify(checker, times(1))
         .showNotification(
-            "Error Reading Cloud SDK Version",
-            "<p>The Cloud SDK version file could not be read. Operations may have unintended "
+            "Unrecognized Cloud SDK Version",
+            "<p>Operations may have unintended "
                 + "results. You can install the Cloud SDK manually and set the path "
                 + "via:<p><p>Settings -> Google -> Cloud Sdk -> Use a custom local "
                 + "installation</p>");

--- a/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifierTest.java
+++ b/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifierTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.TestService;
 import com.google.common.collect.Sets;
@@ -56,7 +57,13 @@ public class DefaultCloudSdkVersionNotifierTest {
         .thenReturn(Sets.newHashSet(CloudSdkValidationResult.CLOUD_SDK_NOT_MINIMUM_VERSION));
 
     checker.notifyIfVersionOutOfDate();
-    verify(checker, times(1)).showNotification(anyString(), anyString());
+    verify(checker, times(1))
+        .showNotification(
+            "Google Cloud SDK Update Required",
+            "<p>The Cloud SDK is out of date. Version "
+                + CloudSdk.MINIMUM_VERSION
+                + " is the minimum required version for use with the "
+                + "Google Cloud Tools Plugin. To update, run \"gcloud components update\".</p>");
   }
 
   @Test
@@ -65,7 +72,13 @@ public class DefaultCloudSdkVersionNotifierTest {
         .thenReturn(Sets.newHashSet(CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR));
 
     checker.notifyIfVersionParseError();
-    verify(checker, times(1)).showNotification(anyString(), anyString());
+    verify(checker, times(1))
+        .showNotification(
+            "Error Reading Cloud SDK Version",
+            "<p>The Cloud SDK version file could not be read. Operations may have unintended "
+                + "results. You can install the Cloud SDK manually and set the path "
+                + "via:<p><p>Settings -> Google -> Cloud Sdk -> Use a custom local "
+                + "installation</p>");
   }
 
   @Test

--- a/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifierTest.java
+++ b/google-cloud-sdk/testSrc/com/google/cloud/tools/intellij/appengine/java/sdk/DefaultCloudSdkVersionNotifierTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkNotFoundException;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkVersionFileException;
 import com.google.cloud.tools.intellij.testing.CloudToolsRule;
 import com.google.cloud.tools.intellij.testing.TestService;
 import com.google.common.collect.Sets;
@@ -42,6 +44,8 @@ public class DefaultCloudSdkVersionNotifierTest {
   @Mock @TestService private CloudSdkService cloudSdkServiceMock;
 
   @Mock @TestService private CloudSdkValidator cloudSdkValidator;
+
+  @Mock private CloudSdk cloudSdk;
 
   @Test
   public void testNotifyIfCloudSdkNotSupported_isSupported() {
@@ -67,9 +71,10 @@ public class DefaultCloudSdkVersionNotifierTest {
   }
 
   @Test
-  public void testNotifyIfCloudSdkNotSupported_versionParseError() {
-    when(cloudSdkValidator.validateCloudSdk())
-        .thenReturn(Sets.newHashSet(CloudSdkValidationResult.CLOUD_SDK_VERSION_FILE_ERROR));
+  public void testNotifyIfCloudSdkNotSupported_versionParseError()
+      throws CloudSdkNotFoundException, CloudSdkVersionFileException {
+    when(cloudSdkValidator.buildCloudSdk()).thenReturn(cloudSdk);
+    when(cloudSdk.getVersion()).thenThrow(new CloudSdkVersionFileException("file error"));
 
     checker.notifyIfVersionParseError();
     verify(checker, times(1))

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/startup/CloudSdkVersionStartupCheckTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/startup/CloudSdkVersionStartupCheckTest.java
@@ -51,6 +51,6 @@ public final class CloudSdkVersionStartupCheckTest extends BasePluginTestCase {
   public void testRunActivity() {
     cloudSdkVersionStartupCheck.runActivity(mockProject);
 
-    verify(cloudSdkVersionNotifier, times(1)).notifyIfUnsupportedVersion();
+    verify(cloudSdkVersionNotifier, times(1)).notifyIfVersionOutOfDate();
   }
 }


### PR DESCRIPTION
fixes #2259 

Will wait to merge until appengine-plugins-core is released with this change: https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/709

Details:

https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/709 updated the generic Cloud SDK validation logic to _not_ throw an exception on version parsing errors.

This PR updates the SDK plugin-side validation by doing the following:
- Adds a new Cloud SDK notification when there is an error parsing the version file. It does this by calling CloudSdk#getVersion instead (which will still throw an exception). The notification looks like this:
![image](https://user-images.githubusercontent.com/1735744/46371051-48c21980-c655-11e8-8ba8-0a976aad4ad7.png)
Note: **This will not block the operation (like deployment):** once the core lib PR is merged, deployment will continue and succeed if the Cloud SDK installation has no other problems
- Catches the `CloudSdkOutOfDateException` during deployment: previously when the SDK was out of date, the notification would be shown and then an IDE error would occur (because the core library throws an exception downstream when the minimum version is not met). Now the behavior is that the warning will be shown, but the IDE won't blow up.

TODO:
- Consider doing an analytics ping when there is a version parsing error (since now we would have no other way to be notified)
