### PR TITLE
Workaround for IDE error when placing App Engine Local Run menu item.

### DIFF
--- a/app-engine/java/resources/META-INF/app-engine-java.xml
+++ b/app-engine/java/resources/META-INF/app-engine-java.xml
@@ -35,11 +35,6 @@
     </extensionPoints>
 
     <actions>
-        <group id="GoogleCloudTools.AppEngine.General" class="com.google.cloud.tools.intellij.appengine.java.util.AppEngineGeneralMenuGroupAction"
-                popup="true">
-            <add-to-group group-id="GoogleCloudTools" anchor="first"/>
-        </group>
-
         <group id="GoogleCloudTools.AppEngine.Support">
             <group id="GoogleCloudTools.AddAppEngineFrameworkSupport"
                    class="com.google.cloud.tools.intellij.appengine.java.facet.AddAppEngineFrameworkSupportMenuGroupAction"

--- a/app-engine/java/resources/messages/AppEngineBundle.properties
+++ b/app-engine/java/resources/messages/AppEngineBundle.properties
@@ -194,7 +194,6 @@ appengine.run.settings.adminhost.label=Admin host:
 appengine.run.settings.adminport.label=Admin port:
 appengine.infopanel.no.region=Can't retrieve region for selected project.
 
-appengine.general.group.menu.text=App Engine
 appengine.add.facet.group.menu.text=Add App Engine support
 appengine.standard.facet.name=Google App Engine standard
 appengine.flexible.facet.name=Google App Engine flexible

--- a/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/server/run/AppEngineStandardLocalRunToolsMenuAction.java
+++ b/app-engine/java/ultimate/src/com/google/cloud/tools/intellij/appengine/java/ultimate/server/run/AppEngineStandardLocalRunToolsMenuAction.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.intellij.appengine.java.ultimate.server.run;
 
-import com.google.cloud.tools.intellij.CloudToolsRunConfigurationAction;
+import com.google.cloud.tools.intellij.action.CloudToolsRunConfigurationAction;
 import com.google.cloud.tools.intellij.appengine.java.AppEngineIcons;
 import com.google.cloud.tools.intellij.appengine.java.AppEngineMessageBundle;
 import com.google.cloud.tools.intellij.appengine.java.project.AppEngineProjectService;

--- a/google-cloud-core/resources/META-INF/google-cloud-core.xml
+++ b/google-cloud-core/resources/META-INF/google-cloud-core.xml
@@ -29,12 +29,19 @@
       <add-to-group group-id="NavBarToolBar" anchor="last"  />
     </action>
 
-    <group id="CloudCodeGoogle" class="com.google.cloud.tools.intellij.CloudCodeTopMenuGroupAction" popup="true">
+    <group id="CloudCodeGoogle" class="com.google.cloud.tools.intellij.action.CloudCodeTopMenuGroupAction" popup="true">
       <add-to-group group-id="ToolsMenu" anchor="last"/>
     </group>
 
-    <group id="GoogleCloudTools" class="com.google.cloud.tools.intellij.CloudToolsMenuGroupAction" popup="true">
+    <group id="GoogleCloudTools" class="com.google.cloud.tools.intellij.action.CloudToolsMenuGroupAction" popup="true">
         <add-to-group group-id="CloudCodeGoogle" anchor="last"/>
+    </group>
+
+      <!-- App engine menu group is initialized in the core plugin making sure bits of App engine support all get access to it regardless of load order. -->
+    <group id="GoogleCloudTools.AppEngine.General"
+           class="com.google.cloud.tools.intellij.action.AppEngineGeneralMenuGroupAction"
+           popup="true">
+        <add-to-group group-id="GoogleCloudTools" anchor="first"/>
     </group>
   </actions>
 

--- a/google-cloud-core/resources/messages/CoreMessageBundle.properties
+++ b/google-cloud-core/resources/messages/CoreMessageBundle.properties
@@ -17,6 +17,7 @@
 
 cloud.code.top.group.menu.text=Cloud Tools
 cloud.tools.group.menu.text=Google Cloud Platform
+appengine.general.group.menu.text=App Engine
 
 cloud.project.selector.signin.message=Sign in with your Google account to list your Google Developers Console projects.
 cloud.project.selector.open.dialog.tooltip=Opens a dialog to select a Google Cloud project

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/action/AppEngineGeneralMenuGroupAction.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/action/AppEngineGeneralMenuGroupAction.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.actionSystem.DefaultActionGroup;
 public class AppEngineGeneralMenuGroupAction extends DefaultActionGroup {
 
   public AppEngineGeneralMenuGroupAction() {
-    getTemplatePresentation().setText(GoogleCloudCoreMessageBundle.message("appengine.general.group.menu.text"));
+    getTemplatePresentation()
+        .setText(GoogleCloudCoreMessageBundle.message("appengine.general.group.menu.text"));
   }
 }

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/action/AppEngineGeneralMenuGroupAction.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/action/AppEngineGeneralMenuGroupAction.java
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij.appengine.java.util;
+package com.google.cloud.tools.intellij.action;
 
