### PR TITLE
Update google panel ID

### DIFF
--- a/google-cloud-core/resources/META-INF/google-cloud-core.xml
+++ b/google-cloud-core/resources/META-INF/google-cloud-core.xml
@@ -36,7 +36,7 @@
   <extensions defaultExtensionNs="com.intellij">
     <applicationConfigurable groupId="google" id="google.settings"
                              instance="com.google.cloud.tools.intellij.settings.GoogleSettingsConfigurable"/>
-    <applicationConfigurable parentId="google.settings"
+    <applicationConfigurable parentId="google.settings" id="google.usagetracker.settings"
                              provider="com.google.cloud.tools.intellij.analytics.UsageTrackerConfigurableProvider"/>
 
     <applicationService

--- a/google-cloud-core/resources/messages/UsageTrackerBundle.properties
+++ b/google-cloud-core/resources/messages/UsageTrackerBundle.properties
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 
-settings.enable.tracker.text=Would you like to help improve Google IntelliJ plugins by sharing anonymous usage data?
+settings.enable.tracker.text=I would like to help improve Google IntelliJ plugins by sharing usage data.
+settings.tracker.panel.text=Usage Tracking
 settings.privacy.policy.comment=<html>Your use of this plugin is subject to the Apache 2.0 software license and the <a href=\"{0}">Google Privacy Policy</a>.</html>
 notification.group.display.id=Google Usage Statistics
 notification.popup.title =Help improve Google IntelliJ plugins by sending anonymous usage statistics to Google

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerPanel.form
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerPanel.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="606" height="400"/>
+      <xy x="20" y="20" width="677" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -13,12 +13,12 @@
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <border type="etched" title="Usage Tracker"/>
+        <border type="etched" title-resource-bundle="messages/UsageTrackerBundle" title-key="settings.tracker.panel.text"/>
         <children>
           <component id="9651d" class="javax.swing.JCheckBox" binding="enableUsageTrackerBox">
             <constraints border-constraint="North"/>
             <properties>
-              <text value="Would you like to help improve Google IntelliJ plugins by sharing anonymous usage data?"/>
+              <text resource-bundle="messages/UsageTrackerBundle" key="settings.enable.tracker.text"/>
             </properties>
           </component>
           <component id="9a1a4" class="javax.swing.JLabel" binding="privacyPolicyText">


### PR DESCRIPTION
fixes #2316 

Sets an ID on the usage panel. Also updates the wording to match the container-tools plugin.

See https://github.com/GoogleContainerTools/google-container-tools-intellij/pull/119 and https://github.com/GoogleContainerTools/google-container-tools-intellij/pull/121 for more info.

![image](https://user-images.githubusercontent.com/1735744/50923757-c5fee680-141b-11e9-96de-988cdb5744a6.png)
