### PR TITLE
Fix skaffold error messages

### DIFF
--- a/kubernetes/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/kubernetes/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -107,7 +107,7 @@ abstract class AbstractSkaffoldRunConfiguration(
 
     override fun checkConfiguration() {
         if (!SkaffoldExecutorService.instance.isSkaffoldAvailable()) {
-            throw RuntimeConfigurationWarning(message("skaffold.not.on.system.error"))
+            throw RuntimeConfigurationWarning(message("skaffold.run.config.not.on.system.error"))
         }
     }
 }

--- a/kubernetes/skaffold/src/main/resources/messages/SkaffoldBundle.properties
+++ b/kubernetes/skaffold/src/main/resources/messages/SkaffoldBundle.properties
@@ -43,4 +43,4 @@ skaffold.no.file.selected.error=Skaffold configuration file is not selected.
 skaffold.invalid.file.error=Skaffold configuration file doesn't exist or invalid.
 skaffold.corrupted.run.settings=Your Skaffold run configuration is corrupted. Please re-create it to fix.
 skaffold.run.config.not.on.system.error=Could not detect Skaffold installation. Please install Skaffold. See required dependencies <a href="https://github.com/GoogleContainerTools/google-container-tools-intellij#prerequisites-and-required-dependencies">here</a>
-skaffold.not.on.system.error=Could not detect Skaffold installation. Please install Skaffold. See required dependencies https://github.com/GoogleContainerTools/google-container-tools-intellij#prerequisites-and-required-dependencies
+skaffold.not.on.system.error=Could not detect Skaffold installation. Please install Skaffold.\nSee required dependencies https://github.com/GoogleContainerTools/google-container-tools-intellij#prerequisites-and-required-dependencies

--- a/kubernetes/skaffold/src/main/resources/messages/SkaffoldBundle.properties
+++ b/kubernetes/skaffold/src/main/resources/messages/SkaffoldBundle.properties
@@ -42,5 +42,5 @@ skaffold.override.image.repo.tooltip=<html>The default image repository allows y
 skaffold.no.file.selected.error=Skaffold configuration file is not selected.
 skaffold.invalid.file.error=Skaffold configuration file doesn't exist or invalid.
 skaffold.corrupted.run.settings=Your Skaffold run configuration is corrupted. Please re-create it to fix.
-skaffold.run.config.not.on.system.error=Could not detect Skaffold installation. Please install Skaffold. See required dependencies <a href="https://github.com/GoogleContainerTools/google-container-tools-intellij#prerequisites-and-required-dependencies">here</a>
-skaffold.not.on.system.error=Could not detect Skaffold installation. Please install Skaffold.\nSee required dependencies https://github.com/GoogleContainerTools/google-container-tools-intellij#prerequisites-and-required-dependencies
+skaffold.run.config.not.on.system.error=Could not detect Skaffold installation: please install Skaffold.<br />See required dependencies <a href="https://github.com/GoogleContainerTools/google-container-tools-intellij#prerequisites-and-required-dependencies">here</a>
+skaffold.not.on.system.error=Could not detect Skaffold installation: please install Skaffold.\nSee required dependencies https://github.com/GoogleContainerTools/google-container-tools-intellij#prerequisites-and-required-dependencies

--- a/kubernetes/skaffold/src/main/resources/messages/SkaffoldBundle.properties
+++ b/kubernetes/skaffold/src/main/resources/messages/SkaffoldBundle.properties
@@ -42,7 +42,5 @@ skaffold.override.image.repo.tooltip=<html>The default image repository allows y
 skaffold.no.file.selected.error=Skaffold configuration file is not selected.
 skaffold.invalid.file.error=Skaffold configuration file doesn't exist or invalid.
 skaffold.corrupted.run.settings=Your Skaffold run configuration is corrupted. Please re-create it to fix.
-skaffold.not.on.system.title =Skaffold Error
-skaffold.not.on.system.error=Could not detect Skaffold installation. Please install Skaffold. See required dependencies <a href="https://github.com/GoogleContainerTools/google-container-tools-intellij#prerequisites-and-required-dependencies">here</a>
-skaffold.not.on.system.title =Skaffold Error
-skaffold.not.on.system.error=Could not detect Skaffold installation. Please install Skaffold. See required dependencies <a href="https://github.com/GoogleContainerTools/google-container-tools-intellij#prerequisites-and-required-dependencies">here</a>
+skaffold.run.config.not.on.system.error=Could not detect Skaffold installation. Please install Skaffold. See required dependencies <a href="https://github.com/GoogleContainerTools/google-container-tools-intellij#prerequisites-and-required-dependencies">here</a>
+skaffold.not.on.system.error=Could not detect Skaffold installation. Please install Skaffold. See required dependencies https://github.com/GoogleContainerTools/google-container-tools-intellij#prerequisites-and-required-dependencies


### PR DESCRIPTION
Previously, a hyperlink was shown in the platform error message that popped up when running Skaffold when it is not found on the path. This hyperlink, however, was not clickable.

This PR:
- Shows the full url instead, so that the user can copy/paste it:
![image](https://user-images.githubusercontent.com/1735744/53355616-61c6b200-38f7-11e9-85db-536c1ae28479.png)
- Cleans up duplicated messages in `SkaffoldBundle.properties`
- Fixes #2360 by adding a line break so that the message isn't truncated to `...`:
![image](https://user-images.githubusercontent.com/1735744/53355803-dbf73680-38f7-11e9-8ec7-b11c90f98755.png)