-import com.google.cloud.tools.intellij.appengine.java.AppEngineMessageBundle;
+import com.google.cloud.tools.intellij.GoogleCloudCoreMessageBundle;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 
 /** General menu group for all App Engine related actions, including all menu sub-groups. */
 public class AppEngineGeneralMenuGroupAction extends DefaultActionGroup {
 
   public AppEngineGeneralMenuGroupAction() {
-    getTemplatePresentation()
-        .setText(AppEngineMessageBundle.message("appengine.general.group.menu.text"));
+    getTemplatePresentation().setText(GoogleCloudCoreMessageBundle.message("appengine.general.group.menu.text"));
   }
 }

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/action/CloudCodeTopMenuGroupAction.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/action/CloudCodeTopMenuGroupAction.java
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij;
+package com.google.cloud.tools.intellij.action;
 
+import com.google.cloud.tools.intellij.GoogleCloudCoreIcons;
+import com.google.cloud.tools.intellij.GoogleCloudCoreMessageBundle;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 
 /**
- * Creates the tools menu top-level menu group for Cloud Tools. All relevant shortcuts are sub-menu
- * items of this.
+ * Top menu group for all plugin visible actions that are expressed with menu items. All K8s and
+ * Google Cloud functionality is nested under this group. See plugin.xml for structure.
  */
-public class CloudToolsMenuGroupAction extends DefaultActionGroup {
-
-  public CloudToolsMenuGroupAction() {
+public class CloudCodeTopMenuGroupAction extends DefaultActionGroup {
+  public CloudCodeTopMenuGroupAction() {
     getTemplatePresentation()
-        .setText(GoogleCloudCoreMessageBundle.message("cloud.tools.group.menu.text"));
+        .setText(GoogleCloudCoreMessageBundle.message("cloud.code.top.group.menu.text"));
     getTemplatePresentation().setIcon(GoogleCloudCoreIcons.CLOUD);
   }
 }

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/action/CloudToolsMenuGroupAction.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/action/CloudToolsMenuGroupAction.java
@@ -14,18 +14,21 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij;
+package com.google.cloud.tools.intellij.action;
 
+import com.google.cloud.tools.intellij.GoogleCloudCoreIcons;
+import com.google.cloud.tools.intellij.GoogleCloudCoreMessageBundle;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 
 /**
- * Top menu group for all plugin visible actions that are expressed with menu items. All K8s and
- * Google Cloud functionality is nested under this group. See plugin.xml for structure.
+ * Creates the tools menu top-level menu group for Cloud Tools. All relevant shortcuts are sub-menu
+ * items of this.
  */
-public class CloudCodeTopMenuGroupAction extends DefaultActionGroup {
-  public CloudCodeTopMenuGroupAction() {
+public class CloudToolsMenuGroupAction extends DefaultActionGroup {
+
+  public CloudToolsMenuGroupAction() {
     getTemplatePresentation()
-        .setText(GoogleCloudCoreMessageBundle.message("cloud.code.top.group.menu.text"));
+        .setText(GoogleCloudCoreMessageBundle.message("cloud.tools.group.menu.text"));
     getTemplatePresentation().setIcon(GoogleCloudCoreIcons.CLOUD);
   }
 }

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/action/CloudToolsRunConfigurationAction.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/action/CloudToolsRunConfigurationAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2018 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.intellij;
+package com.google.cloud.tools.intellij.action;
 
 import com.intellij.execution.ProgramRunnerUtil;
 import com.intellij.execution.RunnerAndConfigurationSettings;

--- a/stackdriver-debugger/src/com/google/cloud/tools/intellij/stackdriver/debugger/actions/CloudDebuggerToolsMenuAction.java
+++ b/stackdriver-debugger/src/com/google/cloud/tools/intellij/stackdriver/debugger/actions/CloudDebuggerToolsMenuAction.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.intellij.stackdriver.debugger.actions;
 
-import com.google.cloud.tools.intellij.CloudToolsRunConfigurationAction;
+import com.google.cloud.tools.intellij.action.CloudToolsRunConfigurationAction;
 import com.google.cloud.tools.intellij.stackdriver.debugger.CloudDebugConfigType;
 import com.google.cloud.tools.intellij.stackdriver.debugger.StackdriverDebuggerBundle;
 import com.google.cloud.tools.intellij.stackdriver.debugger.StackdriverDebuggerIcons;


### PR DESCRIPTION
Workaround for #2403 (although looks almost like a solution in itself).

Creates an empty App Engine group as part of the main plugin declaration so the local run action adds there regardless of loading order. The group is empty for non-Java IDEs, but, IDE disables empty groups and in overall, it looks not that annoying. Better than having top level plugin error.

In PyCharm:

![pycharm-disabled-app-engine](https://user-images.githubusercontent.com/11686100/53759066-77a31c80-3e8d-11e9-9411-509051e7da6f.png)
