### PR TITLE
One facet per module checks and add facet action update.

### DIFF
--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/AddAppEngineFrameworkSupportAction.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/AddAppEngineFrameworkSupportAction.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.intellij.appengine.java.facet;
 
 import com.google.cloud.tools.intellij.appengine.java.AppEngineMessageBundle;
+import com.google.cloud.tools.intellij.appengine.java.util.AppEngineUtil;
 import com.google.common.annotations.VisibleForTesting;
 import com.intellij.framework.addSupport.FrameworkSupportInModuleConfigurable;
 import com.intellij.framework.addSupport.FrameworkSupportInModuleProvider;
@@ -126,7 +127,11 @@ public abstract class AddAppEngineFrameworkSupportAction extends AnAction {
     List<Module> suitableModules =
         new ArrayList<>(Arrays.asList(ModuleManager.getInstance(project).getModules()));
     FrameworkSupportInModuleProvider provider = getModuleProvider();
+    // checks if this module type supports out facets at all
     suitableModules.removeIf(module -> !provider.isEnabledForModuleType(ModuleType.get(module)));
+    // filter out compatible modules where support has been already added.
+    suitableModules.removeIf(AppEngineUtil::isAnyAppEngineFacetAlreadyAdded);
+
     return suitableModules;
   }
 }

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/AddAppEngineFrameworkSupportAction.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/AddAppEngineFrameworkSupportAction.java
@@ -127,7 +127,7 @@ public abstract class AddAppEngineFrameworkSupportAction extends AnAction {
     List<Module> suitableModules =
         new ArrayList<>(Arrays.asList(ModuleManager.getInstance(project).getModules()));
     FrameworkSupportInModuleProvider provider = getModuleProvider();
-    // checks if this module type supports out facets at all
+    // checks if this module type supports our facets at all
     suitableModules.removeIf(module -> !provider.isEnabledForModuleType(ModuleType.get(module)));
     // filter out compatible modules where support has been already added.
     suitableModules.removeIf(AppEngineUtil::isAnyAppEngineFacetAlreadyAdded);

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AppEngineFlexibleSupportProvider.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AppEngineFlexibleSupportProvider.java
@@ -152,8 +152,7 @@ public class AppEngineFlexibleSupportProvider extends FrameworkSupportInModulePr
   }
 
   private static boolean hasFlexibleDeploymentConfiguration(List<RunConfiguration> runConfigs) {
-    return runConfigs
-        .stream()
+    return runConfigs.stream()
         .filter(runConfig -> runConfig instanceof DeployToServerRunConfiguration)
         .map(runConfig -> ((DeployToServerRunConfiguration) runConfig).getDeploymentConfiguration())
         .filter(deployConfig -> deployConfig instanceof AppEngineDeploymentConfiguration)
@@ -183,6 +182,14 @@ public class AppEngineFlexibleSupportProvider extends FrameworkSupportInModulePr
         @NotNull ModifiableModelsProvider modifiableModelsProvider) {
       FacetType<AppEngineFlexibleFacet, AppEngineFlexibleFacetConfiguration> facetType =
           AppEngineFlexibleFacet.getFacetType();
+      // pre-condition - multiple facets of the same type are not allowed and result in a critical
+      // error, check for existing facet explicitly and do nothing if it was already added.
+      AppEngineFlexibleFacet existingFacet =
+          FacetManager.getInstance(module).getFacetByType(facetType.getId());
+      if (existingFacet != null) {
+        return;
+      }
+
       AppEngineFlexibleFacet facet =
           FacetManager.getInstance(module)
               .addFacet(facetType, facetType.getPresentableName(), null /* underlyingFacet */);

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AppEngineFlexibleSupportProvider.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AppEngineFlexibleSupportProvider.java
@@ -153,8 +153,7 @@ public class AppEngineFlexibleSupportProvider extends FrameworkSupportInModulePr
   }
 
   private static boolean hasFlexibleDeploymentConfiguration(List<RunConfiguration> runConfigs) {
-    return runConfigs
-        .stream()
+    return runConfigs.stream()
         .filter(runConfig -> runConfig instanceof DeployToServerRunConfiguration)
         .map(runConfig -> ((DeployToServerRunConfiguration) runConfig).getDeploymentConfiguration())
         .filter(deployConfig -> deployConfig instanceof AppEngineDeploymentConfiguration)
@@ -184,7 +183,7 @@ public class AppEngineFlexibleSupportProvider extends FrameworkSupportInModulePr
         @NotNull ModifiableModelsProvider modifiableModelsProvider) {
       FacetType<AppEngineFlexibleFacet, AppEngineFlexibleFacetConfiguration> facetType =
           AppEngineFlexibleFacet.getFacetType();
-      // pre-condition - multiple facets of the same type are not allowed and result in a critical
+      // pre-condition - multiple AE facets of any type are not allowed and result in a critical
       // error, check for existing facet explicitly and do nothing if it was already added.
       if (AppEngineUtil.isAnyAppEngineFacetAlreadyAdded(module)) {
         return;

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AppEngineFlexibleSupportProvider.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AppEngineFlexibleSupportProvider.java
@@ -153,7 +153,8 @@ public class AppEngineFlexibleSupportProvider extends FrameworkSupportInModulePr
   }
 
   private static boolean hasFlexibleDeploymentConfiguration(List<RunConfiguration> runConfigs) {
-    return runConfigs.stream()
+    return runConfigs
+        .stream()
         .filter(runConfig -> runConfig instanceof DeployToServerRunConfiguration)
         .map(runConfig -> ((DeployToServerRunConfiguration) runConfig).getDeploymentConfiguration())
         .filter(deployConfig -> deployConfig instanceof AppEngineDeploymentConfiguration)
@@ -185,8 +186,9 @@ public class AppEngineFlexibleSupportProvider extends FrameworkSupportInModulePr
           AppEngineFlexibleFacet.getFacetType();
       // pre-condition - multiple facets of the same type are not allowed and result in a critical
       // error, check for existing facet explicitly and do nothing if it was already added.
-      if (AppEngineUtil.isAnyAppEngineFacetAlreadyAdded(module))
+      if (AppEngineUtil.isAnyAppEngineFacetAlreadyAdded(module)) {
         return;
+      }
 
       AppEngineFlexibleFacet facet =
           FacetManager.getInstance(module)

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AppEngineFlexibleSupportProvider.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AppEngineFlexibleSupportProvider.java
@@ -153,7 +153,8 @@ public class AppEngineFlexibleSupportProvider extends FrameworkSupportInModulePr
   }
 
   private static boolean hasFlexibleDeploymentConfiguration(List<RunConfiguration> runConfigs) {
-    return runConfigs.stream()
+    return runConfigs
+        .stream()
         .filter(runConfig -> runConfig instanceof DeployToServerRunConfiguration)
         .map(runConfig -> ((DeployToServerRunConfiguration) runConfig).getDeploymentConfiguration())
         .filter(deployConfig -> deployConfig instanceof AppEngineDeploymentConfiguration)

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AppEngineFlexibleSupportProvider.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AppEngineFlexibleSupportProvider.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.intellij.appengine.java.cloud.AppEngineServerConfi
 import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardFacetType;
 import com.google.cloud.tools.intellij.appengine.java.project.AppEngineProjectService;
 import com.google.cloud.tools.intellij.appengine.java.project.AppEngineProjectService.FlexibleRuntime;
+import com.google.cloud.tools.intellij.appengine.java.util.AppEngineUtil;
 import com.google.common.annotations.VisibleForTesting;
 import com.intellij.execution.RunManager;
 import com.intellij.execution.RunnerAndConfigurationSettings;
@@ -184,11 +185,8 @@ public class AppEngineFlexibleSupportProvider extends FrameworkSupportInModulePr
           AppEngineFlexibleFacet.getFacetType();
       // pre-condition - multiple facets of the same type are not allowed and result in a critical
       // error, check for existing facet explicitly and do nothing if it was already added.
-      AppEngineFlexibleFacet existingFacet =
-          FacetManager.getInstance(module).getFacetByType(facetType.getId());
-      if (existingFacet != null) {
+      if (AppEngineUtil.isAnyAppEngineFacetAlreadyAdded(module))
         return;
-      }
 
       AppEngineFlexibleFacet facet =
           FacetManager.getInstance(module)

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineUtil.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineUtil.java
@@ -48,7 +48,8 @@ public class AppEngineUtil {
     Collection<Artifact> artifacts = ArtifactUtil.getArtifactsContainingModuleOutput(module);
     Collection<Artifact> appEngineStandardArtifacts = Lists.newArrayList();
     appEngineStandardArtifacts.addAll(
-        artifacts.stream()
+        artifacts
+            .stream()
             .filter(
                 artifact ->
                     AppEngineProjectService.getInstance().isAppEngineStandardArtifactType(artifact))

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineUtil.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineUtil.java
@@ -69,9 +69,11 @@ public class AppEngineUtil {
    */
   public static boolean isAnyAppEngineFacetAlreadyAdded(@NotNull Module module) {
     AppEngineStandardFacet existingStandardFacet =
-        FacetManager.getInstance(module).getFacetByType(AppEngineStandardFacet.getFacetType().getId());
+        FacetManager.getInstance(module)
+            .getFacetByType(AppEngineStandardFacet.getFacetType().getId());
     AppEngineFlexibleFacet existingFlexibleFacet =
-        FacetManager.getInstance(module).getFacetByType(AppEngineFlexibleFacet.getFacetType().getId());
+        FacetManager.getInstance(module)
+            .getFacetByType(AppEngineFlexibleFacet.getFacetType().getId());
 
     return existingFlexibleFacet != null || existingStandardFacet != null;
   }

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineUtil.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineUtil.java
@@ -22,7 +22,6 @@ import com.google.cloud.tools.intellij.appengine.java.facet.flexible.AppEngineFl
 import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardFacet;
 import com.google.cloud.tools.intellij.appengine.java.project.AppEngineProjectService;
 import com.google.common.collect.Lists;
-import com.intellij.facet.FacetManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.packaging.artifacts.Artifact;
 import com.intellij.packaging.impl.artifacts.ArtifactUtil;
@@ -49,8 +48,7 @@ public class AppEngineUtil {
     Collection<Artifact> artifacts = ArtifactUtil.getArtifactsContainingModuleOutput(module);
     Collection<Artifact> appEngineStandardArtifacts = Lists.newArrayList();
     appEngineStandardArtifacts.addAll(
-        artifacts
-            .stream()
+        artifacts.stream()
             .filter(
                 artifact ->
                     AppEngineProjectService.getInstance().isAppEngineStandardArtifactType(artifact))
@@ -69,11 +67,8 @@ public class AppEngineUtil {
    */
   public static boolean isAnyAppEngineFacetAlreadyAdded(@NotNull Module module) {
     AppEngineStandardFacet existingStandardFacet =
-        FacetManager.getInstance(module)
-            .getFacetByType(AppEngineStandardFacet.getFacetType().getId());
-    AppEngineFlexibleFacet existingFlexibleFacet =
-        FacetManager.getInstance(module)
-            .getFacetByType(AppEngineFlexibleFacet.getFacetType().getId());
+        AppEngineStandardFacet.getAppEngineFacetByModule(module);
+    AppEngineFlexibleFacet existingFlexibleFacet = AppEngineFlexibleFacet.getFacetByModule(module);
 
     return existingFlexibleFacet != null || existingStandardFacet != null;
   }

--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineUtil.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineUtil.java
@@ -18,8 +18,11 @@ package com.google.cloud.tools.intellij.appengine.java.util;
 
 import static java.util.stream.Collectors.toList;
 
+import com.google.cloud.tools.intellij.appengine.java.facet.flexible.AppEngineFlexibleFacet;
+import com.google.cloud.tools.intellij.appengine.java.facet.standard.AppEngineStandardFacet;
 import com.google.cloud.tools.intellij.appengine.java.project.AppEngineProjectService;
 import com.google.common.collect.Lists;
+import com.intellij.facet.FacetManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.packaging.artifacts.Artifact;
 import com.intellij.packaging.impl.artifacts.ArtifactUtil;
@@ -56,5 +59,20 @@ public class AppEngineUtil {
     return appEngineStandardArtifacts.size() == 1
         ? appEngineStandardArtifacts.iterator().next()
         : null;
+  }
+
+  /**
+   * Checks if the given module already has either App Engine Standard or Flexible facets.
+   *
+   * @param module project module.
+   * @return True of module has standard or flexible facets, false otherwise.
+   */
+  public static boolean isAnyAppEngineFacetAlreadyAdded(@NotNull Module module) {
+    AppEngineStandardFacet existingStandardFacet =
+        FacetManager.getInstance(module).getFacetByType(AppEngineStandardFacet.getFacetType().getId());
+    AppEngineFlexibleFacet existingFlexibleFacet =
+        FacetManager.getInstance(module).getFacetByType(AppEngineFlexibleFacet.getFacetType().getId());
+
+    return existingFlexibleFacet != null || existingStandardFacet != null;
   }
 }

--- a/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/facet/AddAppEngineFrameworkSupportActionTest.java
+++ b/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/facet/AddAppEngineFrameworkSupportActionTest.java
@@ -56,8 +56,7 @@ public abstract class AddAppEngineFrameworkSupportActionTest extends PlatformTes
     assertEquals(3, suitableModules.size());
   }
 
-  public void
-      testGetSuitableModules_returnsAllAppEngineModules_whenSomeModulesHaveAppEngineFacet() {
+  public void testGetSuitableModules_returns_noAEFacetsModules_whenSomeModulesHaveAEFacet() {
     if (!PlatformUtils.isIdeaUltimate()) {
       return;
     }
@@ -83,7 +82,7 @@ public abstract class AddAppEngineFrameworkSupportActionTest extends PlatformTes
     }.execute();
 
     List<Module> suitableModules = getAction().getModulesWithoutAppEngineSupport(project);
-    assertEquals(3, suitableModules.size());
+    assertEquals(1, suitableModules.size());
     assertEquals("module1", suitableModules.get(0).getName());
   }
 }

--- a/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AddAppEngineFlexibleFrameworkSupportToolsMenuActionTest.java
+++ b/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/facet/flexible/AddAppEngineFlexibleFrameworkSupportToolsMenuActionTest.java
@@ -62,8 +62,7 @@ public class AddAppEngineFlexibleFrameworkSupportToolsMenuActionTest
   }
 
   @Override
-  public void
-      testGetSuitableModules_returnsAllAppEngineModules_whenSomeModulesHaveAppEngineFacet() {
-    super.testGetSuitableModules_returnsAllAppEngineModules_whenSomeModulesHaveAppEngineFacet();
+  public void testGetSuitableModules_returns_noAEFacetsModules_whenSomeModulesHaveAEFacet() {
+    super.testGetSuitableModules_returns_noAEFacetsModules_whenSomeModulesHaveAEFacet();
   }
 }

--- a/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/facet/standard/AddAppEngineStandardFrameworkSupportToolsMenuActionTest.java
+++ b/app-engine/java/testSrc/com/google/cloud/tools/intellij/appengine/java/facet/standard/AddAppEngineStandardFrameworkSupportToolsMenuActionTest.java
@@ -62,8 +62,7 @@ public class AddAppEngineStandardFrameworkSupportToolsMenuActionTest
   }
 
   @Override
-  public void
-      testGetSuitableModules_returnsAllAppEngineModules_whenSomeModulesHaveAppEngineFacet() {
-    super.testGetSuitableModules_returnsAllAppEngineModules_whenSomeModulesHaveAppEngineFacet();
+  public void testGetSuitableModules_returns_noAEFacetsModules_whenSomeModulesHaveAEFacet() {
+    super.testGetSuitableModules_returns_noAEFacetsModules_whenSomeModulesHaveAEFacet();
   }
 }


### PR DESCRIPTION
Fixes #2292.

Fixed add facets action to use more complete check to make sure a module doesn't have App Engine facets added already, also added a check into add facet for App Engine flexible code where exception tends to happen in case there are other paths where adding facets are possible. Tested on standard and flexible projects, confirmed to fix the issue.