### PR TITLE
It looks like buildResult needs to be initialized before calling chec…

### DIFF
--- a/stackdriver-debugger/src/com/google/cloud/tools/intellij/stackdriver/debugger/ui/CloudAttachDialog.java
+++ b/stackdriver-debugger/src/com/google/cloud/tools/intellij/stackdriver/debugger/ui/CloudAttachDialog.java
@@ -408,6 +408,7 @@ public class CloudAttachDialog extends DialogWrapper {
     BasicAction.saveAll();
 
     if (syncResult == null) {
+      buildResult();
       checkSyncStashState();
     }
 


### PR DESCRIPTION
…kSyncStashState. otherwise checkSyncStashState can be called before processResultState is initialized, which is what would throw the error.

This commit fixes #2315