### PR TITLE
Update Cloud SDK plugin notes

### DIFF
--- a/google-cloud-tools-plugin/change_notes.html
+++ b/google-cloud-tools-plugin/change_notes.html
@@ -1,6 +1,6 @@
 <html>
 <p>
-    This plugin requires the use of the Cloud SDK and will automatically download and manage it for
+    This plugin requires the use of the Cloud SDK and will automatically download and update it for
     you. If you choose to use your own installation (configurable via Settings -> Google -> Cloud
     SDK), make sure to install the Cloud SDK version 171.0.0 or later. Please run 'gcloud components
     update' from your shell to ensure you have the latest Cloud SDK release.

--- a/google-cloud-tools-plugin/change_notes.html
+++ b/google-cloud-tools-plugin/change_notes.html
@@ -1,9 +1,9 @@
 <html>
 <p>
-    IMPORTANT:
-    This plugin requires the use of Cloud SDK v 171.0.0 for correct execution of the local
-    development server with the latest Java 8 SDK. Please run 'gcloud components update' from your
-    shell to ensure you have the latest Cloud SDK release.
+    This plugin requires the use of the Cloud SDK and will automatically download and manage it for
+    you. If you choose to use your own installation (configurable via Settings -> Google -> Cloud
+    SDK), make sure to install the Cloud SDK version 171.0.0 or later. Please run 'gcloud components
+    update' from your shell to ensure you have the latest Cloud SDK release.
 </p>
 <br/>
 


### PR DESCRIPTION
fixes #2262 

Changed the wording a bit. Now mentions managed SDK. Also removed the "IMPORTANT" at the top given that most new users will be using the managed SDK.