### PR TITLE
Better default repo tooltip

### DIFF
--- a/kubernetes/skaffold/src/main/resources/messages/SkaffoldBundle.properties
+++ b/kubernetes/skaffold/src/main/resources/messages/SkaffoldBundle.properties
@@ -36,8 +36,9 @@ skaffold.tail.logs.label=Tail logs after deployment:
 skaffold.image.options.subtitle=Image options:
 skaffold.override.image.repo=Default image repository:
 skaffold.override.image.repo.empty.prompt=e.g. docker.io, gcr.io
-skaffold.override.image.repo.tooltip=<html>The default image repository allows you to omit the repository in your Kubernetes manifests.\
-  <br>For example, a default image repository of "gcr.io" and an image name in your Kubernetes config of "project/app" will yield "gcr.io/project/app".
+skaffold.override.image.repo.tooltip=<html>The default image repository allows you to replace the repository in your Kubernetes manifests.\
+  <br>For example, a default image repository of "gcr.io/gcp_project_id" and an image name in your Kubernetes config of "project/app"\
+  <br>will yield "gcr.io/gcp_project_id/project/app".
 
 skaffold.no.file.selected.error=Skaffold configuration file is not selected.
 skaffold.invalid.file.error=Skaffold configuration file doesn't exist or invalid.

--- a/kubernetes/skaffold/src/main/resources/messages/SkaffoldBundle.properties
+++ b/kubernetes/skaffold/src/main/resources/messages/SkaffoldBundle.properties
@@ -36,9 +36,9 @@ skaffold.tail.logs.label=Tail logs after deployment:
 skaffold.image.options.subtitle=Image options:
 skaffold.override.image.repo=Default image repository:
 skaffold.override.image.repo.empty.prompt=e.g. docker.io, gcr.io
-skaffold.override.image.repo.tooltip=<html>The default image repository allows you to replace the repository in your Kubernetes manifests.\
-  <br>For example, a default image repository of "gcr.io/gcp_project_id" and an image name in your Kubernetes config of "project/app"\
-  <br>will yield "gcr.io/gcp_project_id/project/app".
+skaffold.override.image.repo.tooltip=<html>The default image repository allows you to replace the repository in your Kubernetes manifests but keep the original image name.\
+  <br>For example, a default image repository of "gcr.io/gcp_project_id" and an image name in your Kubernetes config of "docker.io/project/app"\
+  <br>will yield "gcr.io/gcp_project_id/docker.io/project/app".
 
 skaffold.no.file.selected.error=Skaffold configuration file is not selected.
 skaffold.invalid.file.error=Skaffold configuration file doesn't exist or invalid.


### PR DESCRIPTION
Mentions that the repository is actually replaced and the image name is kept intact together with the original repository.