### PR TITLE
Updates Skaffold existence check to execute the process

### DIFF
--- a/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/SkaffoldExecutorService.kt
+++ b/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/SkaffoldExecutorService.kt
@@ -59,7 +59,7 @@ abstract class SkaffoldExecutorService {
 
             // Set a timeout of 150ms since we want this check to be quick - it can be called from
             // the UI thread. If it takes longer (but still no exception is thrown) then we assume
-            // it is available to avoid false positives.
+            // it is available to avoid false negatives.
             val completed = process.waitFor(150, TimeUnit.MILLISECONDS)
 
             return !completed || process.exitValue() == 0

--- a/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/SkaffoldExecutorService.kt
+++ b/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/SkaffoldExecutorService.kt
@@ -61,7 +61,6 @@ abstract class SkaffoldExecutorService {
             // the UI thread. If it takes longer (but still no exception is thrown) then we assume
             // it is available to avoid false positives.
             val completed = process.waitFor(150, TimeUnit.MILLISECONDS)
-            System.out.println("completed: $completed")
 
             return !completed || process.exitValue() == 0
         } catch (e: Exception) {

--- a/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/SkaffoldExecutorService.kt
+++ b/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/SkaffoldExecutorService.kt
@@ -30,7 +30,6 @@ import com.intellij.openapi.components.ServiceManager
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.system.measureTimeMillis
 
 /**
  * Abstract implementation for Skaffold execution service. This service builds and launches Skaffold
@@ -47,8 +46,6 @@ abstract class SkaffoldExecutorService {
 
     /** Path for Skaffold executable, any form supported by [ProcessBuilder] */
     protected abstract var skaffoldExecutablePath: Path
-
-    fun getSystemPath(): String = System.getenv("PATH")
 
     /**
      * Checks if Skaffold is available by executing a 'skaffold version' command. If the process

--- a/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/SkaffoldExecutorService.kt
+++ b/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/SkaffoldExecutorService.kt
@@ -59,7 +59,8 @@ abstract class SkaffoldExecutorService {
 
             // Set a timeout of 150ms since we want this check to be quick - it can be called from
             // the UI thread. If it takes longer (but still no exception is thrown) then we assume
-            // it is available to avoid false negatives.
+            // it is available to avoid false negatives (thinking skaffold is unavailable when it
+            // really just took longer than expected to execute).
             val completed = process.waitFor(150, TimeUnit.MILLISECONDS)
 
             return !completed || process.exitValue() == 0

--- a/kubernetes/skaffold/src/test/kotlin/com/google/kubernetes/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
+++ b/kubernetes/skaffold/src/test/kotlin/com/google/kubernetes/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
@@ -245,6 +245,13 @@ class DefaultSkaffoldExecutorServiceTest {
     }
 
     @Test
+    fun `isSkaffoldAvailable returns true when skaffold execution times out`() {
+        mockSkaffoldExecution()
+        every { mockProcess.waitFor(any(), any()) } answers { false }
+        assertThat(defaultSkaffoldExecutorService.isSkaffoldAvailable()).isTrue()
+    }
+
+    @Test
     fun `isSkaffoldAvailable returns false when skaffold execution throws exception`() {
         mockSkaffoldExecution()
         every { defaultSkaffoldExecutorService.executeSkaffold(any()) } throws Exception()
@@ -257,6 +264,6 @@ class DefaultSkaffoldExecutorServiceTest {
         } answers { mockSkaffoldProcess }
 
         every { mockSkaffoldProcess.process } answers { mockProcess }
-        every { mockProcess.waitFor() } answers { 0 }
+        every { mockProcess.waitFor(any(), any()) } answers { true }
     }
 }


### PR DESCRIPTION
fixes #2424 

Instead of checking the PATH variable manually via `System.getenv("PATH")` which may not inherit the system PATH, actually attempt to execute a Skaffold command instead. 

See #2424 for details, but the gist of why we want to do this is so that the error messaging in the run config matches what will actually happen when Skaffold executes