### PR TITLE
Null check and notification for null MavenProject

### DIFF
--- a/google-cloud-apis/java-apis/maven-apis/resources/messages/MavenCloudApisBundle.properties
+++ b/google-cloud-apis/java-apis/maven-apis/resources/messages/MavenCloudApisBundle.properties
@@ -35,7 +35,7 @@ cloud.libraries.depwriter.maven.added.deps.title=Added Cloud Libraries
 cloud.libraries.depwriter.maven.ignored.deps.message=<html><body>The following libraries were ignored because they already exist in your pom.xml:<br>{0}</body></html>
 cloud.libraries.depwriter.maven.ignored.deps.title=Ignored Cloud Libraries
 cloud.libraries.depwriter.maven.failed.deps.title=Failed to add Cloud Libraries
-cloud.libraries.depwriter.maven.failed.deps.message=<html><body>Failed to add selected libraries your pom.xml.<br></body></html>
+cloud.libraries.depwriter.maven.failed.deps.message=<html><body>Failed to add selected libraries your pom.xml. Ensure that you have a pom.xml and try reimporting your maven project.<br></body></html>
 
 cloud.libraries.bom.selector.label=Google Cloud Java:
 cloud.libraries.version.label=Version: {0}

--- a/google-cloud-apis/java-apis/maven-apis/resources/messages/MavenCloudApisBundle.properties
+++ b/google-cloud-apis/java-apis/maven-apis/resources/messages/MavenCloudApisBundle.properties
@@ -34,6 +34,8 @@ cloud.libraries.depwriter.maven.added.deps.message=<html><body>The following lib
 cloud.libraries.depwriter.maven.added.deps.title=Added Cloud Libraries
 cloud.libraries.depwriter.maven.ignored.deps.message=<html><body>The following libraries were ignored because they already exist in your pom.xml:<br>{0}</body></html>
 cloud.libraries.depwriter.maven.ignored.deps.title=Ignored Cloud Libraries
+cloud.libraries.depwriter.maven.failed.deps.title=Failed to add Cloud Libraries
+cloud.libraries.depwriter.maven.failed.deps.message=<html><body>Failed to add selected libraries your pom.xml.<br></body></html>
 
 cloud.libraries.bom.selector.label=Google Cloud Java:
 cloud.libraries.version.label=Version: {0}

--- a/google-cloud-apis/java-apis/maven-apis/resources/messages/MavenCloudApisBundle.properties
+++ b/google-cloud-apis/java-apis/maven-apis/resources/messages/MavenCloudApisBundle.properties
@@ -35,7 +35,7 @@ cloud.libraries.depwriter.maven.added.deps.title=Added Cloud Libraries
 cloud.libraries.depwriter.maven.ignored.deps.message=<html><body>The following libraries were ignored because they already exist in your pom.xml:<br>{0}</body></html>
 cloud.libraries.depwriter.maven.ignored.deps.title=Ignored Cloud Libraries
 cloud.libraries.depwriter.maven.failed.deps.title=Failed to add Cloud Libraries
-cloud.libraries.depwriter.maven.failed.deps.message=<html><body>Failed to add selected libraries your pom.xml. Ensure that you have a pom.xml and try reimporting your maven project.<br></body></html>
+cloud.libraries.depwriter.maven.failed.deps.message=<html><body>Failed to add selected libraries your pom.xml. Ensure that you have a valid pom.xml and try reimporting your maven project.<br></body></html>
 
 cloud.libraries.bom.selector.label=Google Cloud Java:
 cloud.libraries.version.label=Version: {0}

--- a/google-cloud-apis/java-apis/maven-apis/src/com/google/cloud/tools/intellij/cloudapis/maven/CloudLibraryDependencyWriter.java
+++ b/google-cloud-apis/java-apis/maven-apis/src/com/google/cloud/tools/intellij/cloudapis/maven/CloudLibraryDependencyWriter.java
@@ -107,10 +107,13 @@ public final class CloudLibraryDependencyWriter {
     if (mavenProject != null) {
       model = MavenDomUtil.getMavenDomProjectModel(project, mavenProject.getFile());
     } else {
-      LOG.warn(
-          "Expected mavenized module "
-              + module
-              + " to have an associated MavenProject, but null was found. Possibly due to a missing pom.xml file.");
+      LOG.warn("Null MavenProject found. Possibly due to a missing pom.xml file.");
+      notifyFailedDependencies(project);
+      return;
+    }
+
+    if (model == null) {
+      LOG.warn("Null MavenDomProjectModel found. Possibly due to an empty pom.xml file.");
       notifyFailedDependencies(project);
       return;
     }

--- a/google-cloud-apis/java-apis/maven-apis/src/com/google/cloud/tools/intellij/cloudapis/maven/CloudLibraryDependencyWriter.java
+++ b/google-cloud-apis/java-apis/maven-apis/src/com/google/cloud/tools/intellij/cloudapis/maven/CloudLibraryDependencyWriter.java
@@ -113,7 +113,8 @@ public final class CloudLibraryDependencyWriter {
     }
 
     if (model == null) {
-      LOG.warn("Null MavenDomProjectModel found. Possibly due to an empty pom.xml file.");
+      LOG.warn(
+          "Null MavenDomProjectModel found. Possibly due to an empty or malformed pom.xml file.");
       notifyFailedDependencies(project);
       return;
     }


### PR DESCRIPTION
fixes #2320 

I was able to reproduce this by having a valid maven module (by importing a normal maven project) and then deleting the pom.xml. In this case, the module is still identified as a Maven module, but the `MavenProject` is null.

In this case, I am logging an error and showing the following notification to the user:
![image](https://user-images.githubusercontent.com/1735744/51638539-94fad780-1f2c-11e9-955f-608feb5b96f1.png)

There is no good way to write a test for this given the way we are mocking maven modules (`MavenProject` is always non-null).