### PR TITLE
Notify on missing deployment artifact during local run

### DIFF
--- a/app-engine/java/resources/messages/AppEngineBundle.properties
+++ b/app-engine/java/resources/messages/AppEngineBundle.properties
@@ -158,6 +158,7 @@ appengine.converter.description=Convert projects created by the legacy App Engin
 appengine.staged.artifact.name.converter.description=Existing App Engine flexible deployment run configurations will have their staged artifact name explicitly set to target.jar/war for interoperability with existing Dockerfiles.
 appengine.promoteinfo.url=https://console.cloud.google.com/appengine/versions
 appengine.run.server.name=Google App Engine Standard Local Server
+appengine.run.server.artifact.missing.title=Missing Deployment Artifact
 appengine.run.server.artifact.missing=Artifact to deploy isn't specified. If no artifacts are available, ensure the following: <br /> 1) An 'exploded-war' artifact is configured for your desired deployment. <br />2) The App Engine standard facet is applied to the corresponding module(s) you wish to run. You can use the menu action under 'Tools -> Google Cloud Tools -> Add App Engine support -> Google App Engine Standard'.
 appengine.run.server.sdk.misconfigured.panel.message=The Cloud SDK is misconfigured. To fix, use Google -> Cloud SDK settings.
 appengine.run.server.sdk.misconfigured.message=Unable to start local server: Google Cloud SDK is not ready. Please try again and allow Google Cloud SDK installation to complete.


### PR DESCRIPTION
Follow up to #2275:

The original issue was happening when attempting to do a local run without a deployment artifact present.

![image](https://user-images.githubusercontent.com/1735744/46620652-48ad9800-caf3-11e8-82f2-a220248f48b7.png)

Attempting to run this config results in:

![image](https://user-images.githubusercontent.com/1735744/46620669-56fbb400-caf3-11e8-8152-7624deebab40.png)

Click "continue anyway", before #2275 resulted in an NPE. After #2275, the local run would proceed, but then fail in the appengine-plugins-core library due to a failed precondition of `RunConfiguration#getServices` not being null or empty.

This follows up and explicitly checks that `#getServices` is populated, and if not, shows a notification to the user:

![image](https://user-images.githubusercontent.com/1735744/46620756-9c1fe600-caf3-11e8-9876-07ec98750e33.png)
