### PR TITLE
Temporarily pin app engine local run action to the top of the menu

### DIFF
--- a/app-engine/java/ultimate/resources/META-INF/javaee-integration.xml
+++ b/app-engine/java/ultimate/resources/META-INF/javaee-integration.xml
@@ -35,9 +35,11 @@
             implementation="com.google.cloud.tools.intellij.appengine.java.ultimate.cloudapis.AppEngineLocalRunCloudApiRunConfigurationProvider"/>
   </extensions>
   <actions>
-    <action id="GoogleCloudTools.AppEngineStandardLocalRun"
-            class="com.google.cloud.tools.intellij.appengine.java.ultimate.server.run.AppEngineStandardLocalRunToolsMenuAction">
-      <add-to-group group-id="GoogleCloudTools.AppEngine" relative-to-action="GoogleCloudTools.AppEngineDeploy" anchor="before"/>
-    </action>
+    <group id="GoogleCloudTools.AppEngineLocalRun">
+      <action id="GoogleCloudTools.AppEngineStandardLocalRun"
+              class="com.google.cloud.tools.intellij.appengine.java.ultimate.server.run.AppEngineStandardLocalRunToolsMenuAction" />
+        <separator/>
+        <add-to-group group-id="GoogleCloudTools" anchor="first"/>
+    </group>
   </actions>
 </idea-plugin>


### PR DESCRIPTION
(cherry picked from commit af41c61)

Note this was part of the 18.11 patch release. Just bringing master up to date.

This is a temporary workaround for: https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/2176

Added in because in release 2018.3 of IntelliJ, this warning is now an IDE level error, so we needed a fix (or workaround for this) to properly support 2018.3.

What this does is pin the app engine local run action to the top of the Google Cloud Tools menu. The error in the linked issue was happening because the relative ordering used previously was generating errors due to nondeterministic load order of the action groups. The next step is to refactor with a proper relative order fix.