### PR TITLE
Fix test compilation in 2018.3

### DIFF
--- a/stackdriver-debugger/testSrc/com/google/cloud/tools/intellij/stackdriver/debugger/CloudBreakpointHandlerTest.java
+++ b/stackdriver-debugger/testSrc/com/google/cloud/tools/intellij/stackdriver/debugger/CloudBreakpointHandlerTest.java
@@ -44,7 +44,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiClassOwner;
 import com.intellij.psi.PsiJavaFile;
 import com.intellij.psi.PsiManager;
-import com.intellij.testFramework.IdeaTestCase;
 import com.intellij.testFramework.UsefulTestCase;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory;
@@ -88,11 +87,6 @@ public class CloudBreakpointHandlerTest extends UsefulTestCase {
   private ServerToIdeFileResolver fileResolver;
 
   private PsiJavaFile psiJavaFile;
-
-  @SuppressWarnings("JUnitTestCaseWithNonTrivialConstructors")
-  public CloudBreakpointHandlerTest() {
-    IdeaTestCase.initPlatformPrefix();
-  }
 
   @Override
   protected void setUp() throws Exception {

--- a/stackdriver-debugger/testSrc/com/google/cloud/tools/intellij/stackdriver/debugger/CloudDebugProcessStateTest.java
+++ b/stackdriver-debugger/testSrc/com/google/cloud/tools/intellij/stackdriver/debugger/CloudDebugProcessStateTest.java
@@ -33,7 +33,6 @@ import com.google.gdt.eclipse.login.common.GoogleLoginState;
 import com.intellij.mock.MockProjectEx;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.psi.PsiManager;
-import com.intellij.testFramework.IdeaTestCase;
 import com.intellij.testFramework.UsefulTestCase;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory;
@@ -60,11 +59,6 @@ public class CloudDebugProcessStateTest extends UsefulTestCase {
 
   private MockProjectEx project;
   private IdeaProjectTestFixture fixture;
-
-  @SuppressWarnings("JUnitTestCaseWithNonTrivialConstructors")
-  public CloudDebugProcessStateTest() {
-    IdeaTestCase.initPlatformPrefix();
-  }
 
   private static boolean verifyList(List<Breakpoint> breakpoints, String... ids) {
     int bindex = 0;


### PR DESCRIPTION
In 2018.3, the removed static call no longer exists. In all of our supported versions (2017.1 and up) this call was empty and deprecated, so removing it has no effect on earlier supported versions.