### PR TITLE
Nullable check for error reporting message, description

### DIFF
--- a/google-cloud-core/src/com/google/cloud/tools/intellij/feedback/GoogleFeedbackErrorReporter.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/feedback/GoogleFeedbackErrorReporter.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.intellij.feedback;
 
+import com.google.cloud.tools.intellij.service.PluginInfoService;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.intellij.diagnostic.AbstractMessage;
@@ -35,6 +36,7 @@ import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ApplicationNamesInfo;
 import com.intellij.openapi.application.ex.ApplicationInfoEx;
+import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter;
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent;
 import com.intellij.openapi.diagnostic.SubmittedReportInfo;
@@ -137,8 +139,8 @@ public class GoogleFeedbackErrorReporter extends ErrorReportSubmitter {
             true,
             event.getThrowable(),
             params,
-            error.getMessage(),
-            error.getDescription(),
+            error.getMessage() == null ? "" : error.getMessage(),
+            error.getDescription() == null ? "" : error.getDescription(),
             ApplicationInfo.getInstance().getFullVersion(),
             successCallback,
             errorCallback);
@@ -194,7 +196,9 @@ public class GoogleFeedbackErrorReporter extends ErrorReportSubmitter {
             .put(APP_INTERNAL_KEY, Boolean.toString(application.isInternal()))
             .put(APP_VERSION_MAJOR_KEY, intelliJAppExtendedInfo.getMajorVersion())
             .put(APP_VERSION_MINOR_KEY, intelliJAppExtendedInfo.getMinorVersion())
-            .put(PLUGIN_VERSION, error.getPluginVersion())
+            .put(
+                PLUGIN_VERSION,
+                ServiceManager.getService(PluginInfoService.class).getPluginVersion())
             .build();
 
     return params;

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/feedback/GoogleFeedbackErrorReporter.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/feedback/GoogleFeedbackErrorReporter.java
@@ -19,13 +19,9 @@ package com.google.cloud.tools.intellij.feedback;
 import com.google.cloud.tools.intellij.service.PluginInfoService;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import com.intellij.diagnostic.AbstractMessage;
-import com.intellij.diagnostic.IdeErrorsDialog;
 import com.intellij.diagnostic.ReportMessages;
 import com.intellij.errorreport.bean.ErrorBean;
 import com.intellij.ide.DataManager;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManager;
 import com.intellij.idea.IdeaLogger;
 import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
@@ -40,7 +36,6 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter;
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent;
 import com.intellij.openapi.diagnostic.SubmittedReportInfo;
-import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.progress.EmptyProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
@@ -83,8 +78,6 @@ public class GoogleFeedbackErrorReporter extends ErrorReportSubmitter {
       final String description) {
     error.setDescription(description);
     error.setMessage(event.getMessage());
-
-    configureErrorFromEvent(event, error);
 
     ApplicationNamesInfo intelliJAppNameInfo = ApplicationNamesInfo.getInstance();
     ApplicationInfoEx intelliJAppExtendedInfo = ApplicationInfoEx.getInstanceEx();
@@ -150,26 +143,6 @@ public class GoogleFeedbackErrorReporter extends ErrorReportSubmitter {
       ProgressManager.getInstance().run(task);
     }
     return true;
-  }
-
-  private static void configureErrorFromEvent(IdeaLoggingEvent event, ErrorBean error) {
-    Throwable throwable = event.getThrowable();
-    if (throwable != null) {
-      PluginId pluginId = IdeErrorsDialog.findPluginId(throwable);
-      if (pluginId != null) {
-        IdeaPluginDescriptor ideaPluginDescriptor = PluginManager.getPlugin(pluginId);
-        if (ideaPluginDescriptor != null && !ideaPluginDescriptor.isBundled()) {
-          error.setPluginName(ideaPluginDescriptor.getName());
-          error.setPluginVersion(ideaPluginDescriptor.getVersion());
-        }
-      }
-    }
-
-    Object data = event.getData();
-
-    if (data instanceof AbstractMessage) {
-      error.setAttachments(((AbstractMessage) data).getIncludedAttachments());
-    }
   }
 
   @VisibleForTesting

--- a/google-cloud-core/testSrc/com/google/cloud/tools/intellij/feedback/GoogleFeedbackErrorReporterTest.java
+++ b/google-cloud-core/testSrc/com/google/cloud/tools/intellij/feedback/GoogleFeedbackErrorReporterTest.java
@@ -19,20 +19,22 @@ package com.google.cloud.tools.intellij.feedback;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.tools.intellij.service.PluginInfoService;
+import com.google.cloud.tools.intellij.testing.CloudToolsRule;
+import com.google.cloud.tools.intellij.testing.TestService;
 import com.intellij.errorreport.bean.ErrorBean;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationNamesInfo;
 import com.intellij.openapi.application.ex.ApplicationInfoEx;
 import java.util.Map;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 /** Test cases for {@link GoogleFeedbackErrorReporter}. */
-@RunWith(MockitoJUnitRunner.class)
 public class GoogleFeedbackErrorReporterTest {
+  @Rule public final CloudToolsRule cloudToolsRule = new CloudToolsRule(this);
 
   private static final String TEST_MESSAGE = "Test message";
   private static final String LAST_ACTION = "last action";
@@ -42,6 +44,8 @@ public class GoogleFeedbackErrorReporterTest {
   private static final String MAJOR_VERSION = "major version";
   private static final String MINOR_VERSION = "minor version";
   private static final String PLUGIN_VERSION = "plugin version";
+
+  @TestService @Mock private PluginInfoService pluginInfoService;
 
   @Mock private ApplicationNamesInfo mockAppNameInfo;
 
@@ -53,12 +57,12 @@ public class GoogleFeedbackErrorReporterTest {
   @Before
   public void setUp() {
     error = new ErrorBean(new Throwable(TEST_MESSAGE), LAST_ACTION);
-    error.setPluginVersion(PLUGIN_VERSION);
     when(mockAppNameInfo.getFullProductName()).thenReturn(FULL_PRODUCT_NAME);
     when(mockAppInfoEx.getPackageCode()).thenReturn(PACKAGE_CODE);
     when(mockAppInfoEx.getVersionName()).thenReturn(VERSION_NAME);
     when(mockAppInfoEx.getMajorVersion()).thenReturn(MAJOR_VERSION);
     when(mockAppInfoEx.getMinorVersion()).thenReturn(MINOR_VERSION);
+    when(pluginInfoService.getPluginVersion()).thenReturn(PLUGIN_VERSION);
   }
 
   @Test


### PR DESCRIPTION
I noticed this in the process of testing out the reporting in the other plugin.

In 2018.2+, the message isn't populated in the same way as it was before, causing it to be `null` (and error reporting to fail) unless a message is specifically present in the throwable. To fix this we need null checks. Also, the mechanism previously used to fetch the version does not work any more.