### PR TITLE
Finalizes GCP menu group, removes extra icons.

### DIFF
--- a/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineGeneralMenuGroupAction.java
+++ b/app-engine/java/src/com/google/cloud/tools/intellij/appengine/java/util/AppEngineGeneralMenuGroupAction.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.intellij.appengine.java.util;
 
-import com.google.cloud.tools.intellij.appengine.java.AppEngineIcons;
 import com.google.cloud.tools.intellij.appengine.java.AppEngineMessageBundle;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 
@@ -26,6 +25,5 @@ public class AppEngineGeneralMenuGroupAction extends DefaultActionGroup {
   public AppEngineGeneralMenuGroupAction() {
     getTemplatePresentation()
         .setText(AppEngineMessageBundle.message("appengine.general.group.menu.text"));
-    getTemplatePresentation().setIcon(AppEngineIcons.APP_ENGINE);
   }
 }

--- a/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/CloudLibrariesGeneralMenuGroup.java
+++ b/google-cloud-apis/src/com/google/cloud/tools/intellij/cloudapis/CloudLibrariesGeneralMenuGroup.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.intellij.cloudapis;
 
-import com.google.cloud.tools.intellij.GoogleCloudCoreIcons;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 
 /** General menu group for all Cloud APIs related actions, including all menu sub-groups. */
@@ -25,6 +24,5 @@ public class CloudLibrariesGeneralMenuGroup extends DefaultActionGroup {
   public CloudLibrariesGeneralMenuGroup() {
     getTemplatePresentation()
         .setText(GoogleCloudApisMessageBundle.message("cloud.libraries.general.menu.group.text"));
-    getTemplatePresentation().setIcon(GoogleCloudCoreIcons.CLOUD);
   }
 }

--- a/google-cloud-repos/src/com/google/cloud/tools/intellij/csr/CloudRepositoryGeneralMenuGroupAction.java
+++ b/google-cloud-repos/src/com/google/cloud/tools/intellij/csr/CloudRepositoryGeneralMenuGroupAction.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.intellij.csr;
 
-import com.google.cloud.tools.intellij.GoogleCloudCoreIcons;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 
 /** General menu group for all Cloud Debugger related actions, including all menu sub-groups. */
@@ -25,6 +24,5 @@ public class CloudRepositoryGeneralMenuGroupAction extends DefaultActionGroup {
   public CloudRepositoryGeneralMenuGroupAction() {
     getTemplatePresentation()
         .setText(CloudReposMessageBundle.message("cloud.repos.general.menu.group.text"));
-    getTemplatePresentation().setIcon(GoogleCloudCoreIcons.CLOUD);
   }
 }

--- a/google-cloud-storage/resources/META-INF/google-cloud-storage.xml
+++ b/google-cloud-storage/resources/META-INF/google-cloud-storage.xml
@@ -27,7 +27,7 @@
         <group id="GoogleCloudTools.gcs.general"
                class="com.google.cloud.tools.intellij.gcs.GcsGeneralMenuGroupAction"
                popup="true">
-            <add-to-group group-id="GoogleCloudTools" anchor="after" relative-to-action="GoogleCloudTools.cloudapis.general"/>
+            <add-to-group group-id="GoogleCloudTools" anchor="after" relative-to-action="GoogleCloudTools.csr.general"/>
         </group>
 
         <group id="GoogleCloudTools.gcs">

--- a/google-cloud-storage/src/com/google/cloud/tools/intellij/gcs/GcsGeneralMenuGroupAction.java
+++ b/google-cloud-storage/src/com/google/cloud/tools/intellij/gcs/GcsGeneralMenuGroupAction.java
@@ -24,6 +24,5 @@ public class GcsGeneralMenuGroupAction extends DefaultActionGroup {
   public GcsGeneralMenuGroupAction() {
     getTemplatePresentation()
         .setText(GoogleCloudStorageMessageBundle.message("gcs.tools.general.menu.group.text"));
-    getTemplatePresentation().setIcon(GoogleCloudStorageIcons.CLOUD_STORAGE);
   }
 }

--- a/stackdriver-debugger/src/com/google/cloud/tools/intellij/stackdriver/debugger/actions/CloudDebuggerGeneralMenuGroupAction.java
+++ b/stackdriver-debugger/src/com/google/cloud/tools/intellij/stackdriver/debugger/actions/CloudDebuggerGeneralMenuGroupAction.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.intellij.stackdriver.debugger.actions;
 
 import com.google.cloud.tools.intellij.stackdriver.debugger.StackdriverDebuggerBundle;
-import com.google.cloud.tools.intellij.stackdriver.debugger.StackdriverDebuggerIcons;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 
 /** General menu group for all Cloud Debugger related actions, including all menu sub-groups. */
@@ -26,6 +25,5 @@ public class CloudDebuggerGeneralMenuGroupAction extends DefaultActionGroup {
   public CloudDebuggerGeneralMenuGroupAction() {
     getTemplatePresentation()
         .setText(StackdriverDebuggerBundle.message("clouddebug.general.menu.group.text"));
-    getTemplatePresentation().setIcon(StackdriverDebuggerIcons.STACKDRIVER_DEBUGGER);
   }
 }


### PR DESCRIPTION
Closes #2344.

It seems we cannot enforce alphabetical order due to randomness of loading order, but at least App Engine always goes first and Stackdriver Debugger always comes last so this makes it a bit more structured.

![gcp-overall-menu-group](https://user-images.githubusercontent.com/11686100/53748439-59302780-3e73-11e9-9585-34db93e12888.png)
