### PR TITLE
Fixes progress bar exception preventing managed SDK success messages to show and report.

### DIFF
--- a/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkProgressListener.java
+++ b/google-cloud-sdk/src/com/google/cloud/tools/intellij/appengine/java/sdk/ManagedCloudSdkProgressListener.java
@@ -81,10 +81,14 @@ class ManagedCloudSdkProgressListener implements ProgressListener {
 
   @Override
   public void done() {
-    if (progressIndicator != null && !progressIndicator.isFinished(task)) {
-      progressIndicator.finish(task);
-      progressIndicator.dispose();
-    }
+    ApplicationManager.getApplication()
+        .invokeLater(
+            () -> {
+              if (progressIndicator != null && !progressIndicator.isFinished(task)) {
+                progressIndicator.finish(task);
+                progressIndicator.dispose();
+              }
+            });
   }
 
   @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 ideaEdition = IU
-ideaVersion = 2018.2
+ideaVersion = 2018.3
 intellijRepoUrl = https://www.jetbrains.com/intellij-repository
 javaVersion = 1.8
 ijPluginRepoChannel = alpha


### PR DESCRIPTION
Fixes #2304.

`dispose()` for progress bar must be called from EDT starting from 2018.3. Tested and works on 2018.2.