### PR TITLE
Fix mocking in test to accommodate 2018.3 API change

### DIFF
--- a/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/cloudapis/AppEngineLocalRunCloudApiRunConfigurationProviderTest.java
+++ b/app-engine/java/ultimate/testSrc/com/google/cloud/tools/intellij/appengine/java/ultimate/cloudapis/AppEngineLocalRunCloudApiRunConfigurationProviderTest.java
@@ -67,6 +67,7 @@ public class AppEngineLocalRunCloudApiRunConfigurationProviderTest {
   @Mock private JavaPatchableProgramRunner mockProgramRunner;
   @Mock private CommonStrategy mockCommonStrategy;
   @Mock private ScriptHelper mockScriptHelper;
+  @Mock private RunConfiguration runConfiguration;
   private RunnerSpecificLocalConfigurationBit runnerSpecificLocalConfigurationBit;
 
   private AppEngineLocalRunCloudApiRunConfigurationProvider appEngineConfigProvider;
@@ -87,7 +88,8 @@ public class AppEngineLocalRunCloudApiRunConfigurationProviderTest {
         new RunnerSpecificLocalConfigurationBit(new TestConfigurationInfoProvider());
     runnerSpecificLocalConfigurationBit.setEnvironmentVariables(new ArrayList<>());
 
-    when(mockRunnerAndConfigurationSettings.getConfigurationSettings(mockProgramRunner))
+    when(mockRunnerAndConfigurationSettings.getConfiguration()).thenReturn(runConfiguration);
+    when(mockRunnerAndConfigurationSettings.getConfigurationSettings(any()))
         .thenReturn(runnerSpecificLocalConfigurationBit);
     when(mockRunnerRegistry.getRunner(any(), any())).thenReturn(mockProgramRunner);
 


### PR DESCRIPTION
fixes #2308 

Also fixes the reason why the build of https://github.com/GoogleCloudPlatform/google-cloud-intellij/pull/2307 is broken