### PR TITLE
Reduce title length to make it readable when plugin is initially installed.

### DIFF
--- a/google-cloud-core/resources/messages/UsageTrackerBundle.properties
+++ b/google-cloud-core/resources/messages/UsageTrackerBundle.properties
@@ -18,5 +18,5 @@ settings.enable.tracker.text=I would like to help improve Google IntelliJ plugin
 settings.tracker.panel.text=Usage Tracking
 settings.privacy.policy.comment=<html>Your use of this plugin is subject to the Apache 2.0 software license and the <a href=\"{0}">Google Privacy Policy</a>.</html>
 notification.group.display.id=Google Usage Statistics
-notification.popup.title = To help improve Google IntelliJ plugins, feature usage statistics are collected and sent to Google
-notification.popup.content=<html>You can opt-out at any time by visiting <a href='settings'>Settings...</a><br /> Your use of this plugin is subject to the Apache 2.0 software license and the <a href=\'policy'>Google Privacy Policy</a>.</html>
+notification.popup.title=Google Usage Statistics
+notification.popup.content=<html>To help improve Google IntelliJ plugins, feature usage statistics are collected and sent to Google.<br> You can opt-out at any time by visiting <a href='settings'>Settings...</a><br /> Your use of this plugin is subject to the Apache 2.0 software license and the <a href=\'policy'>Google Privacy Policy</a>.</html>

--- a/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerNotification.java
+++ b/google-cloud-core/src/com/google/cloud/tools/intellij/analytics/UsageTrackerNotification.java
@@ -46,29 +46,26 @@ public class UsageTrackerNotification {
   /** Show the notification panel. */
   public void showNotification() {
     NotificationListener listener =
-        new NotificationListener() {
-          @Override
-          public void hyperlinkUpdate(Notification notification, HyperlinkEvent event) {
-            if (event.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
-              final String description = event.getDescription();
-              if ("allow".equals(description)) {
-                usageTrackingManagementService.setTrackingPreference(true);
-                notification.expire();
-              } else if ("decline".equals(description)) {
-                usageTrackingManagementService.setTrackingPreference(false);
-                notification.expire();
-              } else if ("policy".equals(description)) {
-                try {
-                  BrowserUtil.browse(new URL(UsageTrackerPanel.PRIVACY_POLICY_URL));
-                } catch (MalformedURLException ex) {
-                  LOG.error(ex);
-                }
-                notification.expire();
-              } else if ("settings".equals(description)) {
-                final ShowSettingsUtil util = ShowSettingsUtil.getInstance();
-                util.showSettingsDialog(null, UsageTrackerConfigurable.class);
-                notification.expire();
+        (notification, event) -> {
+          if (event.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+            final String description = event.getDescription();
+            if ("allow".equals(description)) {
+              usageTrackingManagementService.setTrackingPreference(true);
+              notification.expire();
+            } else if ("decline".equals(description)) {
+              usageTrackingManagementService.setTrackingPreference(false);
+              notification.expire();
+            } else if ("policy".equals(description)) {
+              try {
+                BrowserUtil.browse(new URL(UsageTrackerPanel.PRIVACY_POLICY_URL));
+              } catch (MalformedURLException ex) {
+                LOG.error(ex);
               }
+              notification.expire();
+            } else if ("settings".equals(description)) {
+              final ShowSettingsUtil util = ShowSettingsUtil.getInstance();
+              util.showSettingsDialog(null, UsageTrackerConfigurable.class);
+              notification.expire();
             }
           }
         };


### PR DESCRIPTION
When the plugin is initially installed into a fresh IDE never configured for usage statistics before, the notification is shown at the start, clipping the title at 3-4 words making it essentially unreadable.