### PR TITLE
Show warning in the kubernetes settings if skaffold is not executable

### DIFF
--- a/google-cloud-tools-plugin/build.gradle
+++ b/google-cloud-tools-plugin/build.gradle
@@ -58,10 +58,7 @@ dependencies {
     compile(project(':app-engine:java:gradle'))
     compile(project(':app-engine:java:ultimate'))
     compile(project(':stackdriver-debugger'))
-
     compile(project(':kubernetes'))
-    compile(project(':kubernetes:core'))
-    compile(project(':kubernetes:skaffold'))
 
     compile 'com.google.protobuf:protobuf-java:2.5.0'
     compile 'com.google.apis:google-api-services-clouddebugger:v2-rev7-1.21.0'

--- a/kubernetes/build.gradle.kts
+++ b/kubernetes/build.gradle.kts
@@ -35,6 +35,7 @@ allprojects {
 
 dependencies {
     compile(project(":kubernetes:core"))
+    compile(project(":kubernetes:skaffold"))
 
     compile("com.google.protobuf:protobuf-java:2.5.0")
 

--- a/kubernetes/core/src/main/resources/META-INF/core.xml
+++ b/kubernetes/core/src/main/resources/META-INF/core.xml
@@ -19,8 +19,5 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.google.kubernetes.tools.core.PluginInfo"/>
         <applicationService serviceImplementation="com.google.kubernetes.tools.core.settings.KubernetesSettingsService"/>
-
-        <applicationConfigurable parentId="google.settings" id="google.kubernetes.settings"
-                                 instance="com.google.kubernetes.tools.core.settings.KubernetesSettingsConfigurable" />
     </extensions>
 </idea-plugin>

--- a/kubernetes/core/src/main/resources/messages/CoreBundle.properties
+++ b/kubernetes/core/src/main/resources/messages/CoreBundle.properties
@@ -19,3 +19,4 @@ kubernetes.settings.dependencies.skaffold.browse.title=Browse to Skaffold execut
 kubernetes.settings.dependencies.skaffold.selector.title=Path to Skaffold executable:
 kubernetes.settings.dependencies.panel.title=Dependencies
 kubernetes.settings.dependencies.skaffold.note=<a href="https://skaffold.dev/docs/getting-started/#installing-skaffold">Skaffold</a> is required for deployment and continuous development on Kubernetes.
+kubernetes.settings.dependencies.skaffold.not.executable.warning=Could not execute selected Skaffold binary. Please select your Skaffold executable.

--- a/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/SkaffoldExecutorService.kt
+++ b/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/SkaffoldExecutorService.kt
@@ -46,7 +46,7 @@ abstract class SkaffoldExecutorService {
     }
 
     /** Path for Skaffold executable, any form supported by [ProcessBuilder] */
-    protected abstract var skaffoldExecutablePath: Path
+    abstract var skaffoldExecutablePath: Path
 
     /**
      * Checks if Skaffold is available by executing a 'skaffold version' command. If the process

--- a/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -17,7 +17,6 @@
 package com.google.kubernetes.tools.skaffold.run
 
 import com.google.common.annotations.VisibleForTesting
-import com.google.kubernetes.tools.core.settings.KubernetesSettingsConfigurable
 import com.google.kubernetes.tools.skaffold.SkaffoldExecutorService
 import com.google.kubernetes.tools.skaffold.SkaffoldExecutorSettings
 import com.google.kubernetes.tools.skaffold.message
@@ -31,6 +30,7 @@ import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.configurations.RuntimeConfigurationWarning
 import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
@@ -123,10 +123,17 @@ abstract class AbstractSkaffoldRunConfiguration(
         if (!SkaffoldExecutorService.instance.isSkaffoldAvailable()) {
             throw RuntimeConfigurationWarning(message("skaffold.run.config.not.on.system.error"),
                     Runnable {
-                        ShowSettingsUtil.getInstance()
-                                .showSettingsDialog(
-                                        project,
-                                        KubernetesSettingsConfigurable::class.java)
+                        val kubernetesConfigurable =
+                                Configurable.APPLICATION_CONFIGURABLE.extensionList.find {
+                            it.id == "google.kubernetes.settings"
+                        }
+
+                        kubernetesConfigurable?.let {
+                            ShowSettingsUtil.getInstance()
+                                    .showSettingsDialog(
+                                            project,
+                                            it.instanceClass)
+                        }
                     })
         }
     }

--- a/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -37,6 +37,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.util.xmlb.XmlSerializer
 import org.jdom.Element
 
+private const val KUBERNETES_SETTINGS_CONFIGURABLE_ID = "google.kubernetes.settings"
+
 /**
  * Template configuration for Skaffold single run configuration, serving as a base for all new
  * configurations created by a user. Has its own UI settings and editor and provides execution state
@@ -125,7 +127,7 @@ abstract class AbstractSkaffoldRunConfiguration(
                     Runnable {
                         val kubernetesConfigurable =
                                 Configurable.APPLICATION_CONFIGURABLE.extensionList.find {
-                            it.id == "google.kubernetes.settings"
+                            it.id == KUBERNETES_SETTINGS_CONFIGURABLE_ID
                         }
 
                         kubernetesConfigurable?.let {

--- a/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/kubernetes/skaffold/src/main/kotlin/com/google/kubernetes/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -129,10 +129,9 @@ abstract class AbstractSkaffoldRunConfiguration(
                         }
 
                         kubernetesConfigurable?.let {
-                            ShowSettingsUtil.getInstance()
-                                    .showSettingsDialog(
-                                            project,
-                                            it.instanceClass)
+                            ShowSettingsUtil.getInstance().showSettingsDialog(
+                                    project,
+                                    it.instanceClass)
                         }
                     })
         }

--- a/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
+++ b/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
@@ -85,8 +85,8 @@ class KubernetesSettingsConfigurable : Configurable {
             private fun checkSkaffold() {
                 skaffoldExecutorService.skaffoldExecutablePath = Paths.get(skaffoldBrowser.text)
 
-                skaffoldNotExecutableWarning.isVisible = skaffoldBrowser.text.isEmpty()
-                        || !skaffoldExecutorService.isSkaffoldAvailable()
+                skaffoldNotExecutableWarning.isVisible = skaffoldBrowser.text.isEmpty() ||
+                        !skaffoldExecutorService.isSkaffoldAvailable()
             }
         })
     }

--- a/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
+++ b/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
@@ -85,8 +85,8 @@ class KubernetesSettingsConfigurable : Configurable {
             private fun checkSkaffold() {
                 skaffoldExecutorService.skaffoldExecutablePath = Paths.get(skaffoldBrowser.text)
 
-                skaffoldNotExecutableWarning.isVisible =
-                        !skaffoldExecutorService.isSkaffoldAvailable()
+                skaffoldNotExecutableWarning.isVisible = skaffoldBrowser.text.isEmpty()
+                        || !skaffoldExecutorService.isSkaffoldAvailable()
             }
         })
     }

--- a/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
+++ b/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
@@ -40,7 +40,8 @@ import javax.swing.event.DocumentListener
  */
 class KubernetesSettingsConfigurable : Configurable {
 
-    private val skaffoldNotExecutableWarning =
+    @VisibleForTesting
+    val skaffoldNotExecutableWarning =
             JLabel(CoreBundle.message(
                     "kubernetes.settings.dependencies.skaffold.not.executable.warning"))
 

--- a/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
+++ b/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
@@ -80,7 +80,7 @@ class KubernetesSettingsConfigurable : Configurable {
 
             /**
              * Checks if the input path to the executable is a valid executable. If not, show a
-             * warning.
+             * warning. Don't show the warning if the field is empty.
              */
             private fun checkSkaffold() {
                 skaffoldExecutorService.skaffoldExecutablePath = Paths.get(skaffoldBrowser.text)

--- a/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
+++ b/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
@@ -85,7 +85,7 @@ class KubernetesSettingsConfigurable : Configurable {
             private fun checkSkaffold() {
                 skaffoldExecutorService.skaffoldExecutablePath = Paths.get(skaffoldBrowser.text)
 
-                skaffoldNotExecutableWarning.isVisible = skaffoldBrowser.text.isEmpty() ||
+                skaffoldNotExecutableWarning.isVisible = !skaffoldBrowser.text.isEmpty() &&
                         !skaffoldExecutorService.isSkaffoldAvailable()
             }
         })

--- a/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
+++ b/kubernetes/src/main/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurable.kt
@@ -14,22 +14,35 @@
  * limitations under the License.
  */
 
-package com.google.kubernetes.tools.core.settings
+package com.google.kubernetes.tools.settings
 
 import com.google.common.annotations.VisibleForTesting
+import com.google.kubernetes.tools.core.settings.KubernetesSettingsService
 import com.google.kubernetes.tools.core.util.CoreBundle
+import com.google.kubernetes.tools.skaffold.SkaffoldExecutorService
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.ui.border.IdeaTitledBorder
 import com.intellij.ui.layout.panel
+import java.awt.Color
 import java.awt.Insets
+import java.nio.file.Path
+import java.nio.file.Paths
 import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
 
 /**
  * Creates a "Kubernetes" menu item under the "Google" menu item in the IDE Settings.
  */
 class KubernetesSettingsConfigurable : Configurable {
+
+    private val skaffoldNotExecutableWarning =
+            JLabel(CoreBundle.message(
+                    "kubernetes.settings.dependencies.skaffold.not.executable.warning"))
 
     @VisibleForTesting
     val skaffoldBrowser = TextFieldWithBrowseButton()
@@ -46,6 +59,35 @@ class KubernetesSettingsConfigurable : Configurable {
                         false /*chooseJarsAsFiles*/,
                         false /*chooseJarContents*/,
                         false /*chooseMultiple*/))
+
+        skaffoldBrowser.textField.document.addDocumentListener(object : DocumentListener {
+            val skaffoldExecutorService = object : SkaffoldExecutorService() {
+                override var skaffoldExecutablePath: Path = Paths.get(skaffoldBrowser.text)
+            }
+
+            override fun changedUpdate(event: DocumentEvent?) {
+                checkSkaffold()
+            }
+
+            override fun insertUpdate(event: DocumentEvent?) {
+                checkSkaffold()
+            }
+
+            override fun removeUpdate(event: DocumentEvent?) {
+                checkSkaffold()
+            }
+
+            /**
+             * Checks if the input path to the executable is a valid executable. If not, show a
+             * warning.
+             */
+            private fun checkSkaffold() {
+                skaffoldExecutorService.skaffoldExecutablePath = Paths.get(skaffoldBrowser.text)
+
+                skaffoldNotExecutableWarning.isVisible =
+                        !skaffoldExecutorService.isSkaffoldAvailable()
+            }
+        })
     }
 
     override fun isModified(): Boolean {
@@ -63,13 +105,20 @@ class KubernetesSettingsConfigurable : Configurable {
     }
 
     override fun createComponent(): JComponent? {
-        val dependenciesPanel = panel {
+        skaffoldNotExecutableWarning.icon = AllIcons.General.Warning
+        skaffoldNotExecutableWarning.foreground = Color.RED
+        skaffoldNotExecutableWarning.isVisible = false
 
+        val dependenciesPanel = panel {
             row(CoreBundle.message("kubernetes.settings.dependencies.skaffold.selector.title")) {
                 skaffoldBrowser(grow)
             }
 
             noteRow(CoreBundle.message("kubernetes.settings.dependencies.skaffold.note"))
+
+            row {
+                skaffoldNotExecutableWarning()
+            }
         }
 
         dependenciesPanel.border = IdeaTitledBorder(

--- a/kubernetes/src/main/resources/META-INF/kubernetes.xml
+++ b/kubernetes/src/main/resources/META-INF/kubernetes.xml
@@ -21,4 +21,8 @@
     <xi:include href="/META-INF/core.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/skaffold.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationConfigurable parentId="google.settings" id="google.kubernetes.settings"
+                                 instance="com.google.kubernetes.tools.settings.KubernetesSettingsConfigurable"/>
+    </extensions>
 </idea-plugin>

--- a/kubernetes/src/test/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurableTest.kt
+++ b/kubernetes/src/test/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurableTest.kt
@@ -108,4 +108,12 @@ class KubernetesSettingsConfigurableTest {
 
         Truth.assertThat(kubernetesSettingsConfigurable.isModified).isFalse()
     }
+
+    @Test
+    @UiTest
+    fun `skaffold warning is not shown by default`() {
+        kubernetesSettingsConfigurable.createComponent()
+        Truth.assertThat(kubernetesSettingsConfigurable.skaffoldNotExecutableWarning.isVisible)
+                .isFalse()
+    }
 }

--- a/kubernetes/src/test/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurableTest.kt
+++ b/kubernetes/src/test/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurableTest.kt
@@ -116,4 +116,24 @@ class KubernetesSettingsConfigurableTest {
         Truth.assertThat(kubernetesSettingsConfigurable.skaffoldNotExecutableWarning.isVisible)
                 .isFalse()
     }
+
+    @Test
+    @UiTest
+    fun `skaffold warning is not shown when field is empty`() {
+        kubernetesSettingsConfigurable.createComponent()
+        kubernetesSettingsConfigurable.skaffoldBrowser.text = ""
+
+        Truth.assertThat(kubernetesSettingsConfigurable.skaffoldNotExecutableWarning.isVisible)
+                .isFalse()
+    }
+
+    @Test
+    @UiTest
+    fun `skaffold warning is shown when skaffold is not executable`() {
+        kubernetesSettingsConfigurable.createComponent()
+        kubernetesSettingsConfigurable.skaffoldBrowser.text = "/invalid/path/skaffold"
+
+        Truth.assertThat(kubernetesSettingsConfigurable.skaffoldNotExecutableWarning.isVisible)
+                .isTrue()
+    }
 }

--- a/kubernetes/src/test/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurableTest.kt
+++ b/kubernetes/src/test/kotlin/com/google/kubernetes/tools/settings/KubernetesSettingsConfigurableTest.kt
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.kubernetes.tools.core.settings
+package com.google.kubernetes.tools.settings
 
 import com.google.common.truth.Truth
+import com.google.kubernetes.tools.core.settings.KubernetesSettingsService
 import com.google.kubernetes.tools.test.ContainerToolsRule
 import com.google.kubernetes.tools.test.TestService
 import com.google.kubernetes.tools.test.UiTest


### PR DESCRIPTION
fixes #2428 

In order to avoid circular dependencies I did a couple things:
1) Moved the `KubernetesSettingsConfigurable` from `core` to the root module. This allows it to access the Skaffold module which it needs in order to execute Skaffold
2) In the Skaffold module, the `checkConfiguration` method which applies a quick fix and opens the settings, now doesn't depend on `KubernetesSettingsConfigurable` directly - otherwise it would have been a circular dependency. Instead it loads it dynamically from the list of `ApplicationConfigurables`.

This PR adds validation to the Kubernetes dependency settings panel. Now, the status shown for the Skaffold dependency should match what is shown in the Run Configuration and should match what happens at execution time:

![image](https://user-images.githubusercontent.com/1735744/54046468-6f572400-41a2-11e9-9db0-0d85bed5be66.png)
