### PR TITLE
Replaces container tools dependency with Cloud Tools one for K8s example.

### DIFF
--- a/kubernetes/examples/hello-spring-boot/.idea/externalDependencies.xml
+++ b/kubernetes/examples/hello-spring-boot/.idea/externalDependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalDependencies">
-    <plugin id="google-container-tools" />
+    <plugin id="com.google.gct.core" />
   </component>
 </project>
 


### PR DESCRIPTION
Otherwise shown a warning non-existing plugin is required for the project to be run.