### PR TITLE
More errorprone cleanup

### DIFF
--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/CloudSdkAppEngineHelper.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/CloudSdkAppEngineHelper.java
@@ -158,8 +158,8 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
                 .getFlexibleRuntimeFromAppYaml(facetConfiguration.getAppYamlPath());
 
         if (runtimeOptional.filter(runtime -> runtime == FlexibleRuntime.CUSTOM).isPresent()
-            && (!Files.isRegularFile(
-                Paths.get(facetConfiguration.getDockerDirectory(), DOCKERFILE_NAME)))) {
+            && !Files.isRegularFile(
+                Paths.get(facetConfiguration.getDockerDirectory(), DOCKERFILE_NAME))) {
           callback.errorOccurred(
               AppEngineMessageBundle.getString("appengine.deployment.error.Dockerfile.notfound"));
           return Optional.empty();

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/executor/AppEngineExecutor.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/cloud/executor/AppEngineExecutor.java
@@ -68,8 +68,8 @@ public class AppEngineExecutor implements CancellableRunnable {
     ThreadUtil.getInstance()
         .executeInBackground(
             () -> {
+              CloudSdkServiceManager.getInstance().getSdkReadLock().lock();
               try {
-                CloudSdkServiceManager.getInstance().getSdkReadLock().lock();
                 process.waitFor();
               } catch (InterruptedException e) {
                 // unexpected interruption, nothing can be done.

--- a/google-cloud-repos/src/com/google/cloud/tools/intellij/csr/GcpCheckoutProvider.java
+++ b/google-cloud-repos/src/com/google/cloud/tools/intellij/csr/GcpCheckoutProvider.java
@@ -142,7 +142,7 @@ public class GcpCheckoutProvider implements CheckoutProvider {
             new Runnable() {
               @Override
               public void run() {
-                if (project.isOpen() && !project.isDisposed() && (!project.isDefault())) {
+                if (project.isOpen() && !project.isDisposed() && !project.isDefault()) {
                   final VcsDirtyScopeManager mgr = VcsDirtyScopeManager.getInstance(project);
                   mgr.fileDirty(destinationParent);
                 }

--- a/google-cloud-repos/src/com/google/cloud/tools/intellij/csr/GcpCheckoutProvider.java
+++ b/google-cloud-repos/src/com/google/cloud/tools/intellij/csr/GcpCheckoutProvider.java
@@ -142,7 +142,7 @@ public class GcpCheckoutProvider implements CheckoutProvider {
             new Runnable() {
               @Override
               public void run() {
-                if (project.isOpen() && (!project.isDisposed()) && (!project.isDefault())) {
+                if (project.isOpen() && !project.isDisposed() && (!project.isDefault())) {
                   final VcsDirtyScopeManager mgr = VcsDirtyScopeManager.getInstance(project);
                   mgr.fileDirty(destinationParent);
                 }

--- a/stackdriver-debugger/src/com/google/cloud/tools/intellij/stackdriver/debugger/CloudDebuggerClient.java
+++ b/stackdriver-debugger/src/com/google/cloud/tools/intellij/stackdriver/debugger/CloudDebuggerClient.java
@@ -25,7 +25,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.repackaged.com.google.common.base.Strings;
-import com.google.api.services.clouddebugger.v2.Clouddebugger.Builder;
+import com.google.api.services.clouddebugger.v2.Clouddebugger;
 import com.google.api.services.clouddebugger.v2.Clouddebugger.Debugger;
 import com.google.cloud.tools.intellij.login.CredentialedUser;
 import com.google.cloud.tools.intellij.login.Services;
@@ -123,7 +123,7 @@ public class CloudDebuggerClient {
           HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
           String userAgent = ServiceManager.getService(PluginInfoService.class).getUserAgent();
           cloudDebuggerClient =
-              new Builder(httpTransport, JSON_FACTORY, initializer)
+              new Clouddebugger.Builder(httpTransport, JSON_FACTORY, initializer)
                   .setRootUrl(ROOT_URL)
                   // this ends up prefixed to user agent
                   .setApplicationName(userAgent)

--- a/stackdriver-debugger/testSrc/com/google/cloud/tools/intellij/stackdriver/debugger/ui/CloudDebugHistoricalSnapshotsTest.java
+++ b/stackdriver-debugger/testSrc/com/google/cloud/tools/intellij/stackdriver/debugger/ui/CloudDebugHistoricalSnapshotsTest.java
@@ -163,7 +163,7 @@ public class CloudDebugHistoricalSnapshotsTest {
   }
 
   private void runModelSetter(CloudDebugHistoricalSnapshots snapshots) {
-    (snapshots.new ModelSetter(mockProcess.getCurrentBreakpointList(), snapshots.getSelection()))
+    snapshots.new ModelSetter(mockProcess.getCurrentBreakpointList(), snapshots.getSelection())
         .run();
   }
 


### PR DESCRIPTION
redundant parentheses warnings (including on test path), builder import warning, and discouraged use of `lock()` inside of try block