### PR TITLE
Fix deprecated write action and possible disposed server.

### DIFF
--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/AddAppEngineFrameworkSupportDialog.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/facet/AddAppEngineFrameworkSupportDialog.java
@@ -17,8 +17,7 @@
 package com.google.cloud.tools.intellij.appengine.java.facet;
 
 import com.intellij.framework.addSupport.FrameworkSupportInModuleConfigurable;
-import com.intellij.openapi.application.Result;
-import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.IdeaModifiableModelsProvider;
@@ -61,16 +60,15 @@ public class AddAppEngineFrameworkSupportDialog extends DialogWrapper {
   @Override
   protected void doOKAction() {
     if (getOKAction().isEnabled()) {
-      new WriteAction() {
-
-        @Override
-        protected void run(@NotNull final Result result) {
-          ModifiableRootModel model = ModuleRootManager.getInstance(module).getModifiableModel();
-          IdeaModifiableModelsProvider modelsProvider = new IdeaModifiableModelsProvider();
-          moduleConfigurable.addSupport(module, model, modelsProvider);
-          model.commit();
-        }
-      }.execute();
+      ApplicationManager.getApplication()
+          .runWriteAction(
+              () -> {
+                ModifiableRootModel model =
+                    ModuleRootManager.getInstance(module).getModifiableModel();
+                IdeaModifiableModelsProvider modelsProvider = new IdeaModifiableModelsProvider();
+                moduleConfigurable.addSupport(module, model, modelsProvider);
+                model.commit();
+              });
     }
     super.doOKAction();
   }

--- a/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
+++ b/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/impl/AppEngineStandardUltimateWebIntegration.java
@@ -212,7 +212,7 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
   @Override
   public void addDevServerToModuleDependencies(@NotNull ModifiableRootModel rootModel) {
     final ApplicationServer appServer = getOrCreateAppServer();
-    if (appServer != null) {
+    if (appServer != null && !appServer.isDisposed()) {
       rootModel.addLibraryEntry(appServer.getLibrary()).setScope(DependencyScope.PROVIDED);
     }
   }
@@ -267,6 +267,9 @@ public class AppEngineStandardUltimateWebIntegration extends AppEngineStandardWe
     // the first one found
     final List<ApplicationServer> servers =
         ApplicationServersManager.getInstance().getApplicationServers(integration);
+    // make sure no servers are recently disposed (see #2326)
+    servers.removeIf(server -> !server.isDisposed());
+
     if (!servers.isEmpty()) {
       return servers.iterator().next();
     }


### PR DESCRIPTION
Fixes #2326.

I cannot reproduce this, but the reason could be lying in a deprecated way of calling `WriteAction` and some inconsistent state of application server in the list of server, somehow ending up there disposed but still visible to the system. I added necessary checks and changes and this should fix this.